### PR TITLE
Can't compile the atd library with menhir 20211230

### DIFF
--- a/atd.opam
+++ b/atd.opam
@@ -67,7 +67,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "menhir" {>= "20180523"}
+  "menhir" {>= "20180523" & != "20211230"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -74,7 +74,7 @@
  (name atd)
  (depends
   (ocaml (>= 4.08))
-  (menhir (>= 20180523))
+  (menhir (and (>= 20180523) (<> 20211230)))
   easy-format
   (alcotest :with-test)
   (odoc :with-doc)


### PR DESCRIPTION
due to menhir believing that `Variant (a, b)` implies `(a, b)` is a tuple. This is the error message we get:
```
File "atd/src/parser.mly", line 185, characters 15-53:
Error: This expression has type 'a * 'b * 'c
       but an expression was expected of type variant
```
The problem is gone with the subsequent version of menhir, 20220210.

An opam-repository PR should follow.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
