### PR TITLE
Do not allow inline record within polymorphic variant in OCaml

### DIFF
--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -374,7 +374,7 @@ let rec map_expr target
   match x with
     Atd.Ast.Sum (_, l, an) ->
       let kind = get_ocaml_sum target an in
-      `Sum (kind, List.map (map_variant target) l)
+      `Sum (kind, List.map (map_variant ~kind target) l)
   | Record (loc, l, an) ->
       let kind = get_ocaml_record target an in
       let field_prefix = get_ocaml_field_prefix target an in
@@ -404,10 +404,13 @@ let rec map_expr target
   | Tvar (_, s) ->
       `Tvar s
 
-and map_variant target (x : variant) : ocaml_variant =
-  match x with
-    Inherit _ -> assert false
-  | Variant (loc, (s, an), o) ->
+and map_variant ~kind target (x : variant) : ocaml_variant =
+  match kind, x with
+  | _, Inherit _ -> assert false
+  | Poly, Variant (loc, _, Some (Record _)) ->
+      Error.error loc
+        "Inline records are not allowed in polymorphic variants (not valid in OCaml)"
+  | _, Variant (loc, (s, an), o) ->
       let s = get_ocaml_cons target s an in
       (s, Option.map (map_expr target []) o, Atd.Doc.get_doc loc an)
 

--- a/atdgen/test/dune
+++ b/atdgen/test/dune
@@ -212,6 +212,41 @@
  (package atdgen)
  (action (diff test_annot_error.expected.stdout test_annot_error.stdout)))
 
+;; inline records are not allowed within poly variant, but allowed in classic
+
+(rule
+ (targets test_poly_inline_record_error.stderr)
+ (deps    (:atd test_poly_inline_record_error.atd) %{bin:atdgen})
+ (action
+   (with-stderr-to test_poly_inline_record_error.stderr
+   (with-stdout-to test_poly_inline_record_error.stdout
+     (bash "%{bin:atdgen} -t %{atd} || echo 'Failed succesfully!'")))))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_poly_inline_record_error.expected.stderr test_poly_inline_record_error.stderr)))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_poly_inline_record_error.expected.stdout test_poly_inline_record_error.stdout)))
+
+(rule
+ (targets test_classic_inline_record_t.ml test_classic_inline_record_t.mli)
+ (deps    test_classic_inline_record.atd)
+ (action  (run %{bin:atdgen} -t %{deps})))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_classic_inline_record_t.expected.ml test_classic_inline_record_t.ml)))
+
+(alias
+ (name runtest)
+ (package atdgen)
+ (action (diff test_classic_inline_record_t.expected.mli test_classic_inline_record_t.mli)))
+
 (executables
  (libraries atd atdgen-runtime biniou yojson)
  (names test_atdgen_main)

--- a/atdgen/test/test_classic_inline_record.atd
+++ b/atdgen/test/test_classic_inline_record.atd
@@ -1,0 +1,1 @@
+type foo = [ Foo of {x: int} ]<ocaml repr="classic">

--- a/atdgen/test/test_classic_inline_record_t.expected.ml
+++ b/atdgen/test/test_classic_inline_record_t.expected.ml
@@ -1,0 +1,4 @@
+(* Auto-generated from "test_classic_inline_record.atd" *)
+              [@@@ocaml.warning "-27-32-33-35-39"]
+
+type foo =  Foo of { x: int } 

--- a/atdgen/test/test_classic_inline_record_t.expected.mli
+++ b/atdgen/test/test_classic_inline_record_t.expected.mli
@@ -1,0 +1,4 @@
+(* Auto-generated from "test_classic_inline_record.atd" *)
+              [@@@ocaml.warning "-27-32-33-35-39"]
+
+type foo =  Foo of { x: int } 

--- a/atdgen/test/test_poly_inline_record_error.atd
+++ b/atdgen/test/test_poly_inline_record_error.atd
@@ -1,0 +1,1 @@
+type foo = [ Foo of {x: int} ]

--- a/atdgen/test/test_poly_inline_record_error.expected.stderr
+++ b/atdgen/test/test_poly_inline_record_error.expected.stderr
@@ -1,0 +1,2 @@
+File "test_poly_inline_record_error.atd", line 1, characters 13-28:
+Inline records are not allowed in polymorphic variants (not valid in OCaml)

--- a/atdgen/test/test_poly_inline_record_error.expected.stdout
+++ b/atdgen/test/test_poly_inline_record_error.expected.stdout
@@ -1,0 +1,1 @@
+Failed succesfully!


### PR DESCRIPTION
Fixes https://github.com/ahrefs/atd/issues/209, but still allows inline records within classic OCaml variants

```bash
$ make && echo 'type foo = [ Foo of {x: int}]'>example.atd && _build/default/atdgen/bin/ag_main.exe -t example.atd 
dune build
File "example.atd", line 1, characters 13-28:
Inline records are not allowed in polymorphic variants (not valid in OCaml)

$ make && echo 'type foo = [ Foo of {x: int}]<ocaml repr="classic">'>example.atd && _build/default/atdgen/bin/ag_main.exe -t example.atd && cat example_t.ml
dune build
(* Auto-generated from "example.atd" *)
              [@@@ocaml.warning "-27-32-33-35-39"]

type foo =  Foo of { x: int }
```