### PR TITLE
atdpy: fix 'nullable' and clearly disable true 'option' type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Next release
 
 * atdpy: make `atdpy --version` print the version of atdpy itself
   rather than the version of the `atd` library (#270)
+* atdpy: fix handling of `nullable` and improve error message on
+         `option` types used without optional fields
+
 
 2.4.1 (2022-03-25)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Next release
 * atdpy: make `atdpy --version` print the version of atdpy itself
   rather than the version of the `atd` library (#270)
 * atdpy: fix handling of `nullable` and improve error message on
-         `option` types used without optional fields
+         `option` types used without optional fields (#277)
 
 
 2.4.1 (2022-03-25)

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -481,6 +481,10 @@ let py_type_name env (name : string) =
   | "abstract" -> (* not supported *) "Any"
   | user_defined -> class_name env user_defined
 
+let option_is_not_implemented loc =
+  not_implemented loc "true option type (did you forget a '?' \
+                       before the field name?)"
+
 let rec type_name_of_expr env (e : type_expr) : string =
   match e with
   | Sum (loc, _, _) -> not_implemented loc "inline sum types"
@@ -505,7 +509,7 @@ let rec type_name_of_expr env (e : type_expr) : string =
              (type_name_of_expr env value)
       )
   | Option (loc, e, an) -> sprintf "Optional[%s]" (type_name_of_expr env e)
-  | Nullable (loc, e, an) -> type_name_of_expr env e
+  | Nullable (loc, e, an) -> sprintf "Optional[%s]" (type_name_of_expr env e)
   | Shared (loc, e, an) -> not_implemented loc "shared"
   | Wrap (loc, e, an) -> todo "wrap"
   | Name (loc, (loc2, name, []), an) -> py_type_name env name
@@ -521,7 +525,7 @@ let rec get_default_default
   | List _ ->
       if mutable_ok then Some "[]"
       else None
-  | Option _ -> Some "Option(None)"
+  | Option _ -> None
   | Nullable _ -> Some "None"
   | Shared (loc, e, an) -> get_default_default ~mutable_ok e
   | Wrap (loc, e, an) -> get_default_default ~mutable_ok e
@@ -599,7 +603,7 @@ let rec json_writer env e =
            sprintf "_atd_write_assoc_list_to_object(%s)"
              (json_writer env value)
       )
-  | Option (loc, e, an) -> sprintf "_atd_write_option(%s)" (json_writer env e)
+  | Option (loc, e, an) -> option_is_not_implemented loc
   | Nullable (loc, e, an) ->
       sprintf "_atd_write_nullable(%s)" (json_writer env e)
   | Shared (loc, e, an) -> not_implemented loc "shared"
@@ -679,7 +683,7 @@ let rec json_reader env (e : type_expr) =
            sprintf "_atd_read_assoc_object_into_list(%s)"
              (json_reader env value)
       )
-  | Option (loc, e, an) -> sprintf "_atd_read_option(%s)" (json_reader env e)
+  | Option (loc, e, an) -> option_is_not_implemented loc
   | Nullable (loc, e, an) ->
       sprintf "_atd_read_nullable(%s)" (json_reader env e)
   | Shared (loc, e, an) -> not_implemented loc "shared"

--- a/atdpy/test/atd-input/everything.atd
+++ b/atdpy/test/atd-input/everything.atd
@@ -24,6 +24,8 @@ type root = {
   assoc2: (string * int) list <json repr="object">;
   assoc3: (float * int) list <python repr="dict">;
   assoc4: (string * int) list <json repr="object"> <python repr="dict">;
+  nullables: int nullable list;
+  (*options: int option list;*)
 }
 
 type alias = int list

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -386,6 +386,7 @@ class Root:
     assoc2: List[Tuple[str, int]]
     assoc3: Dict[float, int]
     assoc4: Dict[str, int]
+    nullables: List[Optional[int]]
     maybe: Optional[int] = None
     answer: int = 42
 
@@ -405,6 +406,7 @@ class Root:
                 assoc2=_atd_read_assoc_object_into_list(_atd_read_int)(x['assoc2']) if 'assoc2' in x else _atd_missing_json_field('Root', 'assoc2'),
                 assoc3=_atd_read_assoc_array_into_dict(_atd_read_float, _atd_read_int)(x['assoc3']) if 'assoc3' in x else _atd_missing_json_field('Root', 'assoc3'),
                 assoc4=_atd_read_assoc_object_into_dict(_atd_read_int)(x['assoc4']) if 'assoc4' in x else _atd_missing_json_field('Root', 'assoc4'),
+                nullables=_atd_read_list(_atd_read_nullable(_atd_read_int))(x['nullables']) if 'nullables' in x else _atd_missing_json_field('Root', 'nullables'),
                 maybe=_atd_read_int(x['maybe']) if 'maybe' in x else None,
                 answer=_atd_read_int(x['answer']) if 'answer' in x else 42,
             )
@@ -425,6 +427,7 @@ class Root:
         res['assoc2'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.assoc2)
         res['assoc3'] = _atd_write_assoc_dict_to_array(_atd_write_float, _atd_write_int)(self.assoc3)
         res['assoc4'] = _atd_write_assoc_dict_to_object(_atd_write_int)(self.assoc4)
+        res['nullables'] = _atd_write_list(_atd_write_nullable(_atd_write_int))(self.nullables)
         if self.maybe is not None:
             res['maybe'] = _atd_write_int(self.maybe)
         res['answer'] = _atd_write_int(self.answer)

--- a/atdpy/test/python-tests/test_atdpy.py
+++ b/atdpy/test/python-tests/test_atdpy.py
@@ -79,6 +79,7 @@ def test_everything_to_json() -> None:
             "g": 7,
             "h": 8,
         },
+        nullables=[12, None, 34],
     )
     a_str = a_obj.to_json_string(indent=2)
     print(a_str)
@@ -152,6 +153,11 @@ def test_everything_to_json() -> None:
     "g": 7,
     "h": 8
   },
+  "nullables": [
+    12,
+    null,
+    34
+  ],
   "answer": 42
 }"""
     b_obj = e.Root.from_json_string(a_str)


### PR DESCRIPTION
* Fixes the implementation of nullables.
* Python doesn't have a standard `option` type which allows distinguishing `Some None` from `None` like in OCaml. Instead of worrying about the best implementation, I left it unimplemented for now. This is rarely useful anyway. What's more useful is to let the user know that they forgot the question mark in front of the field name as in `foo: int option`. The error message now includes a hint about writing `?foo : ...`. It could be nice to have some form of warning for the other target languages as well, but I don't know how. We wouldn't want a warning if `foo: int option` is valid in those languages and there's a tiny chance the user actually meant that.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
