### PR TITLE
Disable 33 warning (unused open statement)

### DIFF
--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -1394,7 +1394,7 @@ let make_ocaml_files
       | Some path -> sprintf "%S" (Filename.basename path)
     in
     sprintf {|(* Auto-generated from %s *)
-              [@@@ocaml.warning "-27-32-35-39"]|} src
+              [@@@ocaml.warning "-27-32-33-35-39"]|} src
   in
   let mli =
     make_mli ~header ~opens ~with_typedefs ~with_create ~with_fundefs

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -731,7 +731,7 @@ let make_ocaml_files
       | Some path -> sprintf "%S" (Filename.basename path)
     in
     sprintf {|(* Auto-generated from %s *)
-              [@@@ocaml.warning "-27-32-35-39"]|} src
+              [@@@ocaml.warning "-27-32-33-35-39"]|} src
   in
   let ml =
     make_ml ~opens ~header ~with_typedefs ~with_create ~with_fundefs ~original_types

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1359,7 +1359,7 @@ let make_ocaml_files
     in
     sprintf "\
 (* Auto-generated from %s *)
-[@@@ocaml.warning \"-27-32-35-39\"]" src
+[@@@ocaml.warning \"-27-32-33-35-39\"]" src
   in
   let mli =
     make_mli ~header ~opens ~with_typedefs ~with_create ~with_fundefs

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -458,7 +458,7 @@ let make_ocaml_files
       | Some path -> sprintf "%S" (Filename.basename path)
     in
     sprintf {|(* Auto-generated from %s *)
-              [@@@ocaml.warning "-27-32-35-39"]|} src
+              [@@@ocaml.warning "-27-32-33-35-39"]|} src
   in
   let mli =
     make_mli ~header ~opens ~with_typedefs ~with_create ~with_fundefs

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -309,7 +309,7 @@ let get_let ~is_rec ~is_first =
   else "and", "and"
 
 let write_opens buf l =
-  List.iter (fun s -> bprintf buf "open! %s\n" s) l;
+  List.iter (fun s -> bprintf buf "open %s\n" s) l;
   bprintf buf "\n"
 
 let def_of_atd (loc, (name, param, an), x) ~target ~def ~external_

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "bucklespec.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 type recurse = Bucklespec_t.recurse = { recurse_items: recurse list }
 

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.mli
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "bucklespec.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 type recurse = Bucklespec_t.recurse = { recurse_items: recurse list }
 

--- a/atdgen/test/bucklescript/bucklespec_j.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_j.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "bucklespec.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 type recurse = Bucklespec_t.recurse = { recurse_items: recurse list }
 

--- a/atdgen/test/test.expected.ml
+++ b/atdgen/test/test.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 

--- a/atdgen/test/test.expected.mli
+++ b/atdgen/test/test.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 

--- a/atdgen/test/test2.expected.ml
+++ b/atdgen/test/test2.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test2.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 open! Test
 
 type ('aa, 'bb) poly = ('aa, 'bb) Test.poly

--- a/atdgen/test/test2.expected.ml
+++ b/atdgen/test/test2.expected.ml
@@ -1,6 +1,6 @@
 (* Auto-generated from "test2.atd" *)
               [@@@ocaml.warning "-27-32-33-35-39"]
-open! Test
+open Test
 
 type ('aa, 'bb) poly = ('aa, 'bb) Test.poly
 

--- a/atdgen/test/test2.expected.mli
+++ b/atdgen/test/test2.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test2.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 open! Test
 
 type ('aa, 'bb) poly = ('aa, 'bb) Test.poly

--- a/atdgen/test/test2.expected.mli
+++ b/atdgen/test/test2.expected.mli
@@ -1,6 +1,6 @@
 (* Auto-generated from "test2.atd" *)
               [@@@ocaml.warning "-27-32-33-35-39"]
-open! Test
+open Test
 
 type ('aa, 'bb) poly = ('aa, 'bb) Test.poly
 

--- a/atdgen/test/test2j.expected.ml
+++ b/atdgen/test/test2j.expected.ml
@@ -1,8 +1,8 @@
 (* Auto-generated from "test2.atd" *)
 [@@@ocaml.warning "-27-32-33-35-39"]
-open! Test
-open! Test2
-open! Testj
+open Test
+open Test2
+open Testj
 
 let write_poly write__aa write__bb = (
   Testj.write_poly write__aa write__bb

--- a/atdgen/test/test2j.expected.ml
+++ b/atdgen/test/test2j.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test2.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 open! Test
 open! Test2
 open! Testj

--- a/atdgen/test/test2j.expected.mli
+++ b/atdgen/test/test2j.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test2.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 open! Test
 open! Test2
 open! Testj

--- a/atdgen/test/test2j.expected.mli
+++ b/atdgen/test/test2j.expected.mli
@@ -1,8 +1,8 @@
 (* Auto-generated from "test2.atd" *)
 [@@@ocaml.warning "-27-32-33-35-39"]
-open! Test
-open! Test2
-open! Testj
+open Test
+open Test2
+open Testj
 
 val write_poly :
   (Bi_outbuf.t -> 'aa -> unit) ->

--- a/atdgen/test/test3j_j.expected.ml
+++ b/atdgen/test/test3j_j.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test3j.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 type rec_type = Test3j_t.rec_type = { more: rec_type list }
 

--- a/atdgen/test/test3j_j.expected.mli
+++ b/atdgen/test/test3j_j.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test3j.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 type rec_type = Test3j_t.rec_type = { more: rec_type list }
 

--- a/atdgen/test/test3j_t.expected.ml
+++ b/atdgen/test/test3j_t.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test3j.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 type rec_type = { more: rec_type list }
 

--- a/atdgen/test/test3j_t.expected.mli
+++ b/atdgen/test/test3j_t.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test3j.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 type rec_type = { more: rec_type list }
 

--- a/atdgen/test/test_ambiguous_record_j.expected.ml
+++ b/atdgen/test/test_ambiguous_record_j.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test_ambiguous_record.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 open! Test_ambiguous_record_t
 
 let write_ambiguous' : _ -> ambiguous' -> _ = (

--- a/atdgen/test/test_ambiguous_record_j.expected.ml
+++ b/atdgen/test/test_ambiguous_record_j.expected.ml
@@ -1,6 +1,6 @@
 (* Auto-generated from "test_ambiguous_record.atd" *)
 [@@@ocaml.warning "-27-32-33-35-39"]
-open! Test_ambiguous_record_t
+open Test_ambiguous_record_t
 
 let write_ambiguous' : _ -> ambiguous' -> _ = (
   Atdgen_runtime.Oj_run.write_with_adapter Json_adapters.Identity.restore (

--- a/atdgen/test/test_annot_j.expected.ml
+++ b/atdgen/test/test_annot_j.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test_annot.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 type pointC = ProtoC_t.pointC = { f: float }
 

--- a/atdgen/test/test_annot_j.expected.mli
+++ b/atdgen/test/test_annot_j.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test_annot.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 type pointC = ProtoC_t.pointC = { f: float }
 

--- a/atdgen/test/test_annot_t.expected.ml
+++ b/atdgen/test/test_annot_t.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test_annot.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 type pointC = ProtoE_t.pointC = { f: float }
 

--- a/atdgen/test/test_annot_t.expected.mli
+++ b/atdgen/test/test_annot_t.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test_annot.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 type pointC = ProtoE_t.pointC = { f: float }
 

--- a/atdgen/test/test_polymorphic_wrap_j.expected.ml
+++ b/atdgen/test/test_polymorphic_wrap_j.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test_polymorphic_wrap.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 type 'a t = 'a Array_wrap.t
 

--- a/atdgen/test/test_polymorphic_wrap_t.expected.ml
+++ b/atdgen/test/test_polymorphic_wrap_t.expected.ml
@@ -1,4 +1,4 @@
 (* Auto-generated from "test_polymorphic_wrap.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 type 'a t = 'a Array_wrap.t

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 

--- a/atdgen/test/testj.expected.mli
+++ b/atdgen/test/testj.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 

--- a/atdgen/test/testjstd.expected.ml
+++ b/atdgen/test/testjstd.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 

--- a/atdgen/test/testjstd.expected.mli
+++ b/atdgen/test/testjstd.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-[@@@ocaml.warning "-27-32-35-39"]
+[@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 

--- a/atdgen/test/testv.expected.ml
+++ b/atdgen/test/testv.expected.ml
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 

--- a/atdgen/test/testv.expected.mli
+++ b/atdgen/test/testv.expected.mli
@@ -1,5 +1,5 @@
 (* Auto-generated from "test.atd" *)
-              [@@@ocaml.warning "-27-32-35-39"]
+              [@@@ocaml.warning "-27-32-33-35-39"]
 
 (** This is just a test. *)
 


### PR DESCRIPTION
This PR disables 33 warning (`unused open statement`) for all emitters, and revert changes from [Generate open! instead of open for external modules PR](https://github.com/ahrefs/atd/pull/213).

`open!` statement in OCaml 4.08.0+ compiler silence only 44 warning, but still produce 66 warning (Unused open! statement), 

> Adding a ! character after the open keyword indicates that such a shadowing is intentional and should not trigger the warning.
http://caml.inria.fr/pub/docs/manual-ocaml/overridingopen.html

Ocaml 4.06.0 (and bucklescript) compilers don't have 66 warning at all.

To have a universal solution, in this PR I silence 33 warning with ` [@@@ocaml.warning "-33"]` annotation