### PR TITLE
Add CI status badge to the main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ATD project - Static Types for Json APIs
 ==
 
+[![CircleCI](https://circleci.com/gh/ahrefs/atd/tree/master.svg?style=svg)](https://circleci.com/gh/ahrefs/atd/tree/master)
+
 ATD stands for Adaptable Type Definitions. It is a syntax for defining
 cross-language data types. It is used as input to generate efficient
 and type-safe serializers, deserializers and validators.


### PR DESCRIPTION
Adds a status badge that normally looks like this:

![image](https://user-images.githubusercontent.com/343265/157191474-201d2dc9-8710-43ab-a375-2e63ffeabd17.png)

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
