### PR TITLE
Allow to specify arbitrary type attributes

### DIFF
--- a/atdgen/bin/ag_main.ml
+++ b/atdgen/bin/ag_main.ml
@@ -71,21 +71,38 @@ let main () =
     let l = Re.Str.split (Re.Str.regexp " *, *\\| +") s in
     opens := List.rev_append l !opens
   in
-  let pp_convs : Ocaml.pp_convs ref = ref (Ocaml.Ppx []) in
+  let pp_convs : Ocaml.pp_convs ref = ref (Ocaml.Ppx_deriving []) in
+  let set_pp_convs arg =
+    match !pp_convs with
+    | Ocaml.Camlp4 [] | Ppx_deriving [] | Ppx [] ->
+      pp_convs := arg
+    | _ ->
+      match !pp_convs, arg with
+      | Ppx pp_convs', Ppx arg -> pp_convs := Ppx (pp_convs' @ arg)
+      | _ -> failwith "Only one of `-type-conv`, `-deriving-conv`, \
+                       `-type-attr` could be specified. \
+                       `-type-attr` may be used muliple times"
+  in
   let options = [
     "-type-conv", Arg.String (fun s ->
-      pp_convs := Camlp4 (Re.Str.split (Re.Str.regexp ",") s)),
+      set_pp_convs (Camlp4 (Re.Str.split (Re.Str.regexp ",") s))),
     "
     GEN1,GEN2,...
          Insert 'with GEN1, GEN2, ...' after OCaml type definitions for the
          type-conv preprocessor
     ";
     "-deriving-conv", Arg.String (fun s ->
-      pp_convs := Ocaml.Ppx (Re.Str.split (Re.Str.regexp ",") s)),
+      set_pp_convs (Ocaml.Ppx_deriving (Re.Str.split (Re.Str.regexp ",") s))),
     "
     GEN1,GEN2,...
-         Insert 'with GEN1, GEN2, ...' after OCaml type definitions for the
-         ppx_deriving preprocessor
+         Insert '[@@deriving GEN1,GEN2,...]' after OCaml type definitions for
+         the ppx_deriving preprocessor
+    ";
+    "-type-attr", Arg.String (fun s -> set_pp_convs (Ocaml.Ppx [ s ])),
+    "
+    ATTR
+         Insert '[@@ATTR]' after OCaml type definitions.
+         Option can be used multiple times to specify several attributes
     ";
     "-t", Arg.Unit (fun () ->
                       set_once "output type" mode T;

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -724,7 +724,7 @@ let make_ocaml_files
      m1 = original type definitions after dependency analysis
      m2 = monomorphic type definitions after dependency analysis *)
   let ocaml_typedefs =
-    Ocaml.ocaml_of_atd ~pp_convs:(Ppx []) ~target
+    Ocaml.ocaml_of_atd ~pp_convs:(Ppx_deriving []) ~target
       ~type_aliases (head, m1) in
   let defs = Oj_mapping.defs_of_atd_modules m2 ~target in
   let header =

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -13,6 +13,7 @@ open Mapping
 
 type pp_convs =
   | Camlp4 of string list
+  | Ppx_deriving of string list
   | Ppx of string list
 
 (* Type mapping from ATD to OCaml *)
@@ -669,12 +670,15 @@ let append_ocamldoc_comment x doc =
 
 let format_pp_conv_node node = function
   | Camlp4 []
+  | Ppx_deriving []
   | Ppx [] -> node
   | converters ->
+    let attr value = "[@@" ^ value ^ "]" in
     let converters =
       match converters with
-      | Ppx cs -> "[@@deriving " ^ (String.concat ", " cs) ^ "]"
-      | Camlp4 cs -> "with " ^ (String.concat ", " cs) in
+      | Ppx_deriving cs -> attr ("deriving " ^ (String.concat ", " cs))
+      | Camlp4 cs -> "with " ^ (String.concat ", " cs)
+      | Ppx cs -> List.map attr cs |> String.concat "" in
     Label ((node, label), make_atom converters)
 
 let rec format_module_item pp_convs
@@ -836,7 +840,7 @@ let format_all l =
 let ocaml_of_expr x : string =
   Easy_format.Pretty.to_string (format_type_expr x)
 
-let ocaml_of_atd ?(pp_convs=Ppx []) ~target ~type_aliases
+let ocaml_of_atd ?(pp_convs=Ppx_deriving []) ~target ~type_aliases
     (head, (l : (bool * module_body) list)) : string =
   let head = format_head head in
   let bodies =

--- a/atdgen/src/ocaml.mli
+++ b/atdgen/src/ocaml.mli
@@ -2,6 +2,7 @@
 
 type pp_convs =
   | Camlp4 of string list
+  | Ppx_deriving of string list
   | Ppx of string list
 
 type atd_ocaml_sum = Classic | Poly


### PR DESCRIPTION
Addresses https://github.com/ahrefs/atd/issues/215

Example:

```bash
$ make && _build/default/atdgen/bin/ag_main.exe -type-attr "deriving show,eq" -type-attr 'ocamlformat "disable"' -t x.atd && cat x_t.ml
dune build
(* Auto-generated from "x.atd" *)
              [@@@ocaml.warning "-27-32-33-35-39"]

type body = { b: int; c: int } [@@deriving show,eq][@@ocamlformat "disable"]

type adapted = { a: int; body: body }
  [@@deriving show,eq][@@ocamlformat "disable"]
```

To some extent it could be used instead of `-deriving-conv`, but the option is kept for backward compatibility. Also, added the check, so that only one of `-deriving-conv`, `-type-conv`, `-type-attr` is specified. `-type-attr` itself could be specified multiple times though (see example)