### PR TITLE
atdcat: add option to produce `additionalProperties: false` on JSON Schema objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
-2.6.1 (2022-XX-XX)
+Next release
 ------------------
 
 * Add ability to specify JSON/OCaml adapter with the arbitrary code
-  using `<json adapter.to_ocaml="..." adapter.from_ocaml="...">`
+  using `<json adapter.to_ocaml="..." adapter.from_ocaml="...">` (#184).
+* atdcat: add option `-no-additional-properties` for JSON Schema
+  output to specify that JSON objects may not have extra properties (#293).
 
 2.6.0 (2022-05-03)
 ------------------

--- a/atd/src/jsonschema.mli
+++ b/atd/src/jsonschema.mli
@@ -5,8 +5,13 @@
 (** This is for validating the ATD file, not for JSON Schema. *)
 val annot_schema : Annot.schema
 
-(** Translate an ATD AST to a JSON Schema. *)
+(** Translate an ATD AST to a JSON Schema.
+
+    @param xprop whether to allow extra fields in JSON objects. The default
+    is true, which is JSON Schema's default.
+ *)
 val print :
+  ?xprop:bool ->
   src_name:string ->
   root_type:string ->
   out_channel -> Ast.full_module -> unit

--- a/atdcat/src/atdcat.ml
+++ b/atdcat/src/atdcat.ml
@@ -73,12 +73,12 @@ let parse
   let m = first_head, List.flatten bodies in
   strip strip_all strip_sections m
 
-let print ~src_name ~html_doc ~out_format ~out_channel:oc ast =
+let print ~xprop ~src_name ~html_doc ~out_format ~out_channel:oc ast =
   let f =
     match out_format with
     | Atd -> print_atd ~html_doc
     | Ocaml name -> print_ml ~name
-    | Jsonschema root_type -> Atd.Jsonschema.print ~src_name ~root_type
+    | Jsonschema root_type -> Atd.Jsonschema.print ~xprop ~src_name ~root_type
   in
   f oc ast
 
@@ -94,6 +94,7 @@ let () =
   let strip_sections = ref [] in
   let strip_all = ref false in
   let out_format = ref Atd in
+  let allow_additional_properties = ref true in
   let html_doc = ref false in
   let input_files = ref [] in
   let output_file = ref None in
@@ -133,6 +134,12 @@ let () =
     "-jsonschema", Arg.String (fun s -> out_format := Jsonschema s),
     "<root type name>
           translate the ATD file to JSON Schema.";
+
+    "-no-additional-properties",
+    Arg.Unit (fun () -> allow_additional_properties := false),
+    "
+          emit a JSON Schema that doesn't tolerate extra fields on JSON
+          objects.";
 
     "-ml", Arg.String (fun s -> out_format := Ocaml s),
     "<name>
@@ -199,6 +206,7 @@ let () =
       | _ -> "multiple files"
     in
     print
+      ~xprop: !allow_additional_properties
       ~src_name
       ~html_doc: !html_doc
       ~out_format: !out_format

--- a/atdcat/test/data.json
+++ b/atdcat/test/data.json
@@ -9,5 +9,6 @@
   "assoc1": [ [ 1.1, 1 ], [ 2.2, 2 ] ],
   "assoc2": { "c": 3, "d": 4 },
   "options": [ [ "Some", 10 ], "None", [ "Some", 88 ] ],
-  "nullables": [ 13, 71, null ]
+  "nullables": [ 13, 71, null ],
+  "extra": "ignore me please"
 }

--- a/atdcat/test/dune
+++ b/atdcat/test/dune
@@ -51,7 +51,7 @@
      (run python3 -m jsonschema schema.json -i data.json)
 
      ; Check that validation fails due to an extra property in the JSON data
-     (with-accepted-exit-codes (not 0)
+     (with-accepted-exit-codes 1
        (run python3 -m jsonschema schema-no-xprop.json -i data.json)
      )
    )

--- a/atdcat/test/dune
+++ b/atdcat/test/dune
@@ -26,6 +26,13 @@
  (deps schema.atd)
  (action (run %{bin:atdcat} %{deps} -o %{targets} -jsonschema root)))
 
+; Same, with some options for a different JSON Schema output
+(rule
+ (targets schema-no-xprop.json)
+ (deps schema.atd)
+ (action (run %{bin:atdcat} %{deps} -o %{targets} -jsonschema root
+                -no-additional-properties)))
+
 (rule
  (alias runtest)
  (deps
@@ -37,8 +44,16 @@
      ; Check JSON Schema output
      (diff schema.expected.json schema.json)
 
+     ; Check JSON Schema output
+     (diff schema-no-xprop.expected.json schema-no-xprop.json)
+
      ; Check that the JSON Schema is valid and compatible with some JSON data
      (run python3 -m jsonschema schema.json -i data.json)
+
+     ; Check that validation fails due to an extra property in the JSON data
+     (with-accepted-exit-codes (not 0)
+       (run python3 -m jsonschema schema-no-xprop.json -i data.json)
+     )
    )
  )
 )

--- a/atdcat/test/schema-no-xprop.expected.json
+++ b/atdcat/test/schema-no-xprop.expected.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description":
+    "Translated by atdcat from 'schema.atd'.\n\nThis is the title. Here's a code block:\n\n{{{\nthis is line 1\nthis is line 2\n}}}\n\nThis is the root object. For example, the empty object {{ {} }} is invalid.",
+  "type": "object",
+  "required": [
+    "ID", "items", "aliased", "point", "kinds", "assoc1", "assoc2"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "ID": { "description": "This is the 'id' field.", "type": "string" },
+    "items": {
+      "description":
+        "An example of JSON value is {{[[1, 2], [3], [4, 5, 6]]}}",
+      "type": "array",
+      "items": { "type": "array", "items": { "type": "integer" } }
+    },
+    "maybe": { "type": "integer" },
+    "extras": { "type": "array", "items": { "type": "integer" } },
+    "answer": { "type": "integer" },
+    "aliased": { "$ref": "#/definitions/alias" },
+    "point": {
+      "type": "array",
+      "minItems": 2,
+      "items": false,
+      "prefixItems": [ { "type": "number" }, { "type": "number" } ]
+    },
+    "kinds": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/different_kinds_of_things" }
+    },
+    "assoc1": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "minItems": 2,
+        "items": false,
+        "prefixItems": [ { "type": "number" }, { "type": "integer" } ]
+      }
+    },
+    "assoc2": {
+      "type": "object",
+      "additionalProperties": { "type": "integer" }
+    },
+    "options": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "array",
+            "minItems": 2,
+            "items": false,
+            "prefixItems": [ { "const": "Some" }, { "type": "integer" } ]
+          },
+          { "const": "None" }
+        ]
+      }
+    },
+    "nullables": {
+      "type": "array",
+      "items": { "type": [ "integer", "null" ] }
+    }
+  },
+  "definitions": {
+    "different_kinds_of_things": {
+      "oneOf": [
+        { "description": "this is Root", "const": "Root" },
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": false,
+          "prefixItems": [
+            { "description": "this is Thing", "const": "Thing" },
+            { "type": "integer" }
+          ]
+        },
+        { "const": "wow" },
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": false,
+          "prefixItems": [
+            { "const": "!!!" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        }
+      ]
+    },
+    "alias": { "type": "array", "items": { "type": "integer" } },
+    "pair": {
+      "type": "array",
+      "minItems": 2,
+      "items": false,
+      "prefixItems": [ { "type": "string" }, { "type": "integer" } ]
+    }
+  }
+}

--- a/doc/atd-language-reference.rst
+++ b/doc/atd-language-reference.rst
@@ -245,6 +245,8 @@ of ``atdcat -help``:
 ::
 
   Usage: atdcat FILE
+    -o <path>
+            write to this file instead of stdout
     -x 
             make type expressions monomorphic
     -xk 
@@ -258,6 +260,11 @@ of ``atdcat -help``:
             expand `inherit' statements in records
     -iv 
             expand `inherit' statements in sum types
+    -jsonschema <root type name>
+            translate the ATD file to JSON Schema.
+    -no-additional-properties 
+            emit a JSON Schema that doesn't tolerate extra fields on JSON
+            objects.
     -ml <name>
             output the ocaml code of the ATD abstract syntax tree
     -html-doc 


### PR DESCRIPTION
Add an option to atdcat to produce JSON Schema output that rejects extra JSON properties on objects.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
