### PR TITLE
Fix minimum atd version in opam files

### DIFF
--- a/atdpy.opam
+++ b/atdpy.opam
@@ -63,7 +63,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.5.0"}
   "atdgen" {>= "2.3.0"}
   "cmdliner" {>= "1.1.0"}
   "re"

--- a/atdts.opam
+++ b/atdts.opam
@@ -63,7 +63,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.5.0"}
   "atdgen" {>= "2.3.0"}
   "cmdliner" {>= "1.1.0"}
   "re"

--- a/dune-project
+++ b/dune-project
@@ -166,7 +166,7 @@ automatically handled")
  (description "Python/mypy code generation for ATD APIs")
  (depends
   (ocaml (>= 4.08))
-  (atd (>= 2.3.0))
+  (atd (>= 2.5.0))
   (atdgen (>= 2.3.0))
   (cmdliner (>= 1.1.0))
   re
@@ -190,7 +190,7 @@ bucklescript backend")
  (description "TypeScript code generation for ATD APIs")
  (depends
   (ocaml (>= 4.08))
-  (atd (>= 2.3.0))
+  (atd (>= 2.5.0))
   (atdgen (>= 2.3.0))
   (cmdliner (>= 1.1.0))
   re


### PR DESCRIPTION
Earlier, I tried to use the `version` variable (#281) but it didn't help like I thought it would. It's possible that we're going to break the backward compatibility of the `atd` library soon (if we implement #265 ), so I'm more comfortable with keeping version constraints explicit for now.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
