### PR TITLE
Update dune-project with dependency constraints

### DIFF
--- a/atd.opam
+++ b/atd.opam
@@ -33,7 +33,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8" & >= "2.8"}
-  "menhir"
+  "menhir" {>= "20180523"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/atd.opam
+++ b/atd.opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8" & >= "2.8"}
   "menhir"
   "easy-format"
   "alcotest" {with-test}

--- a/atdgen-codec-runtime.opam
+++ b/atdgen-codec-runtime.opam
@@ -29,7 +29,7 @@ license: "MIT"
 homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]

--- a/atdgen-runtime.opam
+++ b/atdgen-runtime.opam
@@ -30,7 +30,7 @@ homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8" & >= "2.8"}
   "yojson" {>= "1.7.0"}
   "biniou" {>= "1.0.6"}
   "camlp-streams"

--- a/atdgen.opam
+++ b/atdgen.opam
@@ -38,7 +38,7 @@ homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8" & >= "2.8"}
   "atd"
   "atdgen-runtime" {>= "2.0.0"}
   "atdgen-codec-runtime" {with-test}

--- a/atdj.opam
+++ b/atdj.opam
@@ -43,7 +43,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8" & >= "2.8"}
-  "atd" {>= "2.0.0"}
+  "atd"
   "re"
   "odoc" {with-doc}
 ]

--- a/atdj.opam
+++ b/atdj.opam
@@ -42,7 +42,7 @@ homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8" & >= "2.8"}
   "atd" {>= "2.0.0"}
   "re"
   "odoc" {with-doc}

--- a/atdpy.opam
+++ b/atdpy.opam
@@ -31,6 +31,7 @@ depends: [
   "dune" {>= "2.8" & >= "2.8"}
   "alcotest" {with-test}
   "atd"
+  "atdgen"
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
 ]

--- a/atdpy.opam
+++ b/atdpy.opam
@@ -28,14 +28,14 @@ homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "1.11"}
+  "dune" {>= "2.8" & >= "2.8"}
   "alcotest" {with-test}
   "atd"
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/atdpy.opam
+++ b/atdpy.opam
@@ -29,10 +29,11 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8" & >= "2.8"}
-  "alcotest" {with-test}
   "atd"
   "atdgen"
   "cmdliner" {>= "1.1.0"}
+  "alcotest" {with-test}
+  "conf-python-3" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/atds.opam
+++ b/atds.opam
@@ -29,7 +29,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8" & >= "2.8"}
-  "atd" {>= "2.0.0"}
+  "atd"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/atds.opam
+++ b/atds.opam
@@ -28,7 +28,7 @@ homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8" & >= "2.8"}
   "atd" {>= "2.0.0"}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
  (depends
   (ocaml (>= 4.08))
   (dune (>= 2.8))
-  menhir
+  (menhir (>= 20180523))
   easy-format
   (alcotest :with-test)
   (odoc :with-doc)

--- a/dune-project
+++ b/dune-project
@@ -109,7 +109,7 @@ automatically handled")
  (depends
   (ocaml (>= 4.08))
   (dune (>= 2.8))
-  (atd (>= 2.0.0))
+  atd ; (atd (>= 2.3.0))
   re
   (odoc :with-doc)))
 
@@ -120,7 +120,7 @@ automatically handled")
  (depends
   (ocaml (>= 4.08))
   (dune (>= 2.8))
-  (atd (>= 2.0.0))
+  atd ; (atd (>= 2.3.0))
   (odoc :with-doc)))
 
 (package
@@ -130,10 +130,11 @@ automatically handled")
  (depends
   (ocaml (>= 4.08))
   (dune (>= 2.8))
-  (alcotest :with-test)
   atd ; (atd (>= 2.3.0))
   atdgen ; (atdgen (>= 2.3.0))
   (cmdliner (>= 1.1.0))
+  (alcotest :with-test)
+  (conf-python-3 :with-test)
   (odoc :with-doc)))
 
 (package

--- a/dune-project
+++ b/dune-project
@@ -132,6 +132,7 @@ automatically handled")
   (dune (>= 2.8))
   (alcotest :with-test)
   atd ; (atd (>= 2.3.0))
+  atdgen ; (atdgen (>= 2.3.0))
   (cmdliner (>= 1.1.0))
   (odoc :with-doc)))
 

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.8)
 (using menhir 2.0)
 (implicit_transitive_deps false)
 
@@ -35,7 +35,7 @@
  (name atd)
  (depends
   (ocaml (>= 4.08))
-  (dune (>= 2.0))
+  (dune (>= 2.8))
   menhir
   easy-format
   (alcotest :with-test)
@@ -53,7 +53,7 @@ formats. "))
  (name atdgen)
  (depends
   (ocaml (>= 4.08))
-  (dune (>= 2.0))
+  (dune (>= 2.8))
   atd ; (atd (>= 2.3.0))
   (atdgen-runtime (>= 2.0.0))
   (atdgen-codec-runtime :with-test)
@@ -82,7 +82,7 @@ This package should be used only in conjunction with the stdgen code
 generator")
  (depends
   (ocaml (>= 4.08))
-  (dune (>= 2.0))
+  (dune (>= 2.8))
   (yojson (>= 1.7.0))
   (biniou (>= 1.0.6))
   camlp-streams
@@ -108,7 +108,7 @@ specification.
 automatically handled")
  (depends
   (ocaml (>= 4.08))
-  (dune (>= 2.0))
+  (dune (>= 2.8))
   (atd (>= 2.0.0))
   re
   (odoc :with-doc)))
@@ -119,7 +119,7 @@ automatically handled")
  (description "ATD Code generator for Scala")
  (depends
   (ocaml (>= 4.08))
-  (dune (>= 2.0))
+  (dune (>= 2.8))
   (atd (>= 2.0.0))
   (odoc :with-doc)))
 
@@ -129,7 +129,7 @@ automatically handled")
  (description "Python/mypy code generation for ATD APIs")
  (depends
   (ocaml (>= 4.08))
-  (dune (>= 1.11))
+  (dune (>= 2.8))
   (alcotest :with-test)
   atd ; (atd (>= 2.3.0))
   (cmdliner (>= 1.1.0))


### PR DESCRIPTION
The `dune-project` file is used by dune to produce the opam files. These changes bring the opam files closer to what's needed by opam-repository. See https://github.com/ocaml/opam-repository/pull/20905 to get a sense of what happened.

The next release, which I'm going to make very soon (2.3.3), is going to be much easier.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
