### PR TITLE
Specify (using menhir 2.0).

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 1.11)
-(using menhir 1.0)
+(using menhir 2.0)
 (implicit_transitive_deps false)
 
 (name atd)


### PR DESCRIPTION
This causes Dune to pass --infer to Menhir.
This allows working around a type-checker bug in OCaml 4.07-4.10.