### PR TITLE
create option 'atdcat -exclude-names REGEXP'

### DIFF
--- a/atd_print.ml
+++ b/atd_print.ml
@@ -43,6 +43,13 @@ let horizontal_sequence0 l = List (("", "", "", shlist0), l)
 
 let quote_string s = Printf.sprintf "%S" s
 
+let list_map_filter f g l =
+  let rec aux acc = function
+    | [] -> acc
+    | x::q -> if f x then aux ((g x)::acc) q else aux acc q
+  in
+  List.rev (aux [] l)
+
 let format_prop (k, (_, opt)) =
   match opt with
       None -> make_atom k
@@ -77,7 +84,7 @@ let string_of_field k fk =
     | `With_default -> "~" ^ k
 
 
-let make_closures format_annot =
+let make_closures format_annot filter_names =
 
   let append_annots (l : annot) x =
     match l with
@@ -241,19 +248,19 @@ let make_closures format_annot =
   let format_full_module ((loc, an), l) =
     List (
       ("", "", "", rlist),
-      List.map format_annot an @ List.map format_module_item l
+      List.map format_annot an @ list_map_filter (fun (`Type (_, (s, _, _), _)) -> filter_names s) format_module_item l
     )
   in
 
   format_full_module, format_type_name
 
+let default_filter = fun s -> true
 
-
-let format ?(annot = default_annot) x =
-  let f, _ = make_closures annot in
+let format ?(annot = default_annot) ?(filter_names = default_filter) x =
+  let f, _ = make_closures annot filter_names in
   f x
 
-let default_format, default_format_type_name = make_closures default_annot
+let default_format, default_format_type_name = make_closures default_annot default_filter
 
 let string_of_type_name name args an =
   let x = default_format_type_name name args an in

--- a/atd_print.mli
+++ b/atd_print.mli
@@ -6,6 +6,7 @@ val default_annot : Atd_ast.annot_section -> Easy_format.t
 
 val format :
   ?annot: (Atd_ast.annot_section -> Easy_format.t) ->
+  ?filter_names : (string -> bool) ->
   Atd_ast.full_module -> Easy_format.t
   (** Pretty-printing. Use the functions of the [Easy_format.Pretty]
       module to convert an [Easy_format.t] into a string


### PR DESCRIPTION
This creates an option that makes it possible to filter out certain ATD definitions from a file.

Currently I use this new option together with 'atdcat -i' to inline pieces of records in my ATD specs and then hide the "abstract" records from the final .ml\* files.

Example:

```
type _named = { name : string }
type obj1 = { inherit _named; x1 : int } <ocaml field_prefix="o1_">
type obj2 = { inherit _named; x2: string } <ocaml field_prefix="o2_">
```

Here I would typically filter out the '_*' types.

This said, I agree this is a bit sketchy and I could live without this option. (In the end I don't use it so much.)
