### PR TITLE
Fixes issue #190, issue #89 Tests for  target-specific annotations and annotation merging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+unreleased
+-----------------
+
+* Add support for merging double annotations (`<ocaml from="ProtoA"><ocaml predef>`)
+
+* Add tests for annotation merging and target-specific annotations
+
 2.1.0 (2019-12-3)
 -----------------
 

--- a/atdgen/test/dune
+++ b/atdgen/test/dune
@@ -164,6 +164,54 @@
  (package atdgen)
  (action (diff test_polymorphic_wrap_j.expected.ml test_polymorphic_wrap_j.ml)))
 
+(rule
+ (targets test_annot_t.ml test_annot_t.mli)
+ (deps    test_annot.atd)
+ (action  (run %{bin:atdgen} -t %{deps})))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_annot_t.expected.ml test_annot_t.ml)))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_annot_t.expected.mli test_annot_t.mli)))
+
+(rule
+ (targets test_annot_j.ml test_annot_j.mli)
+ (deps    test_annot.atd)
+ (action  (run %{bin:atdgen} -j -j-std %{deps})))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_annot_j.expected.ml test_annot_j.ml)))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_annot_j.expected.mli test_annot_j.mli)))
+
+(rule
+ (targets test_annot_error.stderr)
+ (deps    test_annot_error.atd)
+ (action
+   (with-stderr-to test_annot_error.stderr
+   (with-stdout-to test_annot_error.stdout
+     (bash "%{bin:atdgen} -t %{deps} || echo 'Failed succesfully!'")))))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_annot_error.expected.stderr test_annot_error.stderr)))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_annot_error.expected.stdout test_annot_error.stdout)))
+
 (executables
  (libraries atd atdgen-runtime)
  (names test_atdgen_main)

--- a/atdgen/test/test_annot.atd
+++ b/atdgen/test/test_annot.atd
@@ -1,0 +1,11 @@
+type pointA <ocaml from="ProtoA"> <ocaml predef> = {
+  f: float
+}
+
+type pointB <ocaml_json predef><ocaml from="ProtoB"><ocaml_json from="ProtoD"><ocaml_biniou predef> = {
+  f: float
+}
+
+type pointC <ocaml_biniou from="ProtoE"><ocaml from="ProtoC" predef> = {
+  f: float
+}

--- a/atdgen/test/test_annot_error.atd
+++ b/atdgen/test/test_annot_error.atd
@@ -1,0 +1,3 @@
+type pointA <ocaml from="ProtoA"> <ocaml predef from="ProtoB"> <ocaml from="ProtoC" from="ProtoB">= {
+  f: float
+}

--- a/atdgen/test/test_annot_error.expected.stderr
+++ b/atdgen/test/test_annot_error.expected.stderr
@@ -1,0 +1,6 @@
+File "test_annot_error.atd", line 1, characters 19-32:
+Duplicate annotation ocaml.from (also in:
+  File "test_annot_error.atd", line 1, characters 48-61,
+  File "test_annot_error.atd", line 1, characters 70-83,
+  File "test_annot_error.atd", line 1, characters 84-97
+)

--- a/atdgen/test/test_annot_error.expected.stdout
+++ b/atdgen/test/test_annot_error.expected.stdout
@@ -1,0 +1,1 @@
+Failed succesfully!

--- a/atdgen/test/test_annot_j.expected.ml
+++ b/atdgen/test/test_annot_j.expected.ml
@@ -1,0 +1,303 @@
+(* Auto-generated from "test_annot.atd" *)
+[@@@ocaml.warning "-27-32-35-39"]
+
+type pointC = ProtoC_t.pointC = { f: float }
+
+type pointB = ProtoD_t.pointB = { f: float }
+
+type pointA = ProtoA_t.pointA = { f: float }
+
+let write_pointC : _ -> pointC -> _ = (
+  fun ob (x : pointC) ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"f\":";
+    (
+      Yojson.Safe.write_std_float
+    )
+      ob x.f;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_pointC ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_pointC ob x;
+  Bi_outbuf.contents ob
+let read_pointC = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_f = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 1 && String.unsafe_get s pos = 'f' then (
+            0
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_f := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 1 && String.unsafe_get s pos = 'f' then (
+              0
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_f := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            f = (match !field_f with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "f");
+          }
+         : pointC)
+      )
+)
+let pointC_of_string s =
+  read_pointC (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_pointB : _ -> pointB -> _ = (
+  fun ob (x : pointB) ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"f\":";
+    (
+      Yojson.Safe.write_std_float
+    )
+      ob x.f;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_pointB ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_pointB ob x;
+  Bi_outbuf.contents ob
+let read_pointB = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_f = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 1 && String.unsafe_get s pos = 'f' then (
+            0
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_f := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 1 && String.unsafe_get s pos = 'f' then (
+              0
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_f := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            f = (match !field_f with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "f");
+          }
+         : pointB)
+      )
+)
+let pointB_of_string s =
+  read_pointB (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_pointA : _ -> pointA -> _ = (
+  fun ob (x : pointA) ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"f\":";
+    (
+      Yojson.Safe.write_std_float
+    )
+      ob x.f;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_pointA ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_pointA ob x;
+  Bi_outbuf.contents ob
+let read_pointA = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_f = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 1 && String.unsafe_get s pos = 'f' then (
+            0
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_f := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 1 && String.unsafe_get s pos = 'f' then (
+              0
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_f := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            f = (match !field_f with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "f");
+          }
+         : pointA)
+      )
+)
+let pointA_of_string s =
+  read_pointA (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/test_annot_j.expected.mli
+++ b/atdgen/test/test_annot_j.expected.mli
@@ -1,0 +1,69 @@
+(* Auto-generated from "test_annot.atd" *)
+[@@@ocaml.warning "-27-32-35-39"]
+
+type pointC = ProtoC_t.pointC = { f: float }
+
+type pointB = ProtoD_t.pointB = { f: float }
+
+type pointA = ProtoA_t.pointA = { f: float }
+
+val write_pointC :
+  Bi_outbuf.t -> pointC -> unit
+  (** Output a JSON value of type {!pointC}. *)
+
+val string_of_pointC :
+  ?len:int -> pointC -> string
+  (** Serialize a value of type {!pointC}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_pointC :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> pointC
+  (** Input JSON data of type {!pointC}. *)
+
+val pointC_of_string :
+  string -> pointC
+  (** Deserialize JSON data of type {!pointC}. *)
+
+val write_pointB :
+  Bi_outbuf.t -> pointB -> unit
+  (** Output a JSON value of type {!pointB}. *)
+
+val string_of_pointB :
+  ?len:int -> pointB -> string
+  (** Serialize a value of type {!pointB}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_pointB :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> pointB
+  (** Input JSON data of type {!pointB}. *)
+
+val pointB_of_string :
+  string -> pointB
+  (** Deserialize JSON data of type {!pointB}. *)
+
+val write_pointA :
+  Bi_outbuf.t -> pointA -> unit
+  (** Output a JSON value of type {!pointA}. *)
+
+val string_of_pointA :
+  ?len:int -> pointA -> string
+  (** Serialize a value of type {!pointA}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_pointA :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> pointA
+  (** Input JSON data of type {!pointA}. *)
+
+val pointA_of_string :
+  string -> pointA
+  (** Deserialize JSON data of type {!pointA}. *)
+

--- a/atdgen/test/test_annot_t.expected.ml
+++ b/atdgen/test/test_annot_t.expected.ml
@@ -1,0 +1,8 @@
+(* Auto-generated from "test_annot.atd" *)
+              [@@@ocaml.warning "-27-32-35-39"]
+
+type pointC = ProtoE_t.pointC = { f: float }
+
+type pointB = ProtoB_t.pointB = { f: float }
+
+type pointA = ProtoA_t.pointA = { f: float }

--- a/atdgen/test/test_annot_t.expected.mli
+++ b/atdgen/test/test_annot_t.expected.mli
@@ -1,0 +1,8 @@
+(* Auto-generated from "test_annot.atd" *)
+              [@@@ocaml.warning "-27-32-35-39"]
+
+type pointC = ProtoE_t.pointC = { f: float }
+
+type pointB = ProtoB_t.pointB = { f: float }
+
+type pointA = ProtoA_t.pointA = { f: float }


### PR DESCRIPTION
Commit aab9683 (fixes issue #89):
- Merge double annotations like  `<ocaml from="ProtoA"> <ocaml predef>`

Commit c818716 (fixes issue #190, tests for issue #89):
- tests for double annotation merging (issue #89)
- tests for https://github.com/ahrefs/atd/pull/187 Check annotations in target-specific ocaml section (issue #190)