### PR TITLE
Annotate simple variant constructors in bucklescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.opt
 *.exe
 _build
+_opam
 .merlin
 *.install
 META

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -204,7 +204,10 @@ let rec make_reader ?type_annot p (x : Oj_mapping.t) : Indent.t list =
           let codec_cons =
             match arg with
             | None ->
-                [Line (sprintf "`Single (%s%s)" tick o)]
+                let single_payload = match type_annot with
+                | None -> sprintf "%s%s" tick o
+                | Some type_annot -> sprintf "%s%s: %s" tick o type_annot in
+                [Line (sprintf "`Single (%s)" single_payload)]
             | Some v ->
                 [ Line "`Decode ("
                 ; Inline (make_reader p v)

--- a/atdgen/test/bucklescript/bucklespec.atd
+++ b/atdgen/test/bucklescript/bucklespec.atd
@@ -98,3 +98,13 @@ type mutual_recurse2 = {
 type using_object = {
    f : (string * int) list <json repr="object">;
  }
+
+type variant1 = [
+  | A of string
+  | B
+] <ocaml repr="classic">
+
+type variant2 = [
+  | A
+  | C
+] <ocaml repr="classic">

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.ml
@@ -11,6 +11,10 @@ and mutual_recurse2 = Bucklespec_t.mutual_recurse2 = {
   mutual_recurse1: mutual_recurse1
 }
 
+type variant2 = Bucklespec_t.variant2 =  A | C 
+
+type variant1 = Bucklespec_t.variant1 =  A of string | B 
+
 type valid = Bucklespec_t.valid
 
 type v2 = Bucklespec_t.v2 =  V1_foo of int | V2_bar of bool 
@@ -153,6 +157,59 @@ and read_recurse js = (
     )
   )
 ) js
+let write_variant2 = (
+  Atdgen_codec_runtime.Encode.make (fun (x : variant2) -> match x with
+    | A ->
+    Atdgen_codec_runtime.Encode.constr0 "A"
+    | C ->
+    Atdgen_codec_runtime.Encode.constr0 "C"
+  )
+)
+let read_variant2 = (
+  Atdgen_codec_runtime.Decode.enum
+  [
+      (
+      "A"
+      ,
+        `Single (A: variant2)
+      )
+    ;
+      (
+      "C"
+      ,
+        `Single (C: variant2)
+      )
+  ]
+)
+let write_variant1 = (
+  Atdgen_codec_runtime.Encode.make (fun (x : variant1) -> match x with
+    | A x ->
+    Atdgen_codec_runtime.Encode.constr1 "A" (
+      Atdgen_codec_runtime.Encode.string
+    ) x
+    | B ->
+    Atdgen_codec_runtime.Encode.constr0 "B"
+  )
+)
+let read_variant1 = (
+  Atdgen_codec_runtime.Decode.enum
+  [
+      (
+      "A"
+      ,
+        `Decode (
+        Atdgen_codec_runtime.Decode.string
+        |> Atdgen_codec_runtime.Decode.map (fun x -> ((A x) : variant1))
+        )
+      )
+    ;
+      (
+      "B"
+      ,
+        `Single (B: variant1)
+      )
+  ]
+)
 let write_valid = (
   Atdgen_codec_runtime.Encode.bool
 )

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.mli
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.mli
@@ -11,6 +11,10 @@ and mutual_recurse2 = Bucklespec_t.mutual_recurse2 = {
   mutual_recurse1: mutual_recurse1
 }
 
+type variant2 = Bucklespec_t.variant2 =  A | C 
+
+type variant1 = Bucklespec_t.variant1 =  A of string | B 
+
 type valid = Bucklespec_t.valid
 
 type v2 = Bucklespec_t.v2 =  V1_foo of int | V2_bar of bool 
@@ -67,6 +71,14 @@ val write_mutual_recurse1 :  mutual_recurse1 Atdgen_codec_runtime.Encode.t
 val read_mutual_recurse2 :  mutual_recurse2 Atdgen_codec_runtime.Decode.t
 
 val write_mutual_recurse2 :  mutual_recurse2 Atdgen_codec_runtime.Encode.t
+
+val read_variant2 :  variant2 Atdgen_codec_runtime.Decode.t
+
+val write_variant2 :  variant2 Atdgen_codec_runtime.Encode.t
+
+val read_variant1 :  variant1 Atdgen_codec_runtime.Decode.t
+
+val write_variant1 :  variant1 Atdgen_codec_runtime.Encode.t
 
 val read_valid :  valid Atdgen_codec_runtime.Decode.t
 

--- a/atdgen/test/bucklescript/bucklespec_j.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_j.expected.ml
@@ -11,6 +11,10 @@ and mutual_recurse2 = Bucklespec_t.mutual_recurse2 = {
   mutual_recurse1: mutual_recurse1
 }
 
+type variant2 = Bucklespec_t.variant2 =  A | C 
+
+type variant1 = Bucklespec_t.variant1 =  A of string | B 
+
 type valid = Bucklespec_t.valid
 
 type v2 = Bucklespec_t.v2 =  V1_foo of int | V2_bar of bool 
@@ -366,6 +370,113 @@ and read_recurse = (
 )
 and recurse_of_string s =
   read_recurse (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_variant2 : _ -> variant2 -> _ = (
+  fun ob x ->
+    match x with
+      | A -> Bi_outbuf.add_string ob "\"A\""
+      | C -> Bi_outbuf.add_string ob "\"C\""
+)
+let string_of_variant2 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_variant2 ob x;
+  Bi_outbuf.contents ob
+let read_variant2 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "A" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (A : variant2)
+            | "C" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (C : variant2)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "A" ->
+              (A : variant2)
+            | "C" ->
+              (C : variant2)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let variant2_of_string s =
+  read_variant2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_variant1 : _ -> variant1 -> _ = (
+  fun ob x ->
+    match x with
+      | A x ->
+        Bi_outbuf.add_string ob "[\"A\",";
+        (
+          Yojson.Safe.write_string
+        ) ob x;
+        Bi_outbuf.add_char ob ']'
+      | B -> Bi_outbuf.add_string ob "\"B\""
+)
+let string_of_variant1 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_variant1 ob x;
+  Bi_outbuf.contents ob
+let read_variant1 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "A" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (A x : variant1)
+            | "B" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (B : variant1)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "B" ->
+              (B : variant1)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "A" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (A x : variant1)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let variant1_of_string s =
+  read_variant1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_valid = (
   Yojson.Safe.write_bool
 )


### PR DESCRIPTION
fix #154

See related PR #177.

I tested this with simple cases and it works fine.

There are still cases where `type_annon` is `None` and the variant value will be left unannotated, e.g.

https://github.com/jchavarri/atd/blob/b5d24f2adbae66dbca598b82cbb0aaf91b6f4166/atdgen/test/bucklescript/bucklespec_bs.expected.ml#L423

If there is a way to cover them in this PR, I can do it, but otherwise I'd like to merge this as it will be already useful for developers.