### PR TITLE
atdpy fix: Avoid applying the `@dataclass` decorator twice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Next
 
 * atdpy: don't apply the `@dataclass` decorator twice if explicitly
   added by the user via an ATD annotation such as
-  `<python decorator="dataclass(frozen=True)">`.
+  `<python decorator="dataclass(frozen=True)">` (#267)
 
 2.4.0 (2022-03-24)
 -----------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Next
+-----------------
+
+* atdpy: don't apply the `@dataclass` decorator twice if explicitly
+  added by the user via an ATD annotation such as
+  `<python decorator="dataclass(frozen=True)">`.
+
 2.4.0 (2022-03-24)
 -----------------
 

--- a/atdpy.opam
+++ b/atdpy.opam
@@ -66,6 +66,7 @@ depends: [
   "atd" {>= "2.3.0"}
   "atdgen" {>= "2.3.0"}
   "cmdliner" {>= "1.1.0"}
+  "re"
   "alcotest" {with-test}
   "conf-python-3" {with-test}
   "odoc" {with-doc}

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -1120,7 +1120,7 @@ let sum env ~class_decorators loc name cases =
   |> double_spaced
 
 let uses_dataclass_decorator =
-  let rex = Re.Pcre.regexp "\\A[ \t\r\n]*dataclass(\\(|[ \t\r\n]|\\z)" in
+  let rex = Re.Pcre.regexp {|\A[ \t\r\n]*dataclass(\(|[ \t\r\n]|\z)|} in
   fun s -> Re.Pcre.pmatch ~rex s
 
 let get_class_decorators an =

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -847,7 +847,6 @@ let record env ~class_decorators loc name (fields : field list) an =
   in
   [
     Inline class_decorators;
-    Line "@dataclass";
     Line (sprintf "class %s:" py_class_name);
     Block (spaced [
       Line (sprintf {|"""Original type: %s = { ... }"""|} name);
@@ -880,7 +879,6 @@ let alias_wrapper env ~class_decorators name type_expr =
   let value_type = type_name_of_expr env type_expr in
   [
     Inline class_decorators;
-    Line "@dataclass";
     Line (sprintf "class %s:" py_class_name);
     Block [
       Line (sprintf {|"""Original type: %s"""|} name);
@@ -1058,7 +1056,6 @@ let sum_container env ~class_decorators loc name cases =
   in
   [
     Inline class_decorators;
-    Line "@dataclass";
     Line (sprintf "class %s:" py_class_name);
     Block [
       Line (sprintf {|"""Original type: %s = [ ... ]"""|} name);
@@ -1122,11 +1119,24 @@ let sum env ~class_decorators loc name cases =
   ]
   |> double_spaced
 
+let uses_dataclass_decorator =
+  let rex = Re.Pcre.regexp "\\A[ \t\r\n]*dataclass(\\(|[ \t\r\n]|\\z)" in
+  fun s -> Re.Pcre.pmatch ~rex s
+
+let get_class_decorators an =
+  let decorators = Python_annot.get_python_decorators an in
+  (* Avoid duplicate use of the @dataclass decorator, which doesn't work
+     if some options like frozen=True are used. *)
+  if List.exists uses_dataclass_decorator decorators then
+    decorators
+  else
+    decorators @ ["dataclass"]
+
 let type_def env ((loc, (name, param, an), e) : A.type_def) : B.t =
   if param <> [] then
     not_implemented loc "parametrized type";
   let class_decorators =
-    Python_annot.get_python_decorators an
+    get_class_decorators an
     |> List.map (fun s -> Line ("@" ^ s))
   in
   let rec unwrap e =

--- a/atdpy/src/lib/dune
+++ b/atdpy/src/lib/dune
@@ -1,6 +1,7 @@
 (library
  (name atdpy)
  (libraries
+   re
    atd
    atdgen_emit
  )

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -441,7 +441,6 @@ class Root:
 @deco.deco1
 @deco.deco2(42)
 @dataclass(order=True)
-@dataclass
 class RequireField:
     """Original type: require_field = { ... }"""
 

--- a/dune-project
+++ b/dune-project
@@ -166,6 +166,7 @@ automatically handled")
   (atd (>= 2.3.0))
   (atdgen (>= 2.3.0))
   (cmdliner (>= 1.1.0))
+  re
   (alcotest :with-test)
   (conf-python-3 :with-test)
   (odoc :with-doc)))


### PR DESCRIPTION
The generated Python class always applies the `@dataclass` decorator. However, the user may want to apply it with special options e.g. `@dataclass(frozen=True)`, which they do via an ATD annotation. This previously resulted in
```
@dataclass(frozen=True)
@dataclass
class Foo:
    ...
```
I previously thought that it was fine but it doesn't work, resulting in a runtime error indicating that the frozenness was violated. This PR ensures that `@dataclass` is only added if not explicitly added by the user.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
