### PR TITLE
Translate <doc ...> annotations as part of the conversion ATD -> JSON Schema

### DIFF
--- a/atd/src/doc.ml
+++ b/atd/src/doc.ml
@@ -10,11 +10,126 @@ type block = Doc_types.block =
 
 type doc = block list
 
-let parse_text loc s =
-  try (Doc_lexer.parse_string s : block list)
-  with e ->
-    failwith (Printf.sprintf "%s:\nInvalid format for doc.text %S:\n%s"
-                (Ast.string_of_loc loc) s (Printexc.to_string e))
+(* Parse and print ATD's own "text" format *)
+module Text = struct
+
+  let parse loc s =
+    try (Doc_lexer.parse_string s : block list)
+    with e ->
+      failwith (Printf.sprintf "%s:\nInvalid format for doc.text %S:\n%s"
+                  (Ast.string_of_loc loc) s (Printexc.to_string e))
+
+  (*
+     Escape as little as we can get away with depending on the context:
+     - always: \ -> \\
+     - normal text mode: {{ -> \{\{
+     - code: }} -> \}\}
+     - pre: }}} -> \}\}\}
+  *)
+
+  let escape_text_re =
+    Re.Pcre.regexp {|\{\{\|\\|}
+
+  let escape_code_re =
+    Re.Pcre.regexp {|\}\}|\\|}
+
+  let escape_pre_re =
+    Re.Pcre.regexp {|\}\}\}|\\|}
+
+  let escape_text s =
+    Re.Pcre.substitute ~rex:escape_text_re ~subst:(function
+      | "{{" -> {|\{\{|}
+      | {|\|} -> {|\\|}
+      | s -> s (* bug *)
+    ) s
+
+  let escape_code s =
+    Re.Pcre.substitute ~rex:escape_code_re ~subst:(function
+      | "}}" -> {|\}\}|}
+      | {|\|} -> {|\\|}
+      | s -> s (* bug *)
+    ) s
+
+  let escape_pre s =
+    Re.Pcre.substitute ~rex:escape_pre_re ~subst:(function
+      | "}}}" -> {|\}\}\}|}
+      | {|\|} -> {|\\|}
+      | s -> s (* bug *)
+    ) s
+
+  let compact_whitespace =
+    let rex = Re.Pcre.regexp "(?: \t\r\n)+" in
+    fun s ->
+      Re.Pcre.substitute ~rex ~subst:(fun _ -> " ") s
+
+  (* - remove leading and trailing whitespace
+     - turn inner whitespace sequences into a single space *)
+  let normalize_inline s =
+    s
+    |> String.trim
+    |> compact_whitespace
+
+  let concat_nonempty sep xs =
+    xs
+    |> List.filter ((<>) "")
+    |> String.concat sep
+
+  let print_inline (x : Doc_types.inline) =
+    match x with
+    | Text s -> s |> normalize_inline |> escape_text
+    | Code s ->
+        match s |> normalize_inline |> escape_code with
+        | "" -> ""
+        | s ->
+            let first_space =
+              if s.[0] = '{' then
+                " "
+              else
+                ""
+            in
+            let last_space =
+              if s.[String.length s - 1] = '}' then
+                " "
+              else
+                ""
+            in
+            sprintf "{{%s%s%s}}"
+              first_space s last_space
+
+  let print_block (x : Doc_types.block) =
+    match x with
+    | Paragraph xs ->
+        xs
+        |> List.map print_inline
+        |> concat_nonempty " "
+    | Pre s ->
+        let content = escape_pre s in
+        match content with
+        | "" -> ""
+        | s ->
+            let first_newline =
+              if s.[0] <> '\n' then
+                "\n"
+              else
+                ""
+            in
+            let last_newline =
+              if s.[String.length s - 1] <> '\n' then
+                "\n"
+              else
+                ""
+            in
+            sprintf "{{{%s%s%s}}}"
+              first_newline s last_newline
+
+  let print_blocks blocks =
+    blocks
+    |> List.map print_block
+    |> String.concat "\n\n"
+end
+
+let parse_text = Text.parse
+let print_text = Text.print_blocks
 
 (*
    This must hold all the valid annotations of the form

--- a/atd/src/doc.ml
+++ b/atd/src/doc.ml
@@ -16,13 +16,29 @@ let parse_text loc s =
     failwith (Printf.sprintf "%s:\nInvalid format for doc.text %S:\n%s"
                 (Ast.string_of_loc loc) s (Printexc.to_string e))
 
-(* TODO: define a validation schema for the <doc ...> annotations. *)
+(*
+   This must hold all the valid annotations of the form
+   '<doc ...>'.
+*)
+let annot_schema : Annot.schema = [
+  {
+    section = "doc";
+    fields = [
+      Module_head, "text";
+      Type_def, "text";
+      Variant, "text";
+      Field, "text";
+      (* Tolerate but deprecate?
+      Type_expr, "text"; *)
+    ]
+  }
+]
+
 let get_doc loc an : doc option =
   Annot.get_opt_field
     ~parse:(fun s -> Some (parse_text loc s))
     ~sections:["doc"]
     ~field:"text" an
-
 
 (* Conversion to HTML *)
 

--- a/atd/src/doc.mli
+++ b/atd/src/doc.mli
@@ -10,10 +10,10 @@
    account by code generators that care about documentation:
 
    - after the type name on the left-hand side of a type definition
-   - after the type expression on the right-hand side of a type definition
-    (but not after any type expression)
    - after record field names
    - after variant names
+   - DEPRECATED: after the type expression on the right-hand side of a type
+     definition (but not after any type expression)
 
    Formats:
 
@@ -46,14 +46,17 @@ type block =
       within [\{\{\{ \}\}\}] and should be rendered using a fixed-width
       font preserving all space and newline characters. *)
 
-type doc = block list
 (** A document is a list of paragraph-like blocks. *)
+type doc = block list
 
-val parse_text : Ast.loc -> string -> doc
 (** Parse the contents of a doc.text annotation. *)
+val parse_text : Ast.loc -> string -> doc
 
-val get_doc : Ast.loc -> Ast.annot -> doc option
+(** This is for checking the placement of <doc ...> annotations. *)
+val annot_schema : Annot.schema
+
 (** Get and parse doc data from annotations. *)
+val get_doc : Ast.loc -> Ast.annot -> doc option
 
-val html_of_doc : doc -> string
 (** Convert parsed doc into HTML. *)
+val html_of_doc : doc -> string

--- a/atd/src/doc.mli
+++ b/atd/src/doc.mli
@@ -52,6 +52,12 @@ type doc = block list
 (** Parse the contents of a doc.text annotation. *)
 val parse_text : Ast.loc -> string -> doc
 
+(** Print documentation in ATD's "text" format.
+    This performs whitespace normalization, i.e. some non-significant
+    whitespace is removed and newlines are inserted if needed
+    to ensure that [{{{] and [}}}] are on their own line. *)
+val print_text : doc -> string
+
 (** This is for checking the placement of <doc ...> annotations. *)
 val annot_schema : Annot.schema
 

--- a/atd/src/doc_lexer.mll
+++ b/atd/src/doc_lexer.mll
@@ -1,4 +1,3 @@
-(* $Id: ag_doc_lexer.mll 48186 2010-09-09 22:24:27Z martin $ *)
 {
   open Doc_types
 

--- a/atd/src/dune
+++ b/atd/src/dune
@@ -5,6 +5,7 @@
  (name atd)
  (public_name atd)
  (libraries
+   re
    easy-format
    unix
    yojson

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -47,6 +47,11 @@ type t = {
 let make_id type_name =
   "#/definitions/" ^ type_name
 
+let _trans_description loc an =
+  match Doc.get_doc loc an with
+  | None -> None
+  | Some blocks -> Some (Doc.print_text blocks)
+
 let trans_type_expr (x : Ast.type_expr) : type_expr =
   let rec trans_type_expr (x : Ast.type_expr) : type_expr =
     match x with

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -263,6 +263,9 @@ let to_json (x : t) : json =
     @ ["definitions", `Assoc (List.map (fun x -> def_to_json x) x.defs)]
   )
 
+let annot_schema =
+  Json.annot_schema_json @ Doc.annot_schema
+
 let print ~src_name ~root_type oc ast =
   ast
   |> trans_full_module ~src_name ~root_type

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -2,6 +2,12 @@
    Translate ATD to JSON Schema (JSS)
 
    https://json-schema.org/draft/2020-12/json-schema-core.html
+
+   The translation is done in two passes:
+   1. Translation to an AST that models the constructs offered by JSON
+      Schema.
+   2. Translation of that AST to the JSON AST, which is not completely
+      straightforward.
 *)
 
 open Printf

--- a/atd/src/jsonschema.mli
+++ b/atd/src/jsonschema.mli
@@ -2,6 +2,9 @@
    Translate an ATD file to JSON Schema, honoring the <json ...> annotations.
 *)
 
+(** This is for validating the ATD file, not for JSON Schema. *)
+val annot_schema : Annot.schema
+
 (** Translate an ATD AST to a JSON Schema. *)
 val print :
   src_name:string ->

--- a/atd/test/doc.ml
+++ b/atd/test/doc.ml
@@ -1,0 +1,41 @@
+(*
+   Unit tests for Atd.Doc
+*)
+
+open Printf
+
+let normalize s =
+  s
+  |> Atd.Doc.parse_text Atd.Ast.dummy_loc
+  |> Atd.Doc.print_text
+
+let test_parser_and_printer =
+  [
+    "", "";
+    "a", "a";
+    "a b", "a b";
+    "a\nb", "a b";
+    "a  b", "a b";
+    "a \n b", "a b";
+    "a \n\n b", "a\n\nb";
+    "  a  ", "a";
+    "\n\na\n\n", "a";
+    "{{}}", "";
+    "{{a}}", "{{a}}";
+    "{{  a  b\n\nc\n }}", "{{a b c}}";
+    "{{ {a} }}", "{{ {a} }}";
+    "{{{}}}", "";
+    "{{{a}}}", "{{{\na\n}}}";
+    "{{{ }}}", "{{{\n \n}}}";
+    "{{{ {{a}} }}}", "{{{\n {{a}} \n}}}";
+    "{{{ a\n\n  b }}}", "{{{\n a\n\n  b \n}}}";
+  ]
+  |> List.map (fun (input, expected_output) ->
+    let name = sprintf "normalize %S" input in
+    name, `Quick, (fun () ->
+      let output = normalize input in
+      Alcotest.(check string) "equal" expected_output output
+    )
+  )
+
+let test = "Doc", test_parser_and_printer

--- a/atd/test/unit_tests.ml
+++ b/atd/test/unit_tests.ml
@@ -8,6 +8,7 @@ let test_suites : unit Alcotest.test list = [
     "sort", `Quick, Atd.Sort.test
   ];
   Unique_name.test;
+  Doc.test;
 ]
 
 let main () = Alcotest.run "atd" test_suites

--- a/atdcat/Makefile
+++ b/atdcat/Makefile
@@ -7,3 +7,8 @@ build:
 .PHONY: test
 test:
 	$(DUNE) runtest -f
+
+# Show the expected JSON Schema in YAML format (for visual inspection)
+.PHONY: yaml
+yaml:
+	yq e -P test/schema.expected.json

--- a/atdcat/src/atdcat.ml
+++ b/atdcat/src/atdcat.ml
@@ -51,13 +51,14 @@ let strip all sections x =
   Atd.Ast.map_all_annot filter x
 
 let parse
+    ~annot_schema
     ~expand ~keep_poly ~xdebug ~inherit_fields ~inherit_variants
     ~strip_all ~strip_sections files =
   let l =
     List.map (
       fun file ->
         fst (
-          Atd.Util.load_file ~expand ~keep_poly ~xdebug
+          Atd.Util.load_file ~annot_schema ~expand ~keep_poly ~xdebug
             ~inherit_fields ~inherit_variants file
         )
     ) files
@@ -167,15 +168,16 @@ let () =
   let msg = sprintf "Usage: %s FILE" Sys.argv.(0) in
   Arg.parse options (fun file -> input_files := file :: !input_files) msg;
   try
-    let force_inherit =
+    let force_inherit, annot_schema =
       match !out_format with
-      | Jsonschema _ -> true
-      | _ -> false
+      | Jsonschema _ -> true, Atd.Jsonschema.annot_schema
+      | _ -> false, []
     in
     let inherit_fields = !inherit_fields || force_inherit in
     let inherit_variants = !inherit_variants || force_inherit in
     let ast =
       parse
+        ~annot_schema
         ~expand: !expand
         ~keep_poly: !keep_poly
         ~xdebug: !xdebug

--- a/atdcat/test/schema.atd
+++ b/atdcat/test/schema.atd
@@ -1,5 +1,12 @@
 (* Input ATD file for testing the translation to JSON Schema *)
 
+<doc text="This is the title. Here's a code block:
+{{{
+this is line 1
+this is line 2
+}}}
+">
+
 type different_kinds_of_things = [
   | Root
   | Thing of int
@@ -8,14 +15,15 @@ type different_kinds_of_things = [
 ]
 
 type root
- <doc text="This is the root object.">
+ <doc text="This is the root object. For example, the empty object {{ {} }}
+            is invalid.">
  = {
   id
     <json name="ID">
     <doc text="This is the 'id' field.">
     : string;
   items
-    <doc text="An example of JSON value is {{[[1, 2], [3], [4, 5, 6]]}}">
+    <doc text="An example of JSON value is {{ [[1, 2], [3], [4, 5, 6]] }}">
     : int list list;
   ?maybe: int option;
   ~extras: int list;

--- a/atdcat/test/schema.atd
+++ b/atdcat/test/schema.atd
@@ -7,9 +7,16 @@ type different_kinds_of_things = [
   | Amaze <json name="!!!"> of string list
 ]
 
-type root = {
-  id <json name="ID">: string;
-  items: int list list;
+type root
+ <doc text="This is the root object.">
+ = {
+  id
+    <json name="ID">
+    <doc text="This is the 'id' field.">
+    : string;
+  items
+    <doc text="An example of JSON value is {{[[1, 2], [3], [4, 5, 6]]}}">
+    : int list list;
   ?maybe: int option;
   ~extras: int list;
   ~answer: int;

--- a/atdcat/test/schema.atd
+++ b/atdcat/test/schema.atd
@@ -8,8 +8,8 @@ this is line 2
 ">
 
 type different_kinds_of_things = [
-  | Root
-  | Thing of int
+  | Root <doc text="this is Root">
+  | Thing <doc text="this is Thing"> of int
   | WOW <json name="wow">
   | Amaze <json name="!!!"> of string list
 ]

--- a/atdcat/test/schema.expected.json
+++ b/atdcat/test/schema.expected.json
@@ -1,13 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Translated by atdcat from 'schema.atd'",
+  "description":
+    "Translated by atdcat from 'schema.atd'.\n\nThis is the title. Here's a code block:\n\n{{{\nthis is line 1\nthis is line 2\n}}}\n\nThis is the root object. For example, the empty object {{ {} }} is invalid.",
   "type": "object",
   "required": [
     "ID", "items", "aliased", "point", "kinds", "assoc1", "assoc2"
   ],
   "properties": {
-    "ID": { "type": "string" },
+    "ID": { "description": "This is the 'id' field.", "type": "string" },
     "items": {
+      "description":
+        "An example of JSON value is {{[[1, 2], [3], [4, 5, 6]]}}",
       "type": "array",
       "items": { "type": "array", "items": { "type": "integer" } }
     },
@@ -60,12 +63,15 @@
   "definitions": {
     "different_kinds_of_things": {
       "oneOf": [
-        { "const": "Root" },
+        { "description": "this is Root", "const": "Root" },
         {
           "type": "array",
           "minItems": 2,
           "items": false,
-          "prefixItems": [ { "const": "Thing" }, { "type": "integer" } ]
+          "prefixItems": [
+            { "description": "this is Thing", "const": "Thing" },
+            { "type": "integer" }
+          ]
         },
         { "const": "wow" },
         {


### PR DESCRIPTION
This includes new code for reformatting (normalizing + printing) the `<doc text="...">` annotations. These documentation annotations, unlike comments, are made to be translated to the target language by the code generator. This PR does the translation work for JSON Schema which offers `"description"` fields to accommodate documentation.

Eventually, we should do it for the other target languages for which we haven't done it (Python and TypeScript for sure, maybe others).

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
