### PR TITLE
atdpy: avoid errors from the flake8 linter

### DIFF
--- a/.circleci/setup-system
+++ b/.circleci/setup-system
@@ -19,7 +19,7 @@ sudo apt-get install -y \
   scala
 
 # For atdpy
-pip install pytest mypy
+pip install pytest mypy flake8
 
 ###### Sanity checks ######
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,9 @@ Next release
 * Add detection of misplaced annotations and misspelled annotation
   field names for atdgen targets and atdpy (#204, #227)
 
-* Downcase Python output files (#251)
+* atdpy: Downcase Python output files (#251)
+
+* atdpy: Disable flake8 checks on generated code via a special comment (#252)
 
 2.2.0 (2020-09-03)
 ------------------

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -192,6 +192,9 @@ This implements classes for the types defined in '%s', providing
 methods and functions to convert data from/to JSON.
 """
 
+# Disable flake8 entirely on this file:
+# flake8: noqa
+
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, Union
 
@@ -200,6 +203,7 @@ import json
 ############################################################################
 # Private functions
 ############################################################################
+
 
 def _atd_missing_json_field(type_name: str, json_field_name: str) -> NoReturn:
     raise ValueError(f"missing field '{json_field_name}'"
@@ -260,8 +264,8 @@ def _atd_read_string(x: Any) -> str:
 
 
 def _atd_read_list(
-        read_elt: Callable[[Any], Any]
-    ) -> Callable[[List[Any]], List[Any]]:
+            read_elt: Callable[[Any], Any]
+        ) -> Callable[[List[Any]], List[Any]]:
     def read_list(elts: List[Any]) -> List[Any]:
         if isinstance(elts, list):
             return [read_elt(elt) for elt in elts]
@@ -271,9 +275,9 @@ def _atd_read_list(
 
 
 def _atd_read_assoc_array_into_dict(
-        read_key: Callable[[Any], Any],
-        read_value: Callable[[Any], Any],
-    ) -> Callable[[List[Any]], Dict[Any, Any]]:
+            read_key: Callable[[Any], Any],
+            read_value: Callable[[Any], Any],
+        ) -> Callable[[List[Any]], Dict[Any, Any]]:
     def read_assoc(elts: List[List[Any]]) -> Dict[str, Any]:
         if isinstance(elts, list):
             return {read_key(elt[0]): read_value(elt[1]) for elt in elts}
@@ -284,11 +288,12 @@ def _atd_read_assoc_array_into_dict(
 
 
 def _atd_read_assoc_object_into_dict(
-        read_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+            read_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     def read_assoc(elts: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(elts, dict):
-            return {_atd_read_string(k): read_value(v) for k, v in elts.items()}
+            return {_atd_read_string(k): read_value(v)
+                    for k, v in elts.items()}
         else:
             _atd_bad_json('object', elts)
             raise AssertionError('impossible')  # keep mypy happy
@@ -296,11 +301,12 @@ def _atd_read_assoc_object_into_dict(
 
 
 def _atd_read_assoc_object_into_list(
-        read_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[str, Any]], List[Tuple[str, Any]]]:
+            read_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[str, Any]], List[Tuple[str, Any]]]:
     def read_assoc(elts: Dict[str, Any]) -> List[Tuple[str, Any]]:
         if isinstance(elts, dict):
-            return [(_atd_read_string(k), read_value(v)) for k, v in elts.items()]
+            return [(_atd_read_string(k), read_value(v))
+                    for k, v in elts.items()]
         else:
             _atd_bad_json('object', elts)
             raise AssertionError('impossible')  # keep mypy happy
@@ -353,8 +359,8 @@ def _atd_write_string(x: Any) -> str:
 
 
 def _atd_write_list(
-        write_elt: Callable[[Any], Any]
-    ) -> Callable[[List[Any]], List[Any]]:
+            write_elt: Callable[[Any], Any]
+        ) -> Callable[[List[Any]], List[Any]]:
     def write_list(elts: List[Any]) -> List[Any]:
         if isinstance(elts, list):
             return [write_elt(elt) for elt in elts]
@@ -364,9 +370,9 @@ def _atd_write_list(
 
 
 def _atd_write_assoc_dict_to_array(
-        write_key: Callable[[Any], Any],
-        write_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[Any, Any]], List[Tuple[Any, Any]]]:
+            write_key: Callable[[Any], Any],
+            write_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[Any, Any]], List[Tuple[Any, Any]]]:
     def write_assoc(elts: Dict[str, Any]) -> List[Tuple[str, Any]]:
         if isinstance(elts, dict):
             return [(write_key(k), write_value(v)) for k, v in elts.items()]
@@ -377,11 +383,12 @@ def _atd_write_assoc_dict_to_array(
 
 
 def _atd_write_assoc_dict_to_object(
-        write_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+            write_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     def write_assoc(elts: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(elts, dict):
-            return {_atd_write_string(k): write_value(v) for k, v in elts.items()}
+            return {_atd_write_string(k): write_value(v)
+                    for k, v in elts.items()}
         else:
             _atd_bad_python('Dict[str, <value type>]', elts)
             raise AssertionError('impossible')  # keep mypy happy
@@ -389,11 +396,12 @@ def _atd_write_assoc_dict_to_object(
 
 
 def _atd_write_assoc_list_to_object(
-        write_value: Callable[[Any], Any],
-    ) -> Callable[[List[Any]], Dict[str, Any]]:
+            write_value: Callable[[Any], Any],
+        ) -> Callable[[List[Any]], Dict[str, Any]]:
     def write_assoc(elts: List[List[Any]]) -> Dict[str, Any]:
         if isinstance(elts, list):
-            return {_atd_write_string(elt[0]): write_value(elt[1]) for elt in elts}
+            return {_atd_write_string(elt[0]): write_value(elt[1])
+                    for elt in elts}
         else:
             _atd_bad_python('List[Tuple[<key type>, <value type>]]', elts)
             raise AssertionError('impossible')  # keep mypy happy

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -279,7 +279,7 @@ def _atd_read_assoc_array_into_dict(
             return {read_key(elt[0]): read_value(elt[1]) for elt in elts}
         else:
             _atd_bad_json('array', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -291,7 +291,7 @@ def _atd_read_assoc_object_into_dict(
             return {_atd_read_string(k): read_value(v) for k, v in elts.items()}
         else:
             _atd_bad_json('object', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -303,7 +303,7 @@ def _atd_read_assoc_object_into_list(
             return [(_atd_read_string(k), read_value(v)) for k, v in elts.items()]
         else:
             _atd_bad_json('object', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -372,7 +372,7 @@ def _atd_write_assoc_dict_to_array(
             return [(write_key(k), write_value(v)) for k, v in elts.items()]
         else:
             _atd_bad_python('Dict[str, <value type>]]', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return write_assoc
 
 
@@ -384,7 +384,7 @@ def _atd_write_assoc_dict_to_object(
             return {_atd_write_string(k): write_value(v) for k, v in elts.items()}
         else:
             _atd_bad_python('Dict[str, <value type>]', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return write_assoc
 
 
@@ -396,7 +396,7 @@ def _atd_write_assoc_list_to_object(
             return {_atd_write_string(elt[0]): write_value(elt[1]) for elt in elts}
         else:
             _atd_bad_python('List[Tuple[<key type>, <value type>]]', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return write_assoc
 
 

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -91,7 +91,7 @@ def _atd_read_assoc_array_into_dict(
             return {read_key(elt[0]): read_value(elt[1]) for elt in elts}
         else:
             _atd_bad_json('array', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -103,7 +103,7 @@ def _atd_read_assoc_object_into_dict(
             return {_atd_read_string(k): read_value(v) for k, v in elts.items()}
         else:
             _atd_bad_json('object', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -115,7 +115,7 @@ def _atd_read_assoc_object_into_list(
             return [(_atd_read_string(k), read_value(v)) for k, v in elts.items()]
         else:
             _atd_bad_json('object', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -184,7 +184,7 @@ def _atd_write_assoc_dict_to_array(
             return [(write_key(k), write_value(v)) for k, v in elts.items()]
         else:
             _atd_bad_python('Dict[str, <value type>]]', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return write_assoc
 
 
@@ -196,7 +196,7 @@ def _atd_write_assoc_dict_to_object(
             return {_atd_write_string(k): write_value(v) for k, v in elts.items()}
         else:
             _atd_bad_python('Dict[str, <value type>]', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return write_assoc
 
 
@@ -208,7 +208,7 @@ def _atd_write_assoc_list_to_object(
             return {_atd_write_string(elt[0]): write_value(elt[1]) for elt in elts}
         else:
             _atd_bad_python('List[Tuple[<key type>, <value type>]]', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return write_assoc
 
 

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -4,6 +4,9 @@ This implements classes for the types defined in 'everything.atd', providing
 methods and functions to convert data from/to JSON.
 """
 
+# Disable flake8 entirely on this file:
+# flake8: noqa
+
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, Union
 
@@ -12,6 +15,7 @@ import json
 ############################################################################
 # Private functions
 ############################################################################
+
 
 def _atd_missing_json_field(type_name: str, json_field_name: str) -> NoReturn:
     raise ValueError(f"missing field '{json_field_name}'"
@@ -72,8 +76,8 @@ def _atd_read_string(x: Any) -> str:
 
 
 def _atd_read_list(
-        read_elt: Callable[[Any], Any]
-    ) -> Callable[[List[Any]], List[Any]]:
+            read_elt: Callable[[Any], Any]
+        ) -> Callable[[List[Any]], List[Any]]:
     def read_list(elts: List[Any]) -> List[Any]:
         if isinstance(elts, list):
             return [read_elt(elt) for elt in elts]
@@ -83,9 +87,9 @@ def _atd_read_list(
 
 
 def _atd_read_assoc_array_into_dict(
-        read_key: Callable[[Any], Any],
-        read_value: Callable[[Any], Any],
-    ) -> Callable[[List[Any]], Dict[Any, Any]]:
+            read_key: Callable[[Any], Any],
+            read_value: Callable[[Any], Any],
+        ) -> Callable[[List[Any]], Dict[Any, Any]]:
     def read_assoc(elts: List[List[Any]]) -> Dict[str, Any]:
         if isinstance(elts, list):
             return {read_key(elt[0]): read_value(elt[1]) for elt in elts}
@@ -96,11 +100,12 @@ def _atd_read_assoc_array_into_dict(
 
 
 def _atd_read_assoc_object_into_dict(
-        read_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+            read_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     def read_assoc(elts: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(elts, dict):
-            return {_atd_read_string(k): read_value(v) for k, v in elts.items()}
+            return {_atd_read_string(k): read_value(v)
+                    for k, v in elts.items()}
         else:
             _atd_bad_json('object', elts)
             raise AssertionError('impossible')  # keep mypy happy
@@ -108,11 +113,12 @@ def _atd_read_assoc_object_into_dict(
 
 
 def _atd_read_assoc_object_into_list(
-        read_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[str, Any]], List[Tuple[str, Any]]]:
+            read_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[str, Any]], List[Tuple[str, Any]]]:
     def read_assoc(elts: Dict[str, Any]) -> List[Tuple[str, Any]]:
         if isinstance(elts, dict):
-            return [(_atd_read_string(k), read_value(v)) for k, v in elts.items()]
+            return [(_atd_read_string(k), read_value(v))
+                    for k, v in elts.items()]
         else:
             _atd_bad_json('object', elts)
             raise AssertionError('impossible')  # keep mypy happy
@@ -165,8 +171,8 @@ def _atd_write_string(x: Any) -> str:
 
 
 def _atd_write_list(
-        write_elt: Callable[[Any], Any]
-    ) -> Callable[[List[Any]], List[Any]]:
+            write_elt: Callable[[Any], Any]
+        ) -> Callable[[List[Any]], List[Any]]:
     def write_list(elts: List[Any]) -> List[Any]:
         if isinstance(elts, list):
             return [write_elt(elt) for elt in elts]
@@ -176,9 +182,9 @@ def _atd_write_list(
 
 
 def _atd_write_assoc_dict_to_array(
-        write_key: Callable[[Any], Any],
-        write_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[Any, Any]], List[Tuple[Any, Any]]]:
+            write_key: Callable[[Any], Any],
+            write_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[Any, Any]], List[Tuple[Any, Any]]]:
     def write_assoc(elts: Dict[str, Any]) -> List[Tuple[str, Any]]:
         if isinstance(elts, dict):
             return [(write_key(k), write_value(v)) for k, v in elts.items()]
@@ -189,11 +195,12 @@ def _atd_write_assoc_dict_to_array(
 
 
 def _atd_write_assoc_dict_to_object(
-        write_value: Callable[[Any], Any]
-    ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+            write_value: Callable[[Any], Any]
+        ) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
     def write_assoc(elts: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(elts, dict):
-            return {_atd_write_string(k): write_value(v) for k, v in elts.items()}
+            return {_atd_write_string(k): write_value(v)
+                    for k, v in elts.items()}
         else:
             _atd_bad_python('Dict[str, <value type>]', elts)
             raise AssertionError('impossible')  # keep mypy happy
@@ -201,11 +208,12 @@ def _atd_write_assoc_dict_to_object(
 
 
 def _atd_write_assoc_list_to_object(
-        write_value: Callable[[Any], Any],
-    ) -> Callable[[List[Any]], Dict[str, Any]]:
+            write_value: Callable[[Any], Any],
+        ) -> Callable[[List[Any]], Dict[str, Any]]:
     def write_assoc(elts: List[List[Any]]) -> Dict[str, Any]:
         if isinstance(elts, list):
-            return {_atd_write_string(elt[0]): write_value(elt[1]) for elt in elts}
+            return {_atd_write_string(elt[0]): write_value(elt[1])
+                    for elt in elts}
         else:
             _atd_bad_python('List[Tuple[<key type>, <value type>]]', elts)
             raise AssertionError('impossible')  # keep mypy happy

--- a/atdpy/test/python-tests/dune
+++ b/atdpy/test/python-tests/dune
@@ -24,5 +24,6 @@
   (glob_files *.py))
  (action
   (progn
+   (run python3 -m flake8 .)
    (run python3 -m mypy --strict .)
    (run python3 -m pytest .))))

--- a/atdpy/test/python-tests/manual_sample.py
+++ b/atdpy/test/python-tests/manual_sample.py
@@ -2,6 +2,9 @@
 Handwritten code that serves as a model for generated code.
 """
 
+# Disable flake8 entirely on this file:
+# flake8: noqa
+
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple
 

--- a/atdpy/test/python-tests/manual_sample.py
+++ b/atdpy/test/python-tests/manual_sample.py
@@ -84,7 +84,7 @@ def _atd_read_assoc_object_into_dict(
             return {_atd_read_string(k): read_value(v) for k, v in elts.items()}
         else:
             _atd_bad_json('object', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -96,7 +96,7 @@ def _atd_read_assoc_object_into_list(
             return [(_atd_read_string(k), read_value(v)) for k, v in elts.items()]
         else:
             _atd_bad_json('object', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -109,7 +109,7 @@ def _atd_read_assoc_array_into_dict(
             return {read_key(elt[0]): read_value(elt[1]) for elt in elts}
         else:
             _atd_bad_json('array', elts)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
     return read_assoc
 
 
@@ -194,7 +194,7 @@ class Root:
             )
         else:
             _atd_bad_json('Root', x)
-            assert False  # keep mypy happy
+            raise AssertionError('impossible')  # keep mypy happy
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}

--- a/atdpy/test/python-tests/test_atdpy.py
+++ b/atdpy/test/python-tests/test_atdpy.py
@@ -19,6 +19,7 @@ def test_sample() -> None:
     assert b_str == b_str2  # depends on json formatting (whitespace...)
     assert b_str2 == a_str
 
+
 def test_sample_missing_field() -> None:
     try:
         manual_sample.Root.from_json_string('{}')
@@ -172,7 +173,10 @@ def test_pair() -> None:
         assert False
     except ValueError as exn:
         print(f"Exception: {exn}")
-        assert str(exn) == "incompatible JSON value where type 'array of length 2' was expected: '[1, 2, 3]'"
+        assert str(exn) == (
+                "incompatible JSON value where type "
+                "'array of length 2' was expected: '[1, 2, 3]'"
+            )
 
 
 # print updated json


### PR DESCRIPTION
A special comment is now inserted in the generated python files to disable the flake8 linter. We now run flake8 on our test files to check that everything's fine. It needs to be installed like other tools pytest and mypy.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
