### PR TITLE
Encode int64 value as string in json codec

### DIFF
--- a/atdgen-runtime/src/oj_run.ml
+++ b/atdgen-runtime/src/oj_run.ml
@@ -105,7 +105,9 @@ let write_int32 ob x =
   Bi_outbuf.add_string ob (Int32.to_string x)
 
 let write_int64 ob x =
-  Bi_outbuf.add_string ob (Int64.to_string x)
+  Bi_outbuf.add_char ob '"';
+  Bi_outbuf.add_string ob (Int64.to_string x);
+  Bi_outbuf.add_char ob '"'
 
 let min_float = float min_int
 let max_float = float max_int

--- a/atdgen/test/dune
+++ b/atdgen/test/dune
@@ -48,6 +48,16 @@
  (deps    test_unit_biniou.atd)
  (action  (run %{bin:atdgen} -t %{deps})))
 
+(rule
+ (targets test_int64_enc_t.ml test_int64_enc_t.mli)
+ (deps    test_int64_enc.atd)
+ (action  (run %{bin:atdgen} -t %{deps})))
+
+(rule
+ (targets test_int64_enc_j.ml test_int64_enc_j.mli)
+ (deps    test_int64_enc.atd)
+ (action  (run %{bin:atdgen} -j %{deps})))
+
 (alias
  (name runtest)
  (package atdgen)
@@ -275,6 +285,8 @@
   testv
   test_unit_biniou_t
   test_unit_biniou_b
+  test_int64_enc_t
+  test_int64_enc_j
   test_atdgen_main
   test_lib
   ))

--- a/atdgen/test/test_atdgen_main.ml
+++ b/atdgen/test/test_atdgen_main.ml
@@ -634,6 +634,17 @@ let test_polymorphic_wrap () =
     Test_polymorphic_wrap_j.t_of_string Yojson.Safe.read_string json_out in
   check (x = x2)
 
+let test_encoding_int64 () =
+  section "json encoding int64 as string";
+  let encoded = Test_int64_enc_j.string_of_int64 Int64.max_int in
+  check (String.equal encoded {|"9223372036854775807"|})
+
+let test_encoding_decoding_int64 () =
+  section "json encoding & decoding int64";
+  let encoded = Test_int64_enc_j.string_of_int64 Int64.max_int in
+  let decoded = Test_int64_enc_j.int64_of_string encoded in
+  check (decoded = Int64.max_int)
+
 let all_tests = [
   test_ocaml_internals;
   test_biniou_missing_field;
@@ -669,6 +680,8 @@ let all_tests = [
   test_tag_field_emulation_with_catchall;
   test_json_open_enum;
   test_ambiguous_record;
+  test_encoding_int64;
+  test_encoding_decoding_int64;
 ]
 
 (* TODO: use Alcotest to run the test suite. *)

--- a/atdgen/test/test_int64_enc.atd
+++ b/atdgen/test/test_int64_enc.atd
@@ -1,0 +1,1 @@
+type int64 = int <ocaml repr="int64">


### PR DESCRIPTION
Currently, `atdgen-runtime` encodes `int64` value as JSON `number`. This makes it difficult to use the resulting JSON in the JavaScript environments (node, browser). For example, consider this issue with the `Int64.max_int` value:

```
Welcome to Node.js v12.16.2.
Type ".help" for more information.
> JSON.parse("9223372036854775807")
9223372036854776000
```

Right away, some information is lost. If we encode it as string though, we don't have such problem anymore. Moreover decoding already supports string as the transportation format for `int64` (test is added). This change fixes the interoperability with bucklescript https://github.com/ahrefs/bs-atdgen-codec-runtime/issues/22

Nevertheless, the change is breaking, so version bump is needed if merged.