### PR TITLE
Add missing entries to the validation schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Next
+----
+
+* Prevent incorrect validation errors for annotations of the form
+  `<ocaml field_prefix=...>` and a few others.
+
 2.3.2 (2022-03-11)
 ------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Next
 ----
 
 * Prevent incorrect validation errors for annotations of the form
-  `<ocaml field_prefix=...>` and a few others.
+  `<ocaml field_prefix=...>` and a few others (#258)
 
 2.3.2 (2022-03-11)
 ------------------

--- a/atdgen/src/biniou.ml
+++ b/atdgen/src/biniou.ml
@@ -34,15 +34,25 @@ type biniou_repr =
 
 (*
    This must hold all the valid annotations of the form
-   '<biniou ...>'.
+   '<biniou ...>' and '<ocaml_biniou>'.
 *)
-let annot_schema_biniou : Atd.Annot.schema_section =
+let annot_schema_biniou : Atd.Annot.schema = [
   {
     section = "biniou";
     fields = [
       Type_expr, "repr";
     ]
-  }
+  };
+  {
+    section = "ocaml_biniou";
+    fields = [
+      Type_def, "from";
+      Type_def, "module";
+      Type_def, "predef";
+      Type_def, "t";
+    ]
+  };
+]
 
 let biniou_int_of_string s : biniou_int option =
   match s with

--- a/atdgen/src/biniou.mli
+++ b/atdgen/src/biniou.mli
@@ -31,7 +31,7 @@ type biniou_repr =
   | Variant
   | Def
 
-val annot_schema_biniou : Atd.Annot.schema_section
+val annot_schema_biniou : Atd.Annot.schema
 
 val get_biniou_float : Atd.Annot.t -> biniou_float
 val get_biniou_int : Atd.Annot.t -> biniou_int

--- a/atdgen/src/json.ml
+++ b/atdgen/src/json.ml
@@ -67,7 +67,7 @@ type json_repr =
    This must hold all the valid annotations of the form
    '<json ...>'.
 *)
-let annot_schema_json : Atd.Annot.schema_section =
+let annot_schema_json : Atd.Annot.schema = [
   {
     section = "json";
     fields = [
@@ -80,7 +80,18 @@ let annot_schema_json : Atd.Annot.schema_section =
       Field, "name";
       Field, "tag_field";
     ]
-  }
+  };
+  {
+    (* deprecated *)
+    section = "ocaml_json";
+    fields = [
+      Type_def, "from";
+      Type_def, "module";
+      Type_def, "predef";
+      Type_def, "t";
+    ]
+  };
+]
 
 let json_float_of_string s : [ `Float | `Int ] option =
   match s with

--- a/atdgen/src/json.mli
+++ b/atdgen/src/json.mli
@@ -58,7 +58,7 @@ type json_repr =
   | Variant of json_variant
   | Wrap
 
-val annot_schema_json : Atd.Annot.schema_section
+val annot_schema_json : Atd.Annot.schema
 
 val get_json_list : Atd.Annot.t -> json_list
 

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -148,6 +148,7 @@ let annot_schema_ocaml : Atd.Annot.schema_section =
       Type_def, "module";
       Type_def, "predef";
       Type_def, "t";
+      Type_expr, "field_prefix";
       Type_expr, "module";
       Type_expr, "repr";
       Type_expr, "t";
@@ -173,9 +174,9 @@ let annot_schema_of_target (target : target) : Atd.Annot.schema =
   let other_section =
     match target with
     | Default -> []
-    | Biniou -> [ Biniou.annot_schema_biniou ]
-    | Json -> [ Json.annot_schema_json ]
-    | Bucklescript -> [ Json.annot_schema_json ]
+    | Biniou -> Biniou.annot_schema_biniou
+    | Json -> Json.annot_schema_json
+    | Bucklescript -> Json.annot_schema_json
     | Validate -> []
   in
   ocaml_sections @ other_section

--- a/atdgen/test/test.atd
+++ b/atdgen/test/test.atd
@@ -210,3 +210,8 @@ type validate_me =
         <ocaml valid="fun l -> true">
 
 type validated_string_check = string <ocaml valid="fun s -> s = \"abc\"">
+
+type test_field_prefix = {
+  hello: bool;
+  world: int;
+} <ocaml field_prefix="theprefix_">

--- a/atdgen/test/test.expected.ml
+++ b/atdgen/test/test.expected.ml
@@ -64,6 +64,11 @@ type test = {
 
 type tup = (int * test)
 
+type test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = int
 
 type 'a generic = { x294623: int }
@@ -2922,6 +2927,95 @@ let read_tup = (
 )
 let tup_of_string ?pos s =
   read_tup (Bi_inbuf.from_string ?pos s)
+let test_field_prefix_tag = Bi_io.record_tag
+let write_untagged_test_field_prefix : Bi_outbuf.t -> test_field_prefix -> unit = (
+  fun ob x ->
+    Bi_vint.write_uvint ob 2;
+    Bi_outbuf.add_char4 ob '\164' '\193' '3' '\018';
+    (
+      Bi_io.write_bool
+    ) ob x.theprefix_hello;
+    Bi_outbuf.add_char4 ob '\206' 'd' '\150' 'R';
+    (
+      Bi_io.write_svint
+    ) ob x.theprefix_world;
+)
+let write_test_field_prefix ob x =
+  Bi_io.write_tag ob Bi_io.record_tag;
+  write_untagged_test_field_prefix ob x
+let string_of_test_field_prefix ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_test_field_prefix ob x;
+  Bi_outbuf.contents ob
+let get_test_field_prefix_reader = (
+  fun tag ->
+    if tag <> 21 then Atdgen_runtime.Ob_run.read_error () else
+      fun ib ->
+        let field_theprefix_hello = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+        let field_theprefix_world = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+        let bits0 = ref 0 in
+        let len = Bi_vint.read_uvint ib in
+        for i = 1 to len do
+          match Bi_io.read_field_hashtag ib with
+            | 616641298 ->
+              field_theprefix_hello := (
+                (
+                  Atdgen_runtime.Ob_run.read_bool
+                ) ib
+              );
+              bits0 := !bits0 lor 0x1;
+            | -832268718 ->
+              field_theprefix_world := (
+                (
+                  Atdgen_runtime.Ob_run.read_int
+                ) ib
+              );
+              bits0 := !bits0 lor 0x2;
+            | _ -> Bi_io.skip ib
+        done;
+        if !bits0 <> 0x3 then Atdgen_runtime.Ob_run.missing_fields [| !bits0 |] [| "hello"; "world" |];
+        (
+          {
+            theprefix_hello = !field_theprefix_hello;
+            theprefix_world = !field_theprefix_world;
+          }
+         : test_field_prefix)
+)
+let read_test_field_prefix = (
+  fun ib ->
+    if Bi_io.read_tag ib <> 21 then Atdgen_runtime.Ob_run.read_error_at ib;
+    let field_theprefix_hello = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let field_theprefix_world = ref (Obj.magic (Sys.opaque_identity 0.0)) in
+    let bits0 = ref 0 in
+    let len = Bi_vint.read_uvint ib in
+    for i = 1 to len do
+      match Bi_io.read_field_hashtag ib with
+        | 616641298 ->
+          field_theprefix_hello := (
+            (
+              Atdgen_runtime.Ob_run.read_bool
+            ) ib
+          );
+          bits0 := !bits0 lor 0x1;
+        | -832268718 ->
+          field_theprefix_world := (
+            (
+              Atdgen_runtime.Ob_run.read_int
+            ) ib
+          );
+          bits0 := !bits0 lor 0x2;
+        | _ -> Bi_io.skip ib
+    done;
+    if !bits0 <> 0x3 then Atdgen_runtime.Ob_run.missing_fields [| !bits0 |] [| "hello"; "world" |];
+    (
+      {
+        theprefix_hello = !field_theprefix_hello;
+        theprefix_world = !field_theprefix_world;
+      }
+     : test_field_prefix)
+)
+let test_field_prefix_of_string ?pos s =
+  read_test_field_prefix (Bi_inbuf.from_string ?pos s)
 let star_rating_tag = Bi_io.svint_tag
 let write_untagged_star_rating = (
   Bi_io.write_untagged_svint
@@ -4722,6 +4816,14 @@ let create_test
     x2 = x2;
     x3 = x3;
     x4 = x4;
+  }
+let create_test_field_prefix 
+  ~theprefix_hello
+  ~theprefix_world
+  () : test_field_prefix =
+  {
+    theprefix_hello = theprefix_hello;
+    theprefix_world = theprefix_world;
   }
 let create_some_record 
   ~some_field

--- a/atdgen/test/test.expected.mli
+++ b/atdgen/test/test.expected.mli
@@ -64,6 +64,11 @@ type test = {
 
 type tup = (int * test)
 
+type test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = int
 
 type 'a generic = { x294623: int }
@@ -811,6 +816,49 @@ val tup_of_string :
   (** Deserialize a biniou value of type {!tup}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
+
+
+(* Writers for type test_field_prefix *)
+
+val test_field_prefix_tag : Bi_io.node_tag
+  (** Tag used by the writers for type {!test_field_prefix}.
+      Readers may support more than just this tag. *)
+
+val write_untagged_test_field_prefix :
+  Bi_outbuf.t -> test_field_prefix -> unit
+  (** Output an untagged biniou value of type {!test_field_prefix}. *)
+
+val write_test_field_prefix :
+  Bi_outbuf.t -> test_field_prefix -> unit
+  (** Output a biniou value of type {!test_field_prefix}. *)
+
+val string_of_test_field_prefix :
+  ?len:int -> test_field_prefix -> string
+  (** Serialize a value of type {!test_field_prefix} into
+      a biniou string. *)
+
+(* Readers for type test_field_prefix *)
+
+val get_test_field_prefix_reader :
+  Bi_io.node_tag -> (Bi_inbuf.t -> test_field_prefix)
+  (** Return a function that reads an untagged
+      biniou value of type {!test_field_prefix}. *)
+
+val read_test_field_prefix :
+  Bi_inbuf.t -> test_field_prefix
+  (** Input a tagged biniou value of type {!test_field_prefix}. *)
+
+val test_field_prefix_of_string :
+  ?pos:int -> string -> test_field_prefix
+  (** Deserialize a biniou value of type {!test_field_prefix}.
+      @param pos specifies the position where
+                 reading starts. Default: 0. *)
+
+val create_test_field_prefix :
+  theprefix_hello: bool ->
+  theprefix_world: int ->
+  unit -> test_field_prefix
+  (** Create a record of type {!test_field_prefix}. *)
 
 
 (* Writers for type star_rating *)

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -58,6 +58,11 @@ type test = Test.test = {
 
 type tup = Test.tup
 
+type test_field_prefix = Test.test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = Test.star_rating
 
 type 'a generic = 'a Test.generic = { x294623: int }
@@ -3030,6 +3035,177 @@ let read_tup = (
 )
 let tup_of_string s =
   read_tup (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_test_field_prefix : _ -> test_field_prefix -> _ = (
+  fun ob (x : test_field_prefix) ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"hello\":";
+    (
+      Yojson.Safe.write_bool
+    )
+      ob x.theprefix_hello;
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"world\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.theprefix_world;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_test_field_prefix ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_test_field_prefix ob x;
+  Bi_outbuf.contents ob
+let read_test_field_prefix = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_theprefix_hello = ref (None) in
+    let field_theprefix_world = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 5 then (
+            match String.unsafe_get s pos with
+              | 'h' -> (
+                  if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'o' then (
+                    0
+                  )
+                  else (
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+                  )
+                )
+              | 'w' -> (
+                  if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'd' then (
+                    1
+                  )
+                  else (
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+                  )
+                )
+              | _ -> (
+                  (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+                )
+          )
+          else (
+            (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_theprefix_hello := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_theprefix_world := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 5 then (
+              match String.unsafe_get s pos with
+                | 'h' -> (
+                    if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'o' then (
+                      0
+                    )
+                    else (
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+                    )
+                  )
+                | 'w' -> (
+                    if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'd' then (
+                      1
+                    )
+                    else (
+                      (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+                    )
+                  )
+                | _ -> (
+                    (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+                  )
+            )
+            else (
+              (fun loc s -> Printf.eprintf "Warning: skipping field %s (def: %s)
+" s loc) "File \"test.atd\", line 214, characters 25-91" (String.sub s pos len); -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_theprefix_hello := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_theprefix_world := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            theprefix_hello = (match !field_theprefix_hello with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "theprefix_hello");
+            theprefix_world = (match !field_theprefix_world with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "theprefix_world");
+          }
+         : test_field_prefix)
+      )
+)
+let test_field_prefix_of_string s =
+  read_test_field_prefix (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_star_rating = (
   Yojson.Safe.write_int
 )
@@ -4983,6 +5159,14 @@ let create_test
     x2 = x2;
     x3 = x3;
     x4 = x4;
+  }
+let create_test_field_prefix 
+  ~theprefix_hello
+  ~theprefix_world
+  () : test_field_prefix =
+  {
+    theprefix_hello = theprefix_hello;
+    theprefix_world = theprefix_world;
   }
 let create_some_record 
   ~some_field

--- a/atdgen/test/testj.expected.mli
+++ b/atdgen/test/testj.expected.mli
@@ -58,6 +58,11 @@ type test = Test.test = {
 
 type tup = Test.tup
 
+type test_field_prefix = Test.test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = Test.star_rating
 
 type 'a generic = 'a Test.generic = { x294623: int }
@@ -529,6 +534,33 @@ val read_tup :
 val tup_of_string :
   string -> tup
   (** Deserialize JSON data of type {!tup}. *)
+
+
+val write_test_field_prefix :
+  Bi_outbuf.t -> test_field_prefix -> unit
+  (** Output a JSON value of type {!test_field_prefix}. *)
+
+val string_of_test_field_prefix :
+  ?len:int -> test_field_prefix -> string
+  (** Serialize a value of type {!test_field_prefix}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_test_field_prefix :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> test_field_prefix
+  (** Input JSON data of type {!test_field_prefix}. *)
+
+val test_field_prefix_of_string :
+  string -> test_field_prefix
+  (** Deserialize JSON data of type {!test_field_prefix}. *)
+
+val create_test_field_prefix :
+  theprefix_hello: bool ->
+  theprefix_world: int ->
+  unit -> test_field_prefix
+  (** Create a record of type {!test_field_prefix}. *)
 
 
 val write_star_rating :

--- a/atdgen/test/testjstd.expected.ml
+++ b/atdgen/test/testjstd.expected.ml
@@ -58,6 +58,11 @@ type test = Test.test = {
 
 type tup = Test.tup
 
+type test_field_prefix = Test.test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = Test.star_rating
 
 type 'a generic = 'a Test.generic = { x294623: int }
@@ -2998,6 +3003,169 @@ let read_tup = (
 )
 let tup_of_string s =
   read_tup (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_test_field_prefix : _ -> test_field_prefix -> _ = (
+  fun ob (x : test_field_prefix) ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"hello\":";
+    (
+      Yojson.Safe.write_bool
+    )
+      ob x.theprefix_hello;
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"world\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.theprefix_world;
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_test_field_prefix ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_test_field_prefix ob x;
+  Bi_outbuf.contents ob
+let read_test_field_prefix = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_theprefix_hello = ref (None) in
+    let field_theprefix_world = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          if len = 5 then (
+            match String.unsafe_get s pos with
+              | 'h' -> (
+                  if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'o' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 'w' -> (
+                  if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'd' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_theprefix_hello := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_theprefix_world := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            if len = 5 then (
+              match String.unsafe_get s pos with
+                | 'h' -> (
+                    if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'o' then (
+                      0
+                    )
+                    else (
+                      -1
+                    )
+                  )
+                | 'w' -> (
+                    if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'd' then (
+                      1
+                    )
+                    else (
+                      -1
+                    )
+                  )
+                | _ -> (
+                    -1
+                  )
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_theprefix_hello := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_bool
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_theprefix_world := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            theprefix_hello = (match !field_theprefix_hello with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "theprefix_hello");
+            theprefix_world = (match !field_theprefix_world with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "theprefix_world");
+          }
+         : test_field_prefix)
+      )
+)
+let test_field_prefix_of_string s =
+  read_test_field_prefix (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_star_rating = (
   Yojson.Safe.write_int
 )
@@ -4917,6 +5085,14 @@ let create_test
     x2 = x2;
     x3 = x3;
     x4 = x4;
+  }
+let create_test_field_prefix 
+  ~theprefix_hello
+  ~theprefix_world
+  () : test_field_prefix =
+  {
+    theprefix_hello = theprefix_hello;
+    theprefix_world = theprefix_world;
   }
 let create_some_record 
   ~some_field

--- a/atdgen/test/testjstd.expected.mli
+++ b/atdgen/test/testjstd.expected.mli
@@ -58,6 +58,11 @@ type test = Test.test = {
 
 type tup = Test.tup
 
+type test_field_prefix = Test.test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = Test.star_rating
 
 type 'a generic = 'a Test.generic = { x294623: int }
@@ -529,6 +534,33 @@ val read_tup :
 val tup_of_string :
   string -> tup
   (** Deserialize JSON data of type {!tup}. *)
+
+
+val write_test_field_prefix :
+  Bi_outbuf.t -> test_field_prefix -> unit
+  (** Output a JSON value of type {!test_field_prefix}. *)
+
+val string_of_test_field_prefix :
+  ?len:int -> test_field_prefix -> string
+  (** Serialize a value of type {!test_field_prefix}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_test_field_prefix :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> test_field_prefix
+  (** Input JSON data of type {!test_field_prefix}. *)
+
+val test_field_prefix_of_string :
+  string -> test_field_prefix
+  (** Deserialize JSON data of type {!test_field_prefix}. *)
+
+val create_test_field_prefix :
+  theprefix_hello: bool ->
+  theprefix_world: int ->
+  unit -> test_field_prefix
+  (** Create a record of type {!test_field_prefix}. *)
 
 
 val write_star_rating :

--- a/atdgen/test/testv.expected.ml
+++ b/atdgen/test/testv.expected.ml
@@ -58,6 +58,11 @@ type test = Test.test = {
 
 type tup = Test.tup
 
+type test_field_prefix = Test.test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = Test.star_rating
 
 type 'a generic = 'a Test.generic = { x294623: int }
@@ -343,6 +348,9 @@ let validate_test : _ -> test -> _ = (
 let validate_tup = (
   fun _ _ -> None
 )
+let validate_test_field_prefix : _ -> test_field_prefix -> _ = (
+  fun _ _ -> None
+)
 let validate_star_rating = (
   fun path x ->
     let msg = "Failed check by fun x -> x >= 1 && x <= 5" in
@@ -573,6 +581,14 @@ let create_test
     x2 = x2;
     x3 = x3;
     x4 = x4;
+  }
+let create_test_field_prefix 
+  ~theprefix_hello
+  ~theprefix_world
+  () : test_field_prefix =
+  {
+    theprefix_hello = theprefix_hello;
+    theprefix_world = theprefix_world;
   }
 let create_some_record 
   ~some_field

--- a/atdgen/test/testv.expected.mli
+++ b/atdgen/test/testv.expected.mli
@@ -58,6 +58,11 @@ type test = Test.test = {
 
 type tup = Test.tup
 
+type test_field_prefix = Test.test_field_prefix = {
+  theprefix_hello (*atd hello *): bool;
+  theprefix_world (*atd world *): int
+}
+
 type star_rating = Test.star_rating
 
 type 'a generic = 'a Test.generic = { x294623: int }
@@ -266,6 +271,16 @@ val validate_test :
 val validate_tup :
   Atdgen_runtime.Util.Validation.path -> tup -> Atdgen_runtime.Util.Validation.error option
   (** Validate a value of type {!tup}. *)
+
+val create_test_field_prefix :
+  theprefix_hello: bool ->
+  theprefix_world: int ->
+  unit -> test_field_prefix
+  (** Create a record of type {!test_field_prefix}. *)
+
+val validate_test_field_prefix :
+  Atdgen_runtime.Util.Validation.path -> test_field_prefix -> Atdgen_runtime.Util.Validation.error option
+  (** Validate a value of type {!test_field_prefix}. *)
 
 val validate_star_rating :
   Atdgen_runtime.Util.Validation.path -> star_rating -> Atdgen_runtime.Util.Validation.error option

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -47,10 +47,7 @@ let annot_schema_python : Atd.Annot.schema_section =
   }
 
 let annot_schema : Atd.Annot.schema =
-  [
-    annot_schema_python;
-    Atdgen_emit.Json.annot_schema_json;
-  ]
+  annot_schema_python :: Atdgen_emit.Json.annot_schema_json
 
 (* Translate a preferred variable name into an available Python identifier. *)
 let trans env id =


### PR DESCRIPTION
This was causing `github.atd` to fail even though the atd annotations were valid. I'll make a bugfix release later when this is merged.

Test:
```
wget https://raw.githubusercontent.com/mirage/ocaml-github/master/lib_data/github.atd
make
dune exec -- atdgen -j github.atd
```

This should not produce errors.

We still get errors on the following projects because they have incorrect annotations which should be fixed (I'll report them properly later):
* https://github.com/cyborgize/es-cli/blob/b09ce1eb3deb5cc68b72df8fbd93e7f6fb4d52c5/src/elastic.atd#L130
* https://github.com/tmcgilchrist/ocaml-gitlab/blob/8f016af1d6be82553cc1a692cd53fc799b834390/lib/gitlab.atd#L605
(these are reverse dependencies in opam-repository which failed to build with the latest atd)

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
