### PR TITLE
Fix 'atdpy --version'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Next release
+------------------
+
+* atdpy: make `atdpy --version` print the version of atdpy itself
+  rather than the version of the `atd` library (#270)
+
 2.4.1 (2022-03-25)
 ------------------
 

--- a/atdpy/src/bin/Atdpy_main.ml
+++ b/atdpy/src/bin/Atdpy_main.ml
@@ -12,7 +12,7 @@ type conf = {
 
 let run conf =
   if conf.version then (
-    print_endline Atd.Version.version;
+    print_endline Atdpy.Version.version;
     exit 0
   )
   else


### PR DESCRIPTION
`atdpy --version` was showing the version of the `atd` library rather than the version of `atdpy`.

### PR checklist

- ~~New code has tests to catch future regressions~~ (no; too complicated, not worth it)
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
