### PR TITLE
Downcase Python output file names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Next release
 * Add detection of misplaced annotations and misspelled annotation
   field names for atdgen targets and atdpy (#204, #227)
 
+* Downcase Python output files (#251)
+
 2.2.0 (2020-09-03)
 ------------------
 

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -1182,6 +1182,7 @@ let run_file src_path =
        Filename.chop_suffix src_name ".atd"
      else
        src_name) ^ ".py"
+    |> String.lowercase_ascii
   in
   let dst_path = dst_name in
   let (_atd_head, atd_module), _original_types =

--- a/atdpy/test/python-tests/dune
+++ b/atdpy/test/python-tests/dune
@@ -3,9 +3,13 @@
 ;
 (rule
   (targets
-    everything.py)
+    allcaps.py
+    everything.py
+  )
   (deps
-    ../atd-input/everything.atd)
+    ../atd-input/ALLCAPS.atd
+    ../atd-input/everything.atd
+  )
   (action
     (run %{bin:atdpy} %{deps})))
 


### PR DESCRIPTION
File `Foo.atd` becomes `foo.py` as recommended by PEP8 (Python's style guide).

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
