### PR TITLE
atdpy: add support for extra imports and class decorators

### DIFF
--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -41,6 +41,8 @@ let annot_schema_python : Atd.Annot.schema_section =
   {
     section = "python";
     fields = [
+      Module_head, "text";
+      Type_def, "decorator";
       Type_expr, "repr";
       Field, "default";
     ]
@@ -763,7 +765,7 @@ let inst_var_declaration
     Line (sprintf "%s: %s%s" var_name type_name default)
   ]
 
-let record env loc name (fields : field list) an =
+let record env ~class_decorators loc name (fields : field list) an =
   let py_class_name = class_name env name in
   let trans_meth = env.translate_inst_variable () in
   let fields =
@@ -843,6 +845,7 @@ let record env loc name (fields : field list) an =
     ]
   in
   [
+    Inline class_decorators;
     Line "@dataclass";
     Line (sprintf "class %s:" py_class_name);
     Block (spaced [
@@ -871,10 +874,11 @@ class Foo:
   def from_json_string(x):
     ...
 *)
-let alias_wrapper env name type_expr =
+let alias_wrapper env ~class_decorators name type_expr =
   let py_class_name = class_name env name in
   let value_type = type_name_of_expr env type_expr in
   [
+    Inline class_decorators;
     Line "@dataclass";
     Line (sprintf "class %s:" py_class_name);
     Block [
@@ -908,7 +912,8 @@ let alias_wrapper env name type_expr =
     ]
   ]
 
-let case_class env type_name (loc, orig_name, unique_name, an, opt_e) =
+let case_class env type_name
+    (loc, orig_name, unique_name, an, opt_e) =
   let json_name = Atdgen_emit.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
@@ -1016,7 +1021,7 @@ let read_cases1 env loc name cases1 =
             (class_name env name |> single_esc))
   ]
 
-let sum_container env loc name cases =
+let sum_container env ~class_decorators loc name cases =
   let py_class_name = class_name env name in
   let type_list =
     List.map (fun (loc, orig_name, unique_name, an, opt_e) ->
@@ -1051,6 +1056,7 @@ let sum_container env loc name cases =
       []
   in
   [
+    Inline class_decorators;
     Line "@dataclass";
     Line (sprintf "class %s:" py_class_name);
     Block [
@@ -1094,7 +1100,7 @@ let sum_container env loc name cases =
     ]
   ]
 
-let sum env loc name cases =
+let sum env ~class_decorators loc name cases =
   let cases =
     List.map (fun (x : variant) ->
       match x with
@@ -1108,7 +1114,7 @@ let sum env loc name cases =
     List.map (fun x -> Inline (case_class env name x)) cases
     |> double_spaced
   in
-  let container_class = sum_container env loc name cases in
+  let container_class = sum_container env ~class_decorators loc name cases in
   [
     Inline case_classes;
     Inline container_class;
@@ -1118,17 +1124,23 @@ let sum env loc name cases =
 let type_def env ((loc, (name, param, an), e) : A.type_def) : B.t =
   if param <> [] then
     not_implemented loc "parametrized type";
+  let class_decorators =
+    Python_annot.get_python_decorators an
+    |> List.map (fun s -> Line ("@" ^ s))
+  in
   let rec unwrap e =
     match e with
-    | Sum (loc, cases, an) -> sum env loc name cases
-    | Record (loc, fields, an) -> record env loc name fields an
-    | Tuple _ -> alias_wrapper env name e
-    | List _ -> alias_wrapper env name e
-    | Option _ -> alias_wrapper env name e
-    | Nullable _ -> alias_wrapper env name e
+    | Sum (loc, cases, an) ->
+        sum env ~class_decorators loc name cases
+    | Record (loc, fields, an) ->
+        record env  ~class_decorators loc name fields an
+    | Tuple _
+    | List _
+    | Option _
+    | Nullable _
+    | Name _ -> alias_wrapper env ~class_decorators name e
     | Shared _ -> not_implemented loc "cyclic references"
     | Wrap (loc, e, an) -> unwrap e
-    | Name _ -> alias_wrapper env name e
     | Tvar _ -> not_implemented loc "parametrized type"
   in
   unwrap e
@@ -1169,14 +1181,15 @@ let reserve_good_class_names env (items: A.module_body) =
     (fun (Type (loc, (name, param, an), e)) -> ignore (class_name env name))
     items
 
-let to_file ~atd_filename (items : A.module_body) dst_path =
+let to_file ~atd_filename ~head (items : A.module_body) dst_path =
   let env = init_env () in
   reserve_good_class_names env items;
+  let head = List.map (fun s -> Line s) head in
   let python_defs =
     Atd.Util.tsort items
     |> List.map (fun x -> Inline (definition_group ~atd_filename env x))
   in
-  Line (fixed_size_preamble atd_filename) :: python_defs
+  Line (fixed_size_preamble atd_filename) :: Inline head :: python_defs
   |> double_spaced
   |> Indent.to_file ~indent:4 dst_path
 
@@ -1190,9 +1203,10 @@ let run_file src_path =
     |> String.lowercase_ascii
   in
   let dst_path = dst_name in
-  let (_atd_head, atd_module), _original_types =
+  let (atd_head, atd_module), _original_types =
     Atd.Util.load_file
       ~annot_schema
       ~expand:false ~inherit_fields:true ~inherit_variants:true src_path
   in
-  to_file ~atd_filename:src_name atd_module dst_path
+  let head = Python_annot.get_python_text (snd atd_head) in
+  to_file ~atd_filename:src_name ~head atd_module dst_path

--- a/atdpy/src/lib/Python_annot.ml
+++ b/atdpy/src/lib/Python_annot.ml
@@ -26,3 +26,38 @@ let get_python_assoc_repr an : assoc_repr =
     ~sections:["python"]
     ~field:"repr"
     an
+
+(* class decorator
+
+   Later, we might want to add support for decorators on the from_json
+   and to_json methods.
+
+   These would have more specific names such as "to_json_decorator"
+   and "from_json_decorator" or just "to_json" and "from_json".
+   If we want to be consistent with atdgen adapters, we might
+   want something like this:
+
+     <json adapter.to_ocaml="Lift.normalize \"body\" [\"a\"]"
+           adapter.from_ocaml="Lift.restore \"body\" [\"a\"]"
+           adapter.to_python="normalize_whatever"
+           adapter.from_python="restore_whatever"
+      >
+
+   (which is less flexible than method decorators since method decorators
+   are left in charge of calling the origin method but the adapters
+   are simple functions from json to json)
+*)
+let get_python_decorators an : string list =
+  Atd.Annot.get_fields
+    ~parse:(fun s -> Some s)
+    ~sections:["python"]
+    ~field:"decorator"
+    an
+
+(* imports etc. *)
+let get_python_text an : string list =
+  Atd.Annot.get_fields
+    ~parse:(fun s -> Some s)
+    ~sections:["python"]
+    ~field:"text"
+    an

--- a/atdpy/src/lib/Python_annot.mli
+++ b/atdpy/src/lib/Python_annot.mli
@@ -28,3 +28,12 @@ type assoc_repr =
     The default is ["list"].
 *)
 val get_python_assoc_repr : Atd.Annot.t -> assoc_repr
+
+(** Returns the list of class decorators as specified by the user without
+    [@] e.g. [<python decorator="foo" decorator="bar(baz)">]
+    gives [["foo"; "bar(baz)"]]. *)
+val get_python_decorators : Atd.Annot.t -> string list
+
+(** Returns text the user wants to be inserted at the beginning of the
+    Python file such as imports. *)
+val get_python_text : Atd.Annot.t -> string list

--- a/atdpy/test/atd-input/everything.atd
+++ b/atdpy/test/atd-input/everything.atd
@@ -1,3 +1,6 @@
+<python text="import deco">
+<python text="from dataclasses import dataclass">
+
 type kind = [
   | Root (* class name conflict *)
   | Thing of int
@@ -26,6 +29,8 @@ type alias = int list
 
 type pair = (string * int)
 
-type require_field = {
+type require_field <python decorator="deco.deco1"
+                           decorator="deco.deco2(42)"
+                           decorator="dataclass(order=True)"> = {
   req: string;
 }

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -235,6 +235,10 @@ def _atd_write_nullable(write_elt: Callable[[Any], Any]) \
 ############################################################################
 
 
+import deco
+from dataclasses import dataclass
+
+
 @dataclass
 class Root_:
     """Original type: kind = [ ... | Root | ... ]"""
@@ -433,6 +437,9 @@ class Root:
         return json.dumps(self.to_json(), **kw)
 
 
+@deco.deco1
+@deco.deco2(42)
+@dataclass(order=True)
 @dataclass
 class RequireField:
     """Original type: require_field = { ... }"""

--- a/atdpy/test/python-tests/deco.py
+++ b/atdpy/test/python-tests/deco.py
@@ -1,0 +1,16 @@
+"""Test custom decorators.
+"""
+
+from typing import Any
+
+
+def deco1(cls: Any) -> Any:
+    print(f"Decorating class {cls.__name__} with deco1")
+    return cls
+
+
+def deco2(n: int) -> Any:
+    def decorator(cls: Any) -> Any:
+        print(f"Decorating class {cls.__name__} with deco2({n})")
+        return cls
+    return decorator

--- a/doc/atdpy.rst
+++ b/doc/atdpy.rst
@@ -342,3 +342,44 @@ Python dictionaries if the correct annotations are provided:
 * ``(foo * bar) list <python repr="dict">`` will use a Python
   dictionary of type ``Dict[Foo, Bar]`` to represent the association list.
   Using the annotation ``<python repr="list">`` is equivalent to the default.
+
+
+Additional imports
+^^^^^^^^^^^^^^^^^^
+
+At the beginning of the ATD file, placing annotations like this one
+allow inserting arbitrary Python code or comments:
+
+::
+
+   <python text="import deco">
+
+This is the recommended mechanism for inserting imports. In contrast, it
+should be used only as last resort for inserting functions or classes.
+
+
+Custom class decorators
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Extra class decorators can be specified in addition to ``@dataclass``.
+The following ATD definition will add 3 decorators:
+
+.. code-block:: ocaml
+
+   type thing <python decorator="deco.deco1"
+                      decorator="deco.deco2(42)"
+                      decorator="dataclass(order=True)"> = {
+     foo: int;
+     bar: string;
+   }
+
+The generated Python class will start like this:
+
+.. code-block:: python
+
+   @deco.deco1
+   @deco.deco2(42)
+   @dataclass(order=True)
+   @dataclass
+   class Thing:
+       ...


### PR DESCRIPTION
This will allow users to "enrich" the generated Python classes using decorators.

### PR checklist

- [ ] New code has tests to catch future regressions
- [ ] Documentation is up-to-date
- [ ] `CHANGES.md` is up-to-date
