### PR TITLE
Remove 're' dep from atds/atdgen-runtime, add to atdgen

### DIFF
--- a/atd.opam
+++ b/atd.opam
@@ -31,7 +31,6 @@ depends: [
   "dune" {>= "1.11"}
   "menhir"
   "easy-format"
-  "re"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/atdgen-runtime.opam
+++ b/atdgen-runtime.opam
@@ -29,7 +29,6 @@ depends: [
   "dune" {>= "1.11"}
   "yojson" {>= "1.7.0"}
   "biniou" {>= "1.0.6"}
-  "re"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/atdgen.opam
+++ b/atdgen.opam
@@ -41,6 +41,7 @@ depends: [
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
   "odoc" {with-doc}
+  "re"
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"
 build: [

--- a/atds.opam
+++ b/atds.opam
@@ -26,7 +26,6 @@ depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "1.11"}
   "atd" {>= "2.0.0"}
-  "re"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,6 @@
   (dune (>= 1.11))
   menhir
   easy-format
-  re
   (odoc :with-doc))
  (synopsis "Parser for the ATD data format description language")
  (description "\
@@ -53,7 +52,8 @@ formats. "))
   (atdgen-codec-runtime :with-test)
   (biniou (>= 1.0.6))
   (yojson (>= 1.7.0))
-  (odoc :with-doc))
+  (odoc :with-doc)
+  re)
  (synopsis "Generates efficient JSON serializers, deserializers and validators")
  (description "\
 Atdgen is a command-line program that takes as input type definitions in the ATD
@@ -77,7 +77,6 @@ generator")
   (dune (>= 1.11))
   (yojson (>= 1.7.0))
   (biniou (>= 1.0.6))
-  re
   (odoc :with-doc)))
 
 (package
@@ -113,7 +112,6 @@ automatically handled")
   (ocaml (>= 4.02))
   (dune (>= 1.11))
   (atd (>= 2.0.0))
-  re
   (odoc :with-doc)))
 
 (package


### PR DESCRIPTION
I've checked the usage of `Re.` within the code & adjusted `re` usage in `dune-project` dependency lists. Fixes https://github.com/ahrefs/atd/issues/211