### PR TITLE
Add a translator from ATD to JSON Schema

### DIFF
--- a/.circleci/setup-system
+++ b/.circleci/setup-system
@@ -20,8 +20,8 @@ sudo apt-get install -y \
   python-is-python3 \
   scala
 
-# For atdpy
-pip install pytest mypy flake8
+# For JSON Schema and atdpy testing
+pip install jsonschema pytest mypy flake8
 
 ###### Sanity checks ######
 

--- a/.circleci/setup-system
+++ b/.circleci/setup-system
@@ -40,6 +40,9 @@ scalac -version
 echo 'check python3'
 python3 --version
 
+echo 'check jsonschema'
+python3 -m jsonschema --version
+
 echo 'check pytest'
 python3 -m pytest --version
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Next release
+------------------
+
+* atdcat: add option `-jsonschema` to translate from ATD to JSON
+  Schema (#284)
+
 2.5.0 (2022-04-23)
 ------------------
 

--- a/atd.opam
+++ b/atd.opam
@@ -72,6 +72,7 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
   "re" {>= "1.9.0"}
+  "yojson"
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"
 build: [

--- a/atd/src/dune
+++ b/atd/src/dune
@@ -4,4 +4,9 @@
 (library
  (name atd)
  (public_name atd)
- (libraries easy-format unix))
+ (libraries
+   easy-format
+   unix
+   yojson
+ )
+)

--- a/atd/src/json.ml
+++ b/atd/src/json.ml
@@ -67,7 +67,7 @@ type json_repr =
    This must hold all the valid annotations of the form
    '<json ...>'.
 *)
-let annot_schema_json : Atd.Annot.schema = [
+let annot_schema_json : Annot.schema = [
   {
     section = "json";
     fields = [
@@ -104,7 +104,7 @@ let json_precision_of_string s =
   with _ -> None
 
 let get_json_precision an =
-  Atd.Annot.get_opt_field
+  Annot.get_opt_field
     ~parse:json_precision_of_string
     ~sections:["json"]
     ~field:"precision"
@@ -112,7 +112,7 @@ let get_json_precision an =
 
 let get_json_float an : json_float =
   match
-    Atd.Annot.get_field
+    Annot.get_field
       ~parse:json_float_of_string
       ~default:`Float
       ~sections:["json"]
@@ -135,14 +135,14 @@ let json_list_of_string s : json_list option =
 *)
 let get_json_adapter an =
   let ocaml_adapter =
-    Atd.Annot.get_opt_field
+    Annot.get_opt_field
       ~parse:(fun s -> Some s)
       ~sections:["json"]
       ~field:"adapter.ocaml"
       an
   in
   let java_adapter =
-    Atd.Annot.get_opt_field
+    Annot.get_opt_field
       ~parse:(fun s -> Some s)
       ~sections:["json"]
       ~field:"adapter.java"
@@ -152,10 +152,10 @@ let get_json_adapter an =
     java_adapter }
 
 let get_json_open_enum an =
-  Atd.Annot.get_flag ~sections:["json"] ~field:"open_enum" an
+  Annot.get_flag ~sections:["json"] ~field:"open_enum" an
 
 let get_json_lowercase_tags an =
-  Atd.Annot.get_flag ~sections:["json"] ~field:"lowercase_tags" an
+  Annot.get_flag ~sections:["json"] ~field:"lowercase_tags" an
 
 let get_json_sum an = {
   json_sum_adapter = get_json_adapter an;
@@ -164,7 +164,7 @@ let get_json_sum an = {
 }
 
 let get_json_list an =
-  Atd.Annot.get_field
+  Annot.get_field
     ~parse:json_list_of_string
     ~default:Array
     ~sections:["json"]
@@ -172,7 +172,7 @@ let get_json_list an =
     an
 
 let get_json_cons default an =
-  Atd.Annot.get_field
+  Annot.get_field
     ~parse:(fun s -> Some s)
     ~default
     ~sections:["json"]
@@ -180,7 +180,7 @@ let get_json_cons default an =
     an
 
 let get_json_fname default an =
-  Atd.Annot.get_field
+  Annot.get_field
     ~parse:(fun s -> Some s)
     ~default
     ~sections:["json"]
@@ -188,7 +188,7 @@ let get_json_fname default an =
     an
 
 let get_json_keep_nulls an =
-  Atd.Annot.get_flag
+  Annot.get_flag
     ~sections:["json"]
     ~field:"keep_nulls"
     an
@@ -199,5 +199,3 @@ let get_json_record an =
     json_record_adapter = get_json_adapter an;
   }
 
-let tests = [
-]

--- a/atd/src/json.mli
+++ b/atd/src/json.mli
@@ -58,18 +58,16 @@ type json_repr =
   | Variant of json_variant
   | Wrap
 
-val annot_schema_json : Atd.Annot.schema
+val annot_schema_json : Annot.schema
 
-val get_json_list : Atd.Annot.t -> json_list
+val get_json_list : Annot.t -> json_list
 
-val get_json_float : Atd.Annot.t -> json_float
+val get_json_float : Annot.t -> json_float
 
-val get_json_cons : string -> Atd.Annot.t -> string
+val get_json_cons : string -> Annot.t -> string
 
-val get_json_fname : string -> Atd.Annot.t -> string
+val get_json_fname : string -> Annot.t -> string
 
-val get_json_record : Atd.Annot.t -> json_record
+val get_json_record : Annot.t -> json_record
 
-val get_json_sum : Atd.Annot.t -> json_sum
-
-val tests : (string * (unit -> bool)) list
+val get_json_sum : Annot.t -> json_sum

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -207,8 +207,15 @@ let rec type_expr_to_assoc ?(is_nullable = false) (x : type_expr)
       [
         make_type_property ~is_nullable "array";
         "minItems", `Int (List.length xs);
-        "additionalItems", `Bool false;
-        "items", `List (List.map type_expr_to_json xs);
+
+        (* "items" used to be called "additionalItems",
+           "prefixItems" used to be called "items"
+
+           according to
+           https://json-schema.org/understanding-json-schema/reference/array.html
+        *)
+        "items", `Bool false;
+        "prefixItems", `List (List.map type_expr_to_json xs);
       ]
   | Object x ->
       let properties =

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -1,0 +1,234 @@
+(*
+   Translate ATD to JSON Schema (JSS)
+
+   https://json-schema.org/draft/2020-12/json-schema-core.html
+*)
+
+open Printf
+open Ast
+
+type json = Yojson.Safe.t
+
+type type_expr =
+  | Ref of string
+  | Null
+  | Boolean
+  | Integer
+  | Number
+  | String
+  | Array of type_expr
+  | Tuple of type_expr list (* a variation on 'array' *)
+  | Object of object_
+  | Union of type_expr list
+  | Nullable of type_expr
+  | Const of json
+
+and object_ = {
+  properties: property list;
+  required: string list; (* list of the properties that are required *)
+}
+
+and property = string * type_expr
+
+type def = {
+  id: string;
+  description: string option;
+  type_expr: type_expr;
+}
+
+(* The root of a JSON Schema *)
+type t = {
+  root_id: string;
+  root_description: string;
+  schema: string;
+  defs: def list;
+}
+
+let make_id root_id_uri type_name =
+  root_id_uri ^ "/" ^ type_name
+
+let trans_type_expr ~root_id_uri (x : Ast.type_expr) : type_expr =
+  let rec trans_type_expr (x : Ast.type_expr) : type_expr =
+    match x with
+    | Sum (loc, vl, an) ->
+        Union (List.map (fun x ->
+          match (x : variant) with
+          | Variant (loc, (name, an), opt_e) ->
+              let json_name = Json.get_json_cons name an in
+              (match opt_e with
+               | None -> Const (`String json_name)
+               | Some e ->
+                   Tuple [
+                     Const (`String json_name);
+                     trans_type_expr e;
+                   ]
+              )
+          | Inherit _ -> assert false
+        ) vl)
+    | Record (loc, fl, an) ->
+        let fields =
+          List.map (fun (x : field) ->
+            match x with
+            | `Field ((loc, (name, kind, an), e) : simple_field) ->
+                let json_name = Json.get_json_fname name an in
+                let required =
+                  match kind with
+                  | Required -> Some json_name
+                  | Optional
+                  | With_default -> None
+                in
+                let unwrapped_e =
+                  match kind, e with
+                  | Optional, Option (loc, e, an) -> e
+                  | _, e -> e
+                in
+                ((json_name, trans_type_expr unwrapped_e), required)
+            | `Inherit _ -> assert false
+          ) fl
+        in
+        let properties = List.map fst fields in
+        let required =
+          List.filter_map (fun (_, required) -> required) fields
+        in
+        Object { properties; required }
+    | Tuple (loc, tl, an) ->
+        Tuple (List.map (fun (loc, e, an) -> trans_type_expr e) tl)
+    | List (loc, e, an) ->
+        (* TODO: handle <json repr="object"> *)
+        Array (trans_type_expr e)
+    | Option (loc, e, an) ->
+        (* usually not what the user intended *)
+        let transpiled = Sum (loc, [
+          Variant (loc, ("Some", []), Some e);
+          Variant (loc, ("None", []), None);
+        ], an)
+        in
+        trans_type_expr transpiled
+    | Nullable (loc, e, an) ->
+        Nullable (trans_type_expr e)
+    | Shared (loc, e, an) -> error_at loc "unsupported: shared"
+    | Wrap (loc, e, an) -> trans_type_expr e
+    | Tvar (loc, name) -> error_at loc "unsupported: parametrized types"
+    | Name (loc, (loc2, name, args), a) ->
+        (match name with
+         | "unit" -> Null
+         | "bool" -> Boolean
+         | "int" -> Integer
+         | "float" -> Number
+         | "string" -> String
+         | _ -> Ref (make_id root_id_uri name)
+        )
+  in
+  trans_type_expr x
+
+let trans_item
+    ~root_id_uri
+    (Type (loc, (name, param, an), e) : module_item) : def =
+  let id = make_id root_id_uri name in
+  if param <> [] then
+    error_at loc "unsupported: parametrized types";
+  {
+    id;
+    description = None;
+    type_expr = trans_type_expr ~root_id_uri e;
+  }
+
+let trans_full_module
+    ?(root_id_uri = "/schemas")
+    ~src_name
+    ((_head, body) : full_module) : t =
+  let defs = List.map (trans_item ~root_id_uri) body in
+  {
+    root_id = root_id_uri;
+    schema = "https://json-schema.org/draft/2020-12/schema";
+    root_description = sprintf "Translated by atdcat from %s" src_name;
+    defs;
+  }
+
+(***************************************************************************)
+(* Translation to JSON (because we don't have atdgen :-/ *)
+(***************************************************************************)
+
+let string s = `String s
+
+(* optional field *)
+let opt field_name f x =
+  match x with
+  | None -> []
+  | Some x -> ["required", f x]
+
+let make_type_property ~is_nullable name =
+  if is_nullable then
+    ("type", `List [ `String name; `String "null" ])
+  else
+    ("type", `String name)
+
+let rec type_expr_to_assoc ?(is_nullable = false) (x : type_expr)
+  : (string * json) list =
+  match x with
+  | Ref s ->
+      [ "$ref", `String s ]
+  | Null ->
+      [ make_type_property ~is_nullable:false "null" ]
+  | Boolean ->
+      [ make_type_property ~is_nullable "boolean" ]
+  | Integer ->
+      [ make_type_property ~is_nullable "integer" ]
+  | Number ->
+      [ make_type_property ~is_nullable "number" ]
+  | String ->
+      [ make_type_property ~is_nullable "string" ]
+  | Array x ->
+      [
+        make_type_property ~is_nullable "array";
+        "items", type_expr_to_json x
+      ]
+  | Tuple xs ->
+      [
+        make_type_property ~is_nullable "array";
+        "minItems", `Int (List.length xs);
+        "additionalItems", `Bool false;
+        "items", `List (List.map type_expr_to_json xs);
+      ]
+  | Object x ->
+      let properties =
+        List.map (fun (name, x) ->
+          (name, type_expr_to_json x)
+        ) x.properties
+      in
+      [
+        make_type_property ~is_nullable "object";
+        "required", `List (List.map string x.required);
+        "properties", `Assoc properties;
+      ]
+  | Union xs ->
+      [ "oneOf", `List (List.map (type_expr_to_json ~is_nullable) xs) ]
+  | Nullable x ->
+      type_expr_to_assoc ~is_nullable:true x
+  | Const json ->
+      [ "const", json ]
+
+and type_expr_to_json ?(is_nullable = false) (x : type_expr) : json =
+  `Assoc (type_expr_to_assoc ~is_nullable x)
+
+let def_to_json (x : def) : json =
+  `Assoc (List.flatten [
+    ["$id", `String x.id];
+    opt "description" string x.description;
+    type_expr_to_assoc x.type_expr;
+  ])
+
+let to_json (x : t) : json =
+  `Assoc [
+    "$id", `String x.root_id;
+    "$schema", `String x.schema;
+    "description", `String x.root_description;
+    "$defs", `List (List.map def_to_json x.defs);
+  ]
+
+let print ?(root_id_uri = "/schemas") ~src_name oc ast =
+  ast
+  |> trans_full_module ~root_id_uri ~src_name
+  |> to_json
+  |> Yojson.Safe.pretty_to_channel oc;
+  output_char oc '\n'

--- a/atd/src/jsonschema.mli
+++ b/atd/src/jsonschema.mli
@@ -1,0 +1,9 @@
+(**
+   Translate an ATD file to JSON Schema, honoring the <json ...> annotations.
+*)
+
+(** Translate an ATD AST to a JSON Schema. *)
+val print :
+  ?root_id_uri:string ->
+  src_name:string ->
+  out_channel -> Ast.full_module -> unit

--- a/atd/src/jsonschema.mli
+++ b/atd/src/jsonschema.mli
@@ -4,6 +4,6 @@
 
 (** Translate an ATD AST to a JSON Schema. *)
 val print :
-  ?root_id_uri:string ->
   src_name:string ->
+  root_type:string ->
   out_channel -> Ast.full_module -> unit

--- a/atdcat/src/atdcat.ml
+++ b/atdcat/src/atdcat.ml
@@ -1,5 +1,10 @@
 open Atd.Import
 
+type out_format =
+  | Atd
+  | Ocaml of string (* output file name [why?] *)
+  | Jsonschema
+
 let html_of_doc loc s =
   let doc = Atd.Doc.parse_text loc s in
   Atd.Doc.html_of_doc doc
@@ -67,11 +72,12 @@ let parse
   let m = first_head, List.flatten bodies in
   strip strip_all strip_sections m
 
-let print ~html_doc ~out_format ~out_channel:oc ast =
+let print ~src_name ~html_doc ~out_format ~out_channel:oc ast =
   let f =
     match out_format with
-        `Atd -> print_atd ~html_doc
-      | `Ocaml name -> print_ml ~name
+    | Atd -> print_atd ~html_doc
+    | Ocaml name -> print_ml ~name
+    | Jsonschema -> Atd.Jsonschema.print ?root_id_uri:None ~src_name
   in
   f oc ast
 
@@ -86,7 +92,7 @@ let () =
   let inherit_variants = ref false in
   let strip_sections = ref [] in
   let strip_all = ref false in
-  let out_format = ref `Atd in
+  let out_format = ref Atd in
   let html_doc = ref false in
   let input_files = ref [] in
   let output_file = ref None in
@@ -123,7 +129,11 @@ let () =
     "
           expand `inherit' statements in sum types";
 
-    "-ml", Arg.String (fun s -> out_format := `Ocaml s),
+    "-jsonschema", Arg.Unit (fun () -> out_format := Jsonschema),
+    "
+          translate the ATD file to JSON Schema";
+
+    "-ml", Arg.String (fun s -> out_format := Ocaml s),
     "<name>
           output the ocaml code of the ATD abstract syntax tree";
 
@@ -157,23 +167,35 @@ let () =
   let msg = sprintf "Usage: %s FILE" Sys.argv.(0) in
   Arg.parse options (fun file -> input_files := file :: !input_files) msg;
   try
+    let inherit_fields = !inherit_fields || !out_format = Jsonschema in
+    let inherit_variants = !inherit_variants || !out_format = Jsonschema in
     let ast =
       parse
-          ~expand: !expand
-          ~keep_poly: !keep_poly
-          ~xdebug: !xdebug
-          ~inherit_fields: !inherit_fields
-          ~inherit_variants: !inherit_variants
-          ~strip_all: !strip_all
-          ~strip_sections: !strip_sections
-          !input_files
+        ~expand: !expand
+        ~keep_poly: !keep_poly
+        ~xdebug: !xdebug
+        ~inherit_fields
+        ~inherit_variants
+        ~strip_all: !strip_all
+        ~strip_sections: !strip_sections
+        !input_files
     in
     let out_channel =
       match !output_file with
       | None -> stdout
       | Some file -> open_out file
     in
-    print ~html_doc: !html_doc ~out_format: !out_format ~out_channel ast;
+    let src_name =
+      match !input_files with
+      | [] -> "<empty>"
+      | [file] -> sprintf "'%s'" (Filename.basename file)
+      | _ -> "multiple files"
+    in
+    print
+      ~src_name
+      ~html_doc: !html_doc
+      ~out_format: !out_format
+      ~out_channel ast;
     close_out out_channel
   with
       Atd.Ast.Atd_error s ->

--- a/atdcat/test/data.json
+++ b/atdcat/test/data.json
@@ -1,0 +1,13 @@
+{
+  "ID": "abc",
+  "items": [ [], [ 1, 2 ] ],
+  "extras": [ 17, 53 ],
+  "answer": 42,
+  "aliased": [ 8, 9, 10 ],
+  "point": [ 3.3, -77.22 ],
+  "kinds": [ "wow", [ "Thing", 99 ], [ "!!!", [ "a", "b" ] ], "Root" ],
+  "assoc1": [ [ 1.1, 1 ], [ 2.2, 2 ] ],
+  "assoc2": { "c": 3, "d": 4 },
+  "options": [ [ "Some", 10 ], "None", [ "Some", 88 ] ],
+  "nullables": [ 13, 71, null ]
+}

--- a/atdcat/test/dune
+++ b/atdcat/test/dune
@@ -17,3 +17,28 @@
  (alias runtest)
  (deps test2.out.atd)
  (action (diff test2.expected.atd test2.out.atd)))
+
+;;;;;;;;;;;;;;;;;;;;;; Test JSON Schema output
+
+; Translate ATD -> JSON Schema
+(rule
+ (targets schema.json)
+ (deps schema.atd)
+ (action (run %{bin:atdcat} %{deps} -o %{targets} -jsonschema root)))
+
+(rule
+ (alias runtest)
+ (deps
+   schema.json
+   data.json
+ )
+ (action
+   (progn
+     ; Check JSON Schema output
+     (diff schema.expected.json schema.json)
+
+     ; Check that the JSON Schema is valid and compatible with some JSON data
+     (run jsonschema schema.json -i data.json)
+   )
+ )
+)

--- a/atdcat/test/dune
+++ b/atdcat/test/dune
@@ -38,7 +38,7 @@
      (diff schema.expected.json schema.json)
 
      ; Check that the JSON Schema is valid and compatible with some JSON data
-     (run jsonschema schema.json -i data.json)
+     (run python3 -m jsonschema schema.json -i data.json)
    )
  )
 )

--- a/atdcat/test/schema.atd
+++ b/atdcat/test/schema.atd
@@ -1,0 +1,27 @@
+(* Input ATD file for testing the translation to JSON Schema *)
+
+type different_kinds_of_things = [
+  | Root
+  | Thing of int
+  | WOW <json name="wow">
+  | Amaze <json name="!!!"> of string list
+]
+
+type root = {
+  id <json name="ID">: string;
+  items: int list list;
+  ?maybe: int option;
+  ~extras: int list;
+  ~answer: int;
+  aliased: alias;
+  point: (float * float);
+  kinds: different_kinds_of_things list;
+  assoc1: (float * int) list;
+  assoc2: (string * int) list <json repr="object">;
+  ~options: int option list;
+  ~nullables: int nullable list;
+}
+
+type alias = int list
+
+type pair = (string * int)

--- a/atdcat/test/schema.expected.json
+++ b/atdcat/test/schema.expected.json
@@ -35,13 +35,8 @@
       }
     },
     "assoc2": {
-      "type": "array",
-      "items": {
-        "type": "array",
-        "minItems": 2,
-        "additionalItems": false,
-        "items": [ { "type": "string" }, { "type": "integer" } ]
-      }
+      "type": "object",
+      "additionalProperties": { "type": "integer" }
     },
     "options": {
       "type": "array",

--- a/atdcat/test/schema.expected.json
+++ b/atdcat/test/schema.expected.json
@@ -18,8 +18,8 @@
     "point": {
       "type": "array",
       "minItems": 2,
-      "additionalItems": false,
-      "items": [ { "type": "number" }, { "type": "number" } ]
+      "items": false,
+      "prefixItems": [ { "type": "number" }, { "type": "number" } ]
     },
     "kinds": {
       "type": "array",
@@ -30,8 +30,8 @@
       "items": {
         "type": "array",
         "minItems": 2,
-        "additionalItems": false,
-        "items": [ { "type": "number" }, { "type": "integer" } ]
+        "items": false,
+        "prefixItems": [ { "type": "number" }, { "type": "integer" } ]
       }
     },
     "assoc2": {
@@ -45,8 +45,8 @@
           {
             "type": "array",
             "minItems": 2,
-            "additionalItems": false,
-            "items": [ { "const": "Some" }, { "type": "integer" } ]
+            "items": false,
+            "prefixItems": [ { "const": "Some" }, { "type": "integer" } ]
           },
           { "const": "None" }
         ]
@@ -64,15 +64,15 @@
         {
           "type": "array",
           "minItems": 2,
-          "additionalItems": false,
-          "items": [ { "const": "Thing" }, { "type": "integer" } ]
+          "items": false,
+          "prefixItems": [ { "const": "Thing" }, { "type": "integer" } ]
         },
         { "const": "wow" },
         {
           "type": "array",
           "minItems": 2,
-          "additionalItems": false,
-          "items": [
+          "items": false,
+          "prefixItems": [
             { "const": "!!!" },
             { "type": "array", "items": { "type": "string" } }
           ]
@@ -83,8 +83,8 @@
     "pair": {
       "type": "array",
       "minItems": 2,
-      "additionalItems": false,
-      "items": [ { "type": "string" }, { "type": "integer" } ]
+      "items": false,
+      "prefixItems": [ { "type": "string" }, { "type": "integer" } ]
     }
   }
 }

--- a/atdcat/test/schema.expected.json
+++ b/atdcat/test/schema.expected.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Translated by atdcat from 'schema.atd'",
+  "type": "object",
+  "required": [
+    "ID", "items", "aliased", "point", "kinds", "assoc1", "assoc2"
+  ],
+  "properties": {
+    "ID": { "type": "string" },
+    "items": {
+      "type": "array",
+      "items": { "type": "array", "items": { "type": "integer" } }
+    },
+    "maybe": { "type": "integer" },
+    "extras": { "type": "array", "items": { "type": "integer" } },
+    "answer": { "type": "integer" },
+    "aliased": { "$ref": "#/definitions/alias" },
+    "point": {
+      "type": "array",
+      "minItems": 2,
+      "additionalItems": false,
+      "items": [ { "type": "number" }, { "type": "number" } ]
+    },
+    "kinds": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/different_kinds_of_things" }
+    },
+    "assoc1": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "minItems": 2,
+        "additionalItems": false,
+        "items": [ { "type": "number" }, { "type": "integer" } ]
+      }
+    },
+    "assoc2": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "minItems": 2,
+        "additionalItems": false,
+        "items": [ { "type": "string" }, { "type": "integer" } ]
+      }
+    },
+    "options": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "array",
+            "minItems": 2,
+            "additionalItems": false,
+            "items": [ { "const": "Some" }, { "type": "integer" } ]
+          },
+          { "const": "None" }
+        ]
+      }
+    },
+    "nullables": {
+      "type": "array",
+      "items": { "type": [ "integer", "null" ] }
+    }
+  },
+  "definitions": {
+    "different_kinds_of_things": {
+      "oneOf": [
+        { "const": "Root" },
+        {
+          "type": "array",
+          "minItems": 2,
+          "additionalItems": false,
+          "items": [ { "const": "Thing" }, { "type": "integer" } ]
+        },
+        { "const": "wow" },
+        {
+          "type": "array",
+          "minItems": 2,
+          "additionalItems": false,
+          "items": [
+            { "const": "!!!" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        }
+      ]
+    },
+    "alias": { "type": "array", "items": { "type": "integer" } },
+    "pair": {
+      "type": "array",
+      "minItems": 2,
+      "additionalItems": false,
+      "items": [ { "type": "string" }, { "type": "integer" } ]
+    }
+  }
+}

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -1,5 +1,6 @@
 open Atd.Import
 open Indent
+module Json = Atd.Json
 
 type param =
   { deref

--- a/atdgen/src/ocaml.ml
+++ b/atdgen/src/ocaml.ml
@@ -10,6 +10,7 @@ open Atd.Import
 open Easy_format
 open Atd.Ast
 open Mapping
+module Json = Atd.Json
 
 type pp_convs =
   | Camlp4 of string list

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -8,6 +8,7 @@ open Indent
 
 open Atd.Ast
 open Mapping
+module Json = Atd.Json
 
 let target : Ocaml.target = Json
 let annot_schema = Ocaml.annot_schema_of_target target

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -1,6 +1,7 @@
 open Atd.Import
 open Atd.Ast
 open Mapping
+module Json = Atd.Json
 
 type t = (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
 type variant_mapping = (Ocaml.Repr.t, Json.json_repr) Mapping.variant_mapping

--- a/atdgen/src/oj_mapping.mli
+++ b/atdgen/src/oj_mapping.mli
@@ -1,12 +1,13 @@
 (** OCaml-Json decorated ATD AST. *)
 
-type t = (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
-type variant_mapping = (Ocaml.Repr.t, Json.json_repr) Mapping.variant_mapping
+type t = (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.mapping
+type variant_mapping =
+  (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.variant_mapping
 
 val defs_of_atd_modules
   : ('a * Atd.Ast.module_body) list
   -> target:Ocaml.target
-  -> ('a * (Ocaml.Repr.t, Json.json_repr) Mapping.def list) list
+  -> ('a * (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.def list) list
 
 (** "A.B" -> "A.B.normalize" *)
 val json_normalizer_of_adapter_path : string -> string

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -5,6 +5,7 @@
 
 open Atd.Import
 open Mapping
+module Json = Atd.Json
 
 type 'a expr = (Ocaml.Repr.t, 'a) Mapping.mapping
 type 'a def = (Ocaml.Repr.t, 'a) Mapping.def

--- a/atdgen/src/ox_emit.mli
+++ b/atdgen/src/ox_emit.mli
@@ -85,7 +85,7 @@ val default_value
 val include_intf : (Ocaml.Repr.t, 'a) Mapping.def -> bool
 
 type field =
-  { mapping : (Ocaml.Repr.t, Json.json_repr) Mapping.field_mapping
+  { mapping : (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.field_mapping
   ; ocaml_fname : string
   ; json_fname : string
   ; ocaml_default : string option
@@ -94,16 +94,19 @@ type field =
   }
 
 val get_fields
-  : ((Ocaml.Repr.t, Json.json_repr) Mapping.mapping
+  : ((Ocaml.Repr.t, Atd.Json.json_repr) Mapping.mapping
      -> (Ocaml.Repr.t, 'a) Mapping.mapping)
-  -> (Ocaml.Repr.t, Json.json_repr) Mapping.field_mapping array
+  -> (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.field_mapping array
   -> field list
 
-val is_string : (('a, 'b) Mapping.mapping -> ('a, 'b) Mapping.mapping) -> ('a, 'b) Mapping.mapping -> bool
+val is_string :
+  (('a, 'b) Mapping.mapping -> ('a, 'b) Mapping.mapping)
+  -> ('a, 'b) Mapping.mapping
+  -> bool
 
-val get_assoc_type : ((Ocaml.Repr.t, Json.json_repr) Mapping.mapping ->
-  (Ocaml.Repr.t, Json.json_repr) Mapping.mapping) ->
+val get_assoc_type : ((Ocaml.Repr.t, Atd.Json.json_repr) Mapping.mapping ->
+  (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.mapping) ->
     Mapping.loc ->
-      (Ocaml.Repr.t, Json.json_repr) Mapping.mapping ->
-        (Ocaml.Repr.t, Json.json_repr) Mapping.mapping *
-          (Ocaml.Repr.t, Json.json_repr) Mapping.mapping
+      (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.mapping ->
+        (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.mapping *
+          (Ocaml.Repr.t, Atd.Json.json_repr) Mapping.mapping

--- a/atdpy.opam
+++ b/atdpy.opam
@@ -63,8 +63,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.5.0"}
-  "atdgen" {>= "2.3.0"}
+  "atd" {>= "2.6.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -50,7 +50,7 @@ let annot_schema_python : Atd.Annot.schema_section =
   }
 
 let annot_schema : Atd.Annot.schema =
-  annot_schema_python :: Atdgen_emit.Json.annot_schema_json
+  annot_schema_python :: Atd.Json.annot_schema_json
 
 (* Translate a preferred variable name into an available Python identifier. *)
 let trans env id =
@@ -454,7 +454,7 @@ type assoc_kind =
   | Object_list of type_expr (* value type *)
 
 let assoc_kind loc (e : type_expr) an : assoc_kind =
-  let json_repr = Atdgen_emit.Json.get_json_list an in
+  let json_repr = Atd.Json.get_json_list an in
   let python_repr = Python_annot.get_python_assoc_repr an in
   match e, json_repr, python_repr with
   | Tuple (loc, [(_, key, _); (_, value, _)], an2), Array, Dict ->
@@ -641,7 +641,7 @@ let construct_json_field env trans_meth
   let assignment =
     [
       Line (sprintf "res['%s'] = %s(self.%s)"
-              (Atdgen_emit.Json.get_json_fname name an |> single_esc)
+              (Atd.Json.get_json_fname name an |> single_esc)
               writer_function
               (inst_var_name trans_meth name))
     ]
@@ -717,7 +717,7 @@ and tuple_reader env cells =
 let from_json_class_argument
     env trans_meth py_class_name ((loc, (name, kind, an), e) : simple_field) =
   let python_name = inst_var_name trans_meth name in
-  let json_name = Atdgen_emit.Json.get_json_fname name an in
+  let json_name = Atd.Json.get_json_fname name an in
   let unwrapped_type =
     match kind with
     | Required
@@ -917,7 +917,7 @@ let alias_wrapper env ~class_decorators name type_expr =
 
 let case_class env type_name
     (loc, orig_name, unique_name, an, opt_e) =
-  let json_name = Atdgen_emit.Json.get_json_cons orig_name an in
+  let json_name = Atd.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
       [
@@ -983,7 +983,7 @@ let read_cases0 env loc name cases0 =
   let ifs =
     cases0
     |> List.map (fun (loc, orig_name, unique_name, an, opt_e) ->
-      let json_name = Atdgen_emit.Json.get_json_cons orig_name an in
+      let json_name = Atd.Json.get_json_cons orig_name an in
       Inline [
         Line (sprintf "if x == '%s':" (single_esc json_name));
         Block [
@@ -1007,7 +1007,7 @@ let read_cases1 env loc name cases1 =
         | None -> assert false
         | Some x -> x
       in
-      let json_name = Atdgen_emit.Json.get_json_cons orig_name an in
+      let json_name = Atd.Json.get_json_cons orig_name an in
       Inline [
         Line (sprintf "if cons == '%s':" (single_esc json_name));
         Block [

--- a/atdpy/src/lib/Python_annot.ml
+++ b/atdpy/src/lib/Python_annot.ml
@@ -1,7 +1,7 @@
 (*
    ATD annotations to be interpreted specifically by atdpy.
 
-   Atdpy also honors json-related annotations defined in Atdgen_emit.Json.
+   Atdpy also honors json-related annotations defined in Atd.Json.
 *)
 
 type assoc_repr =

--- a/atdpy/src/lib/Python_annot.mli
+++ b/atdpy/src/lib/Python_annot.mli
@@ -3,7 +3,7 @@
 
    This interface serves as a reference of which Python-specific
    ATD annotations are supported. Atdpy also honors JSON-related annotations
-   defined in [Atdgen_emit.Json].
+   defined in [Atd.Json].
 *)
 
 (** Extract ["42"] from [<python default="42">].

--- a/atdpy/src/lib/dune
+++ b/atdpy/src/lib/dune
@@ -3,6 +3,5 @@
  (libraries
    re
    atd
-   atdgen_emit
  )
 )

--- a/atdts.opam
+++ b/atdts.opam
@@ -63,8 +63,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.5.0"}
-  "atdgen" {>= "2.3.0"}
+  "atd" {>= "2.6.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -29,7 +29,7 @@ let annot_schema_ts : Atd.Annot.schema_section =
   }
 
 let annot_schema : Atd.Annot.schema =
-  annot_schema_ts :: Atdgen_emit.Json.annot_schema_json
+  annot_schema_ts :: Atd.Json.annot_schema_json
 
 let not_implemented loc msg =
   A.error_at loc ("not implemented in atdts: " ^ msg)
@@ -575,7 +575,7 @@ type assoc_kind =
   | Object_array of type_expr (* value type *)
 
 let assoc_kind loc (e : type_expr) an : assoc_kind =
-  let json_repr = Atdgen_emit.Json.get_json_list an in
+  let json_repr = Atd.Json.get_json_list an in
   let ts_repr = TS_annot.get_ts_assoc_repr an in
   match e, json_repr, ts_repr with
   | Tuple (loc, [(_, key, _); (_, value, _)], an2), Array, Map ->
@@ -813,7 +813,7 @@ let string_of_case_name name =
 
 let case_type env type_name (loc, case_name, an, opt_e) =
   let comment =
-    let json_name = Atdgen_emit.Json.get_json_cons case_name an in
+    let json_name = Atd.Json.get_json_cons case_name an in
     if case_name <> json_name then
       sprintf " /* JSON: \"%s\" */" (double_esc json_name)
     else
@@ -868,7 +868,7 @@ let make_type_def env ((loc, (name, param, an), e) : A.type_def) : B.t =
   | Tvar _ -> assert false
 
 let read_case env loc orig_name an opt_e =
-  let json_name = Atdgen_emit.Json.get_json_cons orig_name an in
+  let json_name = Atd.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
       [
@@ -888,7 +888,7 @@ let read_case env loc orig_name an opt_e =
       ]
 
 let write_case env loc orig_name an opt_e =
-  let json_name = Atdgen_emit.Json.get_json_cons orig_name an in
+  let json_name = Atd.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
       [
@@ -980,7 +980,7 @@ let read_root_expr env ~ts_type_name e =
           | `Field ((loc, (name, kind, an), e) : simple_field) ->
               let ts_name = trans env name in
               let json_name_lit =
-                Atdgen_emit.Json.get_json_fname name an |> single_esc
+                Atd.Json.get_json_fname name an |> single_esc
               in
               let unwrapped_e = unwrap_field_type loc name kind e in
               (match kind with
@@ -1052,7 +1052,7 @@ let write_root_expr env ~ts_type_name e =
               let ts_name = trans env name in
               let json_name_lit =
                 sprintf "'%s'"
-                  (Atdgen_emit.Json.get_json_fname name an |> single_esc)
+                  (Atd.Json.get_json_fname name an |> single_esc)
               in
               let unwrapped_e = unwrap_field_type loc name kind e in
               (match kind with

--- a/atdts/src/lib/TS_annot.ml
+++ b/atdts/src/lib/TS_annot.ml
@@ -1,7 +1,7 @@
 (*
    ATD annotations to be interpreted specifically by atdts.
 
-   Atdts also honors json-related annotations defined in Atdgen_emit.Json.
+   Atdts also honors json-related annotations defined in Atd.Json.
 *)
 
 type assoc_repr =

--- a/atdts/src/lib/TS_annot.mli
+++ b/atdts/src/lib/TS_annot.mli
@@ -3,7 +3,7 @@
 
    This interface serves as a reference of which TypeScript-specific
    ATD annotations are supported. Atdts also honors JSON-related annotations
-   defined in [Atdgen_emit.Json].
+   defined in [Atd.Json].
 *)
 
 (** Whether an association list of ATD type [(string * foo) list]

--- a/atdts/src/lib/dune
+++ b/atdts/src/lib/dune
@@ -3,6 +3,5 @@
  (libraries
    re
    atd
-   atdgen_emit
  )
 )

--- a/doc/atd-language.rst
+++ b/doc/atd-language.rst
@@ -3,3 +3,4 @@ The ATD Language
 ****************
 
 .. include:: atd-language-reference.rst
+.. include:: atd-language-interoperability.rst

--- a/dune-project
+++ b/dune-project
@@ -82,6 +82,7 @@
   (alcotest :with-test)
   (odoc :with-doc)
   (re (>= 1.9.0))
+  yojson
  )
  (synopsis "Parser for the ATD data format description language")
  (description "\

--- a/dune-project
+++ b/dune-project
@@ -166,8 +166,7 @@ automatically handled")
  (description "Python/mypy code generation for ATD APIs")
  (depends
   (ocaml (>= 4.08))
-  (atd (>= 2.5.0))
-  (atdgen (>= 2.3.0))
+  (atd (>= 2.6.0))
   (cmdliner (>= 1.1.0))
   re
   (alcotest :with-test)
@@ -190,8 +189,7 @@ bucklescript backend")
  (description "TypeScript code generation for ATD APIs")
  (depends
   (ocaml (>= 4.08))
-  (atd (>= 2.5.0))
-  (atdgen (>= 2.3.0))
+  (atd (>= 2.6.0))
   (cmdliner (>= 1.1.0))
   re
   (alcotest :with-test)


### PR DESCRIPTION
I think this should work fine in practice.

Parametrized types aren't supported because JSON Schema doesn't support them. We could support them by monomorphizing the types. This is provided by `atdcat -x` but it comes with complications which didn't seem worth solving just yet.

Closes #284

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
