### PR TITLE
Remove upper bound on menhir version

### DIFF
--- a/atd.opam
+++ b/atd.opam
@@ -67,7 +67,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "menhir" {>= "20180523" & < "20211215"}
+  "menhir" {>= "20180523"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -74,7 +74,7 @@
  (name atd)
  (depends
   (ocaml (>= 4.08))
-  (menhir (and (>= 20180523) (< "20211215")))
+  (menhir (>= 20180523))
   easy-format
   (alcotest :with-test)
   (odoc :with-doc)


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/21061 and decide whether to merge based on that. Maybe we need to exclude specific versions of menhir.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
