### PR TITLE
Some cleanup: add makefile targets, remove dead code/warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,81 @@
+#
+# Makefile for developer's convenience.
+# Build logic is implemented with dune.
+#
+
 DUNE ?= dune
 
+# Build everything. Should only require OCaml libraries and tools installable
+# via opam.
+.PHONY: all
 all:
 	$(DUNE) build
 
+# Install the OCaml dependencies for the build.
+.PHONY: setup
+setup:
+	opam update
+	opam install --deps-only ./*.opam
+
+############################# Testing #####################################
+
+# Test everything. Requires external non-OCaml compilers and libraries
+# to support all the target languages.
+.PHONY: test
 test:
-	$(DUNE) runtest
+	$(DUNE) runtest -f
 
-check: test
+# Test the OCaml code used by all the backends
+test-common:
+	$(MAKE) -C atd test
+	$(MAKE) -C atdcat test
 
+# Test only the OCaml backends
+.PHONY: test-ocaml
+test-ocaml:
+	$(MAKE) test-common
+	$(MAKE) -C atdgen-runtime test
+	$(MAKE) -C atdgen test
+
+# Test only the Scala backend
+.PHONY: test-scala
+test-scala:
+	$(MAKE) test-common
+	$(MAKE) -C atds test
+
+# Test only the Java backend
+.PHONY: test-java
+test-java:
+	$(MAKE) test-common
+	$(MAKE) -C atdj test
+
+############################################################################
+
+.PHONY: js
 js:
 	$(DUNE) build atdgen/bin/ag_main.bc.js
 
+.PHONY: clean
 clean:
 	$(DUNE) clean
 
+.PHONY: all-supported-ocaml-versions
 all-supported-ocaml-versions:
 	$(DUNE) runtest --workspace dune-workspace.dev
 
+.PHONY: doc
 doc:
 	cd doc && sphinx-build . _build
 
+.PHONY: livedoc
 livedoc:
 	cd doc && sphinx-autobuild . _build \
 	  -p 8888 -q  --host $(shell hostname) -r '\.#.*'
 
 package := atd
+.PHONY: opam-release
 opam-release:
 	dune-release distrib --skip-build --skip-lint --skip-tests -n $(package)
 	dune-release publish distrib --verbose -n $(package)
 	dune-release opam pkg -n $(package)
 	dune-release opam submit -n $(package)
-
-.PHONY: all test clean check doc livedoc

--- a/atd/Makefile
+++ b/atd/Makefile
@@ -1,0 +1,9 @@
+DUNE ?= dune
+
+.PHONY: build
+build:
+	$(DUNE) build @all
+
+.PHONY: test
+test:
+	$(DUNE) runtest -f

--- a/atdcat/Makefile
+++ b/atdcat/Makefile
@@ -1,0 +1,9 @@
+DUNE ?= dune
+
+.PHONY: build
+build:
+	$(DUNE) build @all
+
+.PHONY: test
+test:
+	$(DUNE) runtest -f

--- a/atdgen-runtime/Makefile
+++ b/atdgen-runtime/Makefile
@@ -1,0 +1,9 @@
+DUNE ?= dune
+
+.PHONY: build
+build:
+	$(DUNE) build @all
+
+.PHONY: test
+test:
+	$(DUNE) runtest -f

--- a/atdgen-runtime/src/ob_run.ml
+++ b/atdgen-runtime/src/ob_run.ml
@@ -333,6 +333,19 @@ type t = {
 let create () =
   { { _a = None; _b = Array.length Sys.argv } with _a = None }
 
+(*
+   This is a runtime test that checks whether our assumptions about
+   the compiler still hold.
+
+   We get the following warning when using an OCaml compiler built
+   with the flambda optimization. This is probably a good warning
+   and shouldn't be ignored if the OCaml/biniou is to be used.
+   This won't affect the OCaml/JSON backend.
+
+   > Warning 59 [flambda-assignment-to-non-mutable-value]: A potential
+   > assignment to a non-mutable value was detected in this source file.
+   > Such assignments may generate incorrect code when using Flambda.
+*)
 let test () =
   let r = create () in
   let v = Some 17 in

--- a/atdgen-runtime/src/oj_run.ml
+++ b/atdgen-runtime/src/oj_run.ml
@@ -239,14 +239,14 @@ let write_with_adapter restore writer ob x =
 (*
   Checking at runtime that our assumptions on unspecified compiler behavior
   still hold.
+   TODO: what are these assumptions and which component makes them?
 *)
-
 type t = {
   _a : int option;
   _b : int;
 }
 
-let create () =
+(* This must be a test for the type checker since the function isn't used
+   anywhere. *)
+let _test () =
   { { _a = None; _b = Array.length Sys.argv } with _a = None }
-
-(************************************)

--- a/atdgen-runtime/src/oj_run.ml
+++ b/atdgen-runtime/src/oj_run.ml
@@ -236,11 +236,6 @@ let write_with_adapter restore writer ob x =
   let ast' = restore ast in
   Yojson.Safe.to_outbuf ob ast'
 
-(* We want an identity function that is not inlined *)
-type identity_t = { mutable _identity : 'a. 'a -> 'a }
-let identity_ref = { _identity = (fun x -> x) }
-let identity x = identity_ref._identity x
-
 (*
   Checking at runtime that our assumptions on unspecified compiler behavior
   still hold.
@@ -253,16 +248,5 @@ type t = {
 
 let create () =
   { { _a = None; _b = Array.length Sys.argv } with _a = None }
-
-let test () =
-  let r = create () in
-  let v = Some 17 in
-  Obj.set_field (Obj.repr r) 0 (Obj.repr v);
-  let safe_r = identity r in
-  (* r._a is inlined by ocamlopt and equals None
-     because the field is supposed to be immutable. *)
-  assert (safe_r._a = v)
-
-let () = test ()
 
 (************************************)

--- a/atdgen/Makefile
+++ b/atdgen/Makefile
@@ -1,0 +1,9 @@
+DUNE ?= dune
+
+.PHONY: build
+build:
+	$(DUNE) build
+
+.PHONY: test
+test:
+	$(DUNE) runtest -f

--- a/atdj/Makefile
+++ b/atdj/Makefile
@@ -1,0 +1,13 @@
+#
+# Java/JSON backend
+#
+
+DUNE ?= dune
+
+.PHONY: build
+build:
+	$(DUNE) build @all
+
+.PHONY: test
+test:
+	$(DUNE) runtest -f

--- a/atds/Makefile
+++ b/atds/Makefile
@@ -1,0 +1,13 @@
+#
+# Scala/JSON backend
+#
+
+DUNE ?= dune
+
+.PHONY: build
+build:
+	$(DUNE) build @all
+
+.PHONY: test
+test:
+	$(DUNE) runtest -f


### PR DESCRIPTION
This shouldn't break anything. The makefiles are for the developers to not have to think about how to invoke dune.