### PR TITLE
add support for one-element tuples

### DIFF
--- a/atd_parser.mly
+++ b/atd_parser.mly
@@ -135,6 +135,7 @@ type_expr:
 cartesian_product:
 | x = annot_expr STAR l = cartesian_product   { x :: l }
 | x = annot_expr STAR y = annot_expr          { [ x; y ] }
+| x = annot_expr                              { [ x ] }
 ;
 
 annot_expr:


### PR DESCRIPTION
I need this for a project where atd files result from some preprocessing steps.

So far it seems that the parser is the only place that needed to be modified (since Ocaml supports it).
