### PR TITLE
add Ahrefs people to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 #   help us get more users, weigh in on design decisions.
 
 # Fallback reviewers
-* @mjambon @rgrinberg
+* @mjambon @rgrinberg @Khady @zindel @cyberhuman
 
 # ATD language
 /atd/ @mjambon
@@ -36,5 +36,8 @@ bucklescript/ @rgrinberg
 # Scala support
 /atds/ @aij
 
+# Python support
+/atdpy/ @mjambon
+
 # Use of the dune build system
-dune* @rgrinberg
+dune* @rgrinberg @Khady


### PR DESCRIPTION
Automatically assign people from Ahrefs as reviewers to help to speed up the reviews.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
