### PR TITLE
Fix atd opam build template

### DIFF
--- a/atd.opam.template
+++ b/atd.opam.template
@@ -1,5 +1,5 @@
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/scripts/patch-opam-files
+++ b/scripts/patch-opam-files
@@ -11,8 +11,6 @@ sed_in_place() {
   rm -f *.sed-tmp
 }
 
-sed_in_place 's/\["dune" "subst"\] {pinned}/\["dune" "subst"\] {dev}/g' *.opam
-
 # Not sure why @runtest is inserted into some opam files and not others.
 # We remove it so as to not have opam-repository's CI run into errors
 # due to missing dependencies for the target languages (Python, Java, etc.)


### PR DESCRIPTION
The script used to patch the opam files has a sed command to replace the old `pinned` syntax with `dev`. This part is actually not generated by dune but comes for a template file that can be directly fixed instead of relying on an external script.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
