### PR TITLE
Allow `<json repr="int">` for int64 types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+2.10.0 (XXXX-XX-XX)
+-------------------
+
+* atdgen: support `<json repr="int">` for `int64` values
+
 2.9.1 (2022-06-10)
 ------------------
 

--- a/atd/src/json.ml
+++ b/atd/src/json.ml
@@ -2,6 +2,10 @@
   Mapping from ATD to JSON
 *)
 
+type json_int =
+  | Int
+  | String
+
 type json_float =
   | Float of int option (* max decimal places *)
   | Int
@@ -57,7 +61,7 @@ type json_repr =
   | External
   | Field of json_field
   | Float of json_float
-  | Int
+  | Int of json_int
   | List of json_list
   | Nullable
   | Option
@@ -107,6 +111,12 @@ let json_float_of_string s : [ `Float | `Int ] option =
     | "int" -> Some `Int
     | _ -> None
 
+let json_int_of_string s : [ `String | `Int ] option =
+  match s with
+      "string" -> Some `String
+    | "int" -> Some `Int
+    | _ -> None
+
 let json_precision_of_string s =
   try Some (int_of_string s)
   with _ -> None
@@ -128,6 +138,18 @@ let get_json_float an : json_float =
       an
   with
       `Float -> Float (get_json_precision an)
+    | `Int -> Int
+
+let get_json_int an : json_int =
+  match
+    Annot.get_field
+      ~parse:json_int_of_string
+      ~default:`String
+      ~sections:["json"]
+      ~field:"repr"
+      an
+  with
+      `String -> String
     | `Int -> Int
 
 let json_list_of_string s : json_list option =

--- a/atd/src/json.mli
+++ b/atd/src/json.mli
@@ -19,6 +19,10 @@ type json_adapter = {
 
 val no_adapter : json_adapter
 
+type json_int =
+  | Int
+  | String
+
 type json_float =
   | Float of int option (* max decimal places *)
   | Int
@@ -52,7 +56,7 @@ type json_repr =
   | External
   | Field of json_field
   | Float of json_float
-  | Int
+  | Int of json_int
   | List of json_list
   | Nullable
   | Option
@@ -69,6 +73,8 @@ val annot_schema_json : Annot.schema
 val get_json_list : Annot.t -> json_list
 
 val get_json_float : Annot.t -> json_float
+
+val get_json_int : Annot.t -> json_int
 
 val get_json_cons : string -> Annot.t -> string
 

--- a/atdgen-runtime/src/oj_run.ml
+++ b/atdgen-runtime/src/oj_run.ml
@@ -109,6 +109,9 @@ let write_int64 ob x =
   Bi_outbuf.add_string ob (Int64.to_string x);
   Bi_outbuf.add_char ob '"'
 
+let write_int64_as_int ob x =
+  Bi_outbuf.add_string ob (Int64.to_string x)
+
 let min_float = float min_int
 let max_float = float max_int
 

--- a/atdgen-runtime/src/oj_run.mli
+++ b/atdgen-runtime/src/oj_run.mli
@@ -17,6 +17,7 @@ val write_nullable : 'a write -> 'a option write
 val write_int8 : char write
 val write_int32 : int32 write
 val write_int64 : int64 write
+val write_int64_as_int : int64 write
 
 type 'a read = Yojson.lexer_state -> Lexing.lexbuf -> 'a
 

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -89,7 +89,7 @@ let rec get_reader_name
   match x with
     Unit (_, Unit, Unit) -> decoder_ident "unit"
   | Bool (_, Bool, Bool) -> decoder_ident "bool"
-  | Int (_, Int o, Int) ->
+  | Int (_, Int o, Int _) ->
       decoder_ident (
         match o with
         | Int -> "int"
@@ -357,7 +357,7 @@ let rec get_writer_name
       encoder_ident "unit"
   | Bool (_, Bool, Bool) ->
       encoder_ident "bool"
-  | Int (_, Int o, Int) ->
+  | Int (_, Int o, Int _) ->
       encoder_ident (
         match o with
         | Int -> "int"

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -127,12 +127,16 @@ let rec get_writer_name
       "Yojson.Safe.write_null"
   | Bool (_, Bool, Bool) ->
       "Yojson.Safe.write_bool"
-  | Int (_, Int o, Int) ->
+  | Int (_, Int o, Int j) ->
       (match o with
          Int -> "Yojson.Safe.write_int"
        | Char ->  "Atdgen_runtime.Oj_run.write_int8"
        | Int32 -> "Atdgen_runtime.Oj_run.write_int32"
-       | Int64 -> "Atdgen_runtime.Oj_run.write_int64"
+       | Int64 ->
+           (match j with
+            | String -> "Atdgen_runtime.Oj_run.write_int64"
+            | Int -> "Atdgen_runtime.Oj_run.write_int64_as_int"
+           )
        | Float -> "Atdgen_runtime.Oj_run.write_float_as_int"
       )
 
@@ -196,7 +200,7 @@ let rec get_reader_name
   match x with
     Unit (_, Unit, Unit) -> "Atdgen_runtime.Oj_run.read_null"
   | Bool (_, Bool, Bool) -> "Atdgen_runtime.Oj_run.read_bool"
-  | Int (_, Int o, Int) ->
+  | Int (_, Int o, Int _) ->
       (match o with
          Int -> "Atdgen_runtime.Oj_run.read_int"
        | Char -> "Atdgen_runtime.Oj_run.read_int8"

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -94,7 +94,11 @@ let rec mapping_of_expr (x : type_expr) =
            Bool (loc, Bool, Bool)
        | "int" ->
            let o = Ocaml.get_ocaml_int Json an in
-           Int (loc, Int o, Int)
+           let j = match o with
+             | Int64 -> Json.get_json_int an
+             | _ -> (Int : Json.json_int)
+           in
+           Int (loc, Int o, Int j)
        | "float" ->
            let j = Json.get_json_float an in
            Float (loc, Float, Float j)

--- a/atdgen/test/dune
+++ b/atdgen/test/dune
@@ -61,6 +61,11 @@
 (rule
  (alias runtest)
  (package atdgen)
+ (action (diff test_int64_as_int_j.expected.ml test_int64_as_int_j.ml)))
+
+(rule
+ (alias runtest)
+ (package atdgen)
  (action (diff testj.expected.ml testj.ml)))
 
 (rule
@@ -231,7 +236,7 @@
  (alias runtest)
  (package atdgen)
  (action (diff test_annot_error.expected.stdout test_annot_error.stdout)))
- 
+
  ;; inline records are not allowed within poly variant, but allowed in classic
 
 (rule
@@ -317,6 +322,11 @@
 (rule
  (targets test_abstract_j.ml test_abstract_j.mli)
  (deps    test_abstract.atd)
+ (action  (run %{bin:atdgen} -j %{deps})))
+
+(rule
+ (targets test_int64_as_int_j.ml test_int64_as_int_j.mli)
+ (deps    test_int64_as_int.atd)
  (action  (run %{bin:atdgen} -j %{deps})))
 
 (rule

--- a/atdgen/test/test_int64_as_int.atd
+++ b/atdgen/test/test_int64_as_int.atd
@@ -1,0 +1,2 @@
+type i = int <ocaml repr="int64">
+type i1 = int <ocaml repr="int64"><json repr="int">

--- a/atdgen/test/test_int64_as_int_j.expected.ml
+++ b/atdgen/test/test_int64_as_int_j.expected.ml
@@ -1,0 +1,31 @@
+(* Auto-generated from "test_int64_as_int.atd" *)
+[@@@ocaml.warning "-27-32-33-35-39"]
+
+type i1 = Test_int64_as_int_t.i1
+
+type i = Test_int64_as_int_t.i
+
+let write_i1 = (
+  Atdgen_runtime.Oj_run.write_int64_as_int
+)
+let string_of_i1 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_i1 ob x;
+  Bi_outbuf.contents ob
+let read_i1 = (
+  Atdgen_runtime.Oj_run.read_int64
+)
+let i1_of_string s =
+  read_i1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_i = (
+  Atdgen_runtime.Oj_run.write_int64
+)
+let string_of_i ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_i ob x;
+  Bi_outbuf.contents ob
+let read_i = (
+  Atdgen_runtime.Oj_run.read_int64
+)
+let i_of_string s =
+  read_i (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/doc/atdgen-reference.rst
+++ b/doc/atdgen-reference.rst
@@ -644,6 +644,32 @@ Example:
 
     type unixtime = float <json repr="int">
 
+Int64
+~~~~~
+
+Position: after ``int`` type annotated with ``<ocaml repr="int64">``
+
+Values: ``int``
+
+Semantics: sepcifies an ``int64`` value that will be represented in JSON
+as integer as opposite to the default safe string representation. Note,
+that this may be the unsafe choice, depending on the environment where the
+target JSON will be parsed. For example, the ``Int64.max_int`` value parsed
+in Node.js:
+
+.. code::
+
+    Welcome to Node.js v17.8.0.
+    Type ".help" for more information.
+    > JSON.parse("9223372036854775807");
+    9223372036854776000
+
+Example:
+
+.. code:: ocaml
+
+    type bigint = int <ocaml repr="int64"> <json repr="int">
+
 Field ``tag_field``
 """""""""""""""""""
 


### PR DESCRIPTION
One way to address the concern in #273 (allow to encode `int64` value as `int` in JSON). Example:
```
$ cat x.atd && make && _build/default/atdgen/bin/ag_main.exe -j x.atd && cat x_j.ml
type i = int <ocaml repr="int64">
type i1 = int <ocaml repr="int64"><json repr="int">
...
type i1 = X_t.i1
type i = X_t.i
let write_i1 = (
  Atdgen_runtime.Oj_run.write_int64_as_int
)
...
let write_i = (
  Atdgen_runtime.Oj_run.write_int64
)
...
```
The pro is that we don't introduce new annotations and basically re-using the same `repr="int"` instruction as it is done for floats. On the other hand, there is some smell in it: another accepted value is `string`, but it is no-op for any int flavour, but `int64`.  Can be solved by using some specific `<json int64_as_int>` or something 🤷 Advice is welcomed :)
If we like the direction, I will complete the below checklist

cc @AndreyErmilov @Lupus
 
### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
