### PR TITLE
fix `make all` when executed after `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ DUNE ?= dune
 # via opam.
 .PHONY: all
 all:
+	rm -f atdpy/test/python-tests/everything.py
+	rm -f atdts/test/ts-tests/everything.ts
 	$(DUNE) build
 
 # Install the OCaml dependencies for the build.

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ DUNE ?= dune
 # via opam.
 .PHONY: all
 all:
-	rm -f atdpy/test/python-tests/everything.py
-	rm -f atdts/test/ts-tests/everything.ts
+	$(MAKE) -C atdpy clean-for-dune
+	$(MAKE) -C atdts clean-for-dune
 	$(DUNE) build
 
 # Install the OCaml dependencies for the build.


### PR DESCRIPTION
Minor build-related fix. When I run `make test` and then `make` I get this:
```
$ make
dune build
Error: Multiple rules generated for
_build/default/atdpy/test/python-tests/everything.py:
- file present in source tree
- atdpy/test/python-tests/dune:4
-> required by alias default
Hint: rm -f atdpy/test/python-tests/everything.py
Error: Multiple rules generated for
_build/default/atdts/test/ts-tests/everything.ts:
- file present in source tree
- atdts/test/ts-tests/dune:4
-> required by alias default
Hint: rm -f atdts/test/ts-tests/everything.ts
make: *** [Makefile:12: all] Error 1
```

The fix blindly applies the hints from `dune` . If better fix is possible (within `atdts`/`atdpy`) it be great