### PR TITLE
Fix atdpy doc formatting + add meta documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,46 @@ Each subproject has its own README:
 * [atdj](atdj): targets Java
 * [atdpy](atdpy): targets Python
 * [atds](atds): targets Scala
+
+Updating the documentation
+--
+
+### Documentation setup
+
+The user documentation is published at https://atd.readthedocs.io/.
+It's automatically published from the main branch of the GitHub repo
+from the files found in `/doc`.
+
+The [format of the documentation is Restructured
+Text](https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html#restructured-text-rest-and-sphinx-cheatsheet)
+because it's more expressive that Markdown and it's not that hard to
+pick up.
+
+You can either edit the `.rst` files and hope that everything will
+turn out fine or you can preview it by running Sphinx locally. The
+latter is recommended for large edits. Try this:
+
+Install sphinx and the read-the-docs theme:
+```
+pip install sphinx sphinx_rtd_theme
+```
+
+Compile the documentation and run a local
+[HTTP server on port 8888](http://0.0.0.0:8888):
+```
+make livedoc
+```
+
+### Writing good documentation
+
+Don't assume that our existing documentation is already good (!)
+
+Good documentation separates concerns. This not only makes it easy
+to read but also easier to write.
+Daniele Procida has a wonderful presentation about the four kinds of
+documentation and why they're best kept separate:
+
+* [website](https://documentation.divio.com/)
+* [30-min presentation](https://www.youtube.com/watch?v=t4vKPhjcMZg)
+
+![the four kinds of documentation](https://documentation.divio.com/_images/overview.png)

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,12 @@ all-supported-ocaml-versions:
 doc:
 	cd doc && sphinx-build . _build
 
+# Run documentation server.
+# See setup instructions in CONTRIBUTING.md
 .PHONY: livedoc
 livedoc:
-	cd doc && sphinx-autobuild . _build \
-	  -p 8888 -q  --host $(shell hostname) -r '\.#.*'
+	$(MAKE) doc
+	python3 -m http.server 8888 --directory doc/_build
 
 package := atd
 .PHONY: opam-release

--- a/doc/atdpy.rst
+++ b/doc/atdpy.rst
@@ -11,7 +11,7 @@ particular, some how-to guides would be great.
   I recommend watching the 30-min presentation.
 
 Tutorials
-===
+=========
 
 ..
   Tutorials are learning-oriented. The reader is taken through a
@@ -20,26 +20,27 @@ Tutorials
   documentation category: practical/exploring
 
 Hello World
----
+-----------
 
 Grab a copy of ``atdpy`` [how?]. Create a file ``hello.atd``
 containing this:
 
-::
+.. code-block:: ocaml
+
   type message = {
     subject: string;
     body: string;
   }
 
-Call ``atdpy`` to produce ``hello.py``:
+Call ``atdpy`` to produce ``hello.py``::
 
-::
-  $ atdpy hello.atd
+   $ atdpy hello.atd
 
 There's now a file ``hello.py`` that contains a class looking like
 this:
 
-::
+.. code-block:: python
+
   ...
 
   @dataclass
@@ -65,36 +66,37 @@ this:
 
 Let's write a Python program ``say_hello.py`` that uses this code:
 
-::
+.. code-block:: python
+
    import hello
 
    msg = hello.Message("Hello", "Dear friend, I hope you are well.")
    print(msg.to_json_string())
 
-Running it will print the JSON message:
+Running it will print the JSON message::
 
-::
    $ python3 say_hello.py
    {"subject": "Hello", "body": "Dear friend, I hope you are well."}
 
 Such JSON data can be parsed. Let's write a program
 ``read_message.py`` that consumes JSON data from standard input:
 
-::
+.. code-block:: python
+
    import hello, sys, json
 
    data = json.load(sys.stdin)
    msg = hello.Message.from_json(data)
    print(f"subject: {msg.subject}")
 
-::
+Output::
+
    $ echo '{"subject": "big news", "body": ""}' | python3 read_message.py
    subject: big news
 
 It works! But what happens if the JSON data lacks a ``"subject"``
-field? Let's see.
+field? Let's see::
 
-::
    $ echo '{"subj": "big news", "body": ""}' | python3 read_message.py
    Traceback (most recent call last):
    ...
@@ -102,40 +104,38 @@ field? Let's see.
 
 And what if our program also thought that the correct field name was
 ``subj`` rather than subject? Here's ``read_message_wrong.py`` which
-tries to access a ``subj`` field:
+tries to access a ``subj`` field::
 
-::
    import hello, sys, json
 
    data = json.load(sys.stdin)
    msg = hello.Message.from_json(data)
    print(f"subject: {msg.subj}")
 
-Let's run the program through mypy:
+Let's run the program through mypy::
 
-::
    $ mypy read_message_wrong.py
    read_message_wrong.py:5: error: "Message" has no attribute "subj"
    Found 1 error in 1 file (checked 1 source file)
 
 Mypy detected that our program makes incorrect assumptions about the
 message format without running it. On the correct program
-``read_message.py``, we get a reassuring message:
+``read_message.py``, we get a reassuring message::
 
-::
    $ mypy read_message.py
    Success: no issues found in 1 source file
 
 
 ATD Records, JSON objects, Python classes
----
+-----------------------------------------
 
 An ATD file contains types that describe the structure of JSON
 data. JSON objects map to Python classes and objects. They're called
 records in the ATD language. Let's define a simple record type
 in the file ``hello_plus.atd``:
 
-::
+.. code-block:: ocaml
+
    type message = {
      subject: string;
      ~body: string;
@@ -146,9 +146,11 @@ has a default value. Whenever the JSON field is missing from a JSON
 object, a default value is assumed. The implicit default value for a
 string is ``""``.
 
-Let's add a ``signature`` field whose default value isn't the empty string:
+Let's add a ``signature`` field whose default value isn't the empty
+string:
 
-::
+.. code-block:: ocaml
+
    type message = {
      subject: string;
      ~body: string;
@@ -158,7 +160,8 @@ Let's add a ``signature`` field whose default value isn't the empty string:
 Finally, we'll add an optional ``url`` field that doesn't take a default value
 at all:
 
-::
+.. code-block:: ocaml
+
    type message = {
      subject: string;
      ~body: string;
@@ -169,26 +172,27 @@ at all:
 Let's generate the Python code for this.
 
 ::
+
    $ atdpy hello_plus.atd
 
 Let's update our reader program ``read_message_plus.py`` to this:
 
-::
+.. code-block:: python
+
    import hello_plus, sys, json
 
    data = json.load(sys.stdin)
    msg = hello_plus.Message.from_json(data)
    print(msg)
 
-We can test it, showing us the final value of each field:
+We can test it, showing us the final value of each field::
 
-::
    $ echo '{"subject":"hi"}' | python3 read_message_plus.py
    Message(subject='hi', body='', signature='anonymous', url=None)
 
 
 How-to guides
-===
+=============
 
 ..
   How-to guides are goal-oriented. They're for solving specific
@@ -197,18 +201,18 @@ How-to guides
   documentation category: practical/producing
 
 Defining default field values
----
+-----------------------------
 
 [missing]
 
 Renaming field names
----
+--------------------
 
 [missing]
 
 
 Deep dives
----
+==========
 
 ..
   Deep dives are focused on understanding. They're discussions on a
@@ -218,14 +222,14 @@ Deep dives
 [missing]
 
 Reference
-===
+=========
 
 ..
   A reference is precise and complete.
   documentation category: theoretical/producing
 
 Type mapping
----
+------------
 
 +--------------------+----------------------+-------------------------+
 | ATD type           | Python type          | JSON example            |
@@ -254,10 +258,10 @@ Type mapping
 +--------------------+----------------------+-------------------------+
 
 Supported ATD annotations
----
+-------------------------
 
 Default field values
-^^^
+^^^^^^^^^^^^^^^^^^^^
 
 Record fields following a ``~`` assume a default value. The default value can
 be implicit as mandated by the ATD language specification (false for
@@ -267,7 +271,8 @@ A user-provided default uses an annotation of the form
 ``<python default="VALUE">`` where ``VALUE`` evaluates to a Python
 expression e.g.
 
-::
+.. code-block:: ocaml
+
   type foo = {
     ~answer <python default="42">: int;
   }
@@ -278,7 +283,8 @@ Python. However, the implementation of ``dataclass`` via the
 defaults. This causes class constructors to not have default fields
 that are mutable such as ``[]``. For example:
 
-::
+.. code-block:: ocaml
+
    type bar = {
      ~items: int list;
    }
@@ -289,20 +295,22 @@ type list. For example, ``Bar([1, 2, 3])`` would be legal but
 however succeed. Therefore, the following two Python expressions would
 be valid and equivalent:
 
-::
+.. code-block:: python
+
    Bar([])
    Bar.from_json_string('{}')
 
 
 Field and constructor renaming
-^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Alternate JSON object field names can be specified using an annotation
 of the form ``<json name="NAME">`` where ``NAME`` is the desired field
 name to be used in the JSON representation. For example, the following
 specifies the JSON name of the ``id`` field is ``ID``:
 
-::
+.. code-block:: ocaml
+
    type foo = {
      id <json name="ID">: string
    }
@@ -310,7 +318,8 @@ specifies the JSON name of the ``id`` field is ``ID``:
 Similarly, the constructor names of sum types can also be given
 alternate names in the JSON representation. Here's an example:
 
-::
+.. code-block:: ocaml
+
    type bar = [
    | Alpha <json name="alpha">
    | Beta <json name="beta"> of int
@@ -322,14 +331,14 @@ Python keywords or reserved identifiers.
 
 
 Alternate representations for association lists
-^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 List of pairs can be represented by JSON objects or by
 Python dictionaries if the correct annotations are provided:
 
--  ``(string * bar) list <json repr="object">`` will use JSON objects to
-   represent a list of pairs of Python type ``List[str, Bar]``.
-   Using the annotation ``<json repr="array">`` is equivalent to the default.
--  ``(foo * bar) list <python repr="dict">`` will use a Python
-   dictionary of type ``Dict[Foo, Bar]`` to represent the association list.
-   Using the annotation ``<python repr="list">`` is equivalent to the default.
+* ``(string * bar) list <json repr="object">`` will use JSON objects to
+  represent a list of pairs of Python type ``List[str, Bar]``.
+  Using the annotation ``<json repr="array">`` is equivalent to the default.
+* ``(foo * bar) list <python repr="dict">`` will use a Python
+  dictionary of type ``Dict[Foo, Bar]`` to represent the association list.
+  Using the annotation ``<python repr="list">`` is equivalent to the default.


### PR DESCRIPTION
This time I checked that the documentation looks good on my machine.

### PR checklist

- [ ] New code has tests to catch future regressions
- [ ] Documentation is up-to-date
- [ ] `CHANGES.md` is up-to-date
