### PR TITLE
release 2.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Next release
 ------------
 
+* ...
+
+2.3.0 (2022-03-10)
+------------------
+
 * Allow single-quoted strings as an alternative to double-quoted
   strings in ATD files (#239)
 
@@ -15,6 +20,8 @@ Next release
 
 * atdgen: Add support for ppx attributes on individual type
   definitions (#238)
+
+* other enhancement and fixes (see git log)
 
 2.2.0 (2020-09-03)
 ------------------


### PR DESCRIPTION
I think this is ready for release. I still don't understand how topkg is supposed to work. `topkg distrib` fails, telling me it wants a `pkg/pkg.ml`. Also, there's no git tag for the previous release 2.2.1 or no trace of in `CHANGES.md` which is weird. I don't know if you remember what you did @rgrinberg for that release, which was [two years ago](https://github.com/ahrefs/atd/releases/tag/2.2.1).

I remember that one of the motivations for using topkg was that the github-generated tarball might change, which is bad for package managers that expect a particular checksum for the tarball. So I'll try to find a way to upload a tarball as an asset and use that URL in opam-repository.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
