### PR TITLE
Generate open! instead of open for external modules

### DIFF
--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -731,7 +731,7 @@ let make_ocaml_files
       | Some path -> sprintf "%S" (Filename.basename path)
     in
     sprintf {|(* Auto-generated from %s *)
-              [@@@ocaml.warning "-27-32-33-35-39"]|} src
+              [@@@ocaml.warning "-27-32-35-39"]|} src
   in
   let ml =
     make_ml ~opens ~header ~with_typedefs ~with_create ~with_fundefs ~original_types

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -731,7 +731,7 @@ let make_ocaml_files
       | Some path -> sprintf "%S" (Filename.basename path)
     in
     sprintf {|(* Auto-generated from %s *)
-              [@@@ocaml.warning "-27-32-35-39"]|} src
+              [@@@ocaml.warning "-27-32-33-35-39"]|} src
   in
   let ml =
     make_ml ~opens ~header ~with_typedefs ~with_create ~with_fundefs ~original_types

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -309,7 +309,7 @@ let get_let ~is_rec ~is_first =
   else "and", "and"
 
 let write_opens buf l =
-  List.iter (fun s -> bprintf buf "open %s\n" s) l;
+  List.iter (fun s -> bprintf buf "open! %s\n" s) l;
   bprintf buf "\n"
 
 let def_of_atd (loc, (name, param, an), x) ~target ~def ~external_

--- a/atdgen/test/test2.expected.ml
+++ b/atdgen/test/test2.expected.ml
@@ -1,6 +1,6 @@
 (* Auto-generated from "test2.atd" *)
               [@@@ocaml.warning "-27-32-35-39"]
-open Test
+open! Test
 
 type ('aa, 'bb) poly = ('aa, 'bb) Test.poly
 

--- a/atdgen/test/test2.expected.mli
+++ b/atdgen/test/test2.expected.mli
@@ -1,6 +1,6 @@
 (* Auto-generated from "test2.atd" *)
               [@@@ocaml.warning "-27-32-35-39"]
-open Test
+open! Test
 
 type ('aa, 'bb) poly = ('aa, 'bb) Test.poly
 

--- a/atdgen/test/test2j.expected.ml
+++ b/atdgen/test/test2j.expected.ml
@@ -1,8 +1,8 @@
 (* Auto-generated from "test2.atd" *)
 [@@@ocaml.warning "-27-32-35-39"]
-open Test
-open Test2
-open Testj
+open! Test
+open! Test2
+open! Testj
 
 let write_poly write__aa write__bb = (
   Testj.write_poly write__aa write__bb

--- a/atdgen/test/test2j.expected.mli
+++ b/atdgen/test/test2j.expected.mli
@@ -1,8 +1,8 @@
 (* Auto-generated from "test2.atd" *)
 [@@@ocaml.warning "-27-32-35-39"]
-open Test
-open Test2
-open Testj
+open! Test
+open! Test2
+open! Testj
 
 val write_poly :
   (Bi_outbuf.t -> 'aa -> unit) ->

--- a/atdgen/test/test_ambiguous_record_j.expected.ml
+++ b/atdgen/test/test_ambiguous_record_j.expected.ml
@@ -1,6 +1,6 @@
 (* Auto-generated from "test_ambiguous_record.atd" *)
 [@@@ocaml.warning "-27-32-35-39"]
-open Test_ambiguous_record_t
+open! Test_ambiguous_record_t
 
 let write_ambiguous' : _ -> ambiguous' -> _ = (
   Atdgen_runtime.Oj_run.write_with_adapter Json_adapters.Identity.restore (


### PR DESCRIPTION
This PR  ~~disables 33 warning (unused open statement) for bucklescript emitter~~ generates `open!` instead of `open` for external modules.
This is helpful if you share atd generator command across atd files.
For example, I run atdgen for all `.atd` files in a folder, most of those files use types from some shared type module, but others are simple and don't use types from shared type modules, in this case, I want to silence unused open statement warning