### PR TITLE
JSON Schema output: support earlier version "Draft 2019-09"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,14 @@ Next release
 
 * Add ability to specify JSON/OCaml adapter with the arbitrary code
   using `<json adapter.to_ocaml="..." adapter.from_ocaml="...">` (#184).
-* atdcat: add option `-no-additional-properties` for JSON Schema
-  output to specify that JSON objects may not have extra properties (#293).
+* atdcat: add option `-jsonschema-no-additional-properties` for JSON Schema
+  output to specify that JSON objects may not have extra properties
+  (#293, #294).
+* atdcat: add `title` field to JSON Schema output containing the name
+  of root type (#294).
+* atdcat: add command-line option to choose the version of JSON Schema
+  to target. Options are the latest version "Draft 2020-12" and the
+  previous version "Draft 2019-09" (#294).
 
 2.6.0 (2022-05-03)
 ------------------

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -331,7 +331,16 @@ let def_to_json ~version (x : def) =
 let to_json ~version (x : t) : json =
   let root_def =
     match def_to_json ~version x.root_def with
-    | _, `Assoc fields -> fields
+    | _, `Assoc fields ->
+        (* json-schema-to-typescript (command json2ts) will use the 'title'
+           field to generate a name for the root type since otherwise it
+           doesn't have a name. That's why we populate the 'title' field
+           like this.
+           This probably interferes with other tools that expect an actual
+           title. Note that the documentation extracted from the
+           ATD <doc ...> header goes into 'description', not 'title'.
+        *)
+        ("title", `String x.root_def.name) :: fields
     | _ -> assert false
   in
   `Assoc (

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -178,6 +178,7 @@ let trans_item
   }
 
 let trans_full_module
+    ~version
     ~xprop
     ~src_name
     ~root_type
@@ -212,8 +213,13 @@ let trans_full_module
     |> String.concat "\n\n"
   in
   let root_def = { root_def with description = Some description } in
+  let version_url =
+    match version with
+    | Draft_2019_09 -> "https://json-schema.org/draft/2019-09/schema"
+    | Draft_2020_12 -> "https://json-schema.org/draft/2020-12/schema"
+  in
   {
-    schema = "https://json-schema.org/draft/2020-12/schema";
+    schema = version_url;
     root_def = root_def;
     defs;
   }
@@ -343,7 +349,7 @@ let print
     ?(xprop = true)
     ~src_name ~root_type oc ast =
   ast
-  |> trans_full_module ~xprop ~src_name ~root_type
+  |> trans_full_module ~version ~xprop ~src_name ~root_type
   |> to_json ~version
   |> Yojson.Safe.pretty_to_channel oc;
   output_char oc '\n'

--- a/atd/src/jsonschema.ml
+++ b/atd/src/jsonschema.ml
@@ -13,6 +13,14 @@
 open Printf
 open Ast
 
+type version =
+  | Draft_2019_09
+  | Draft_2020_12
+
+(* Change this to the latest version whenever a new version becomes
+   available, as promised by --help. *)
+let default_version = Draft_2020_12
+
 type json = Yojson.Safe.t
 
 (* optional description field *)
@@ -228,7 +236,7 @@ let make_type_property ~is_nullable name =
   else
     ("type", `String name)
 
-let rec type_expr_to_assoc ?(is_nullable = false) (x : type_expr)
+let rec type_expr_to_assoc ?(is_nullable = false) ~version (x : type_expr)
   : (string * json) list =
   match x with
   | Ref s ->
@@ -246,26 +254,33 @@ let rec type_expr_to_assoc ?(is_nullable = false) (x : type_expr)
   | Array x ->
       [
         make_type_property ~is_nullable "array";
-        "items", type_expr_to_json x
+        "items", type_expr_to_json ~version x
       ]
   | Tuple xs ->
-      [
-        make_type_property ~is_nullable "array";
-        "minItems", `Int (List.length xs);
-
-        (* "items" used to be called "additionalItems",
-           "prefixItems" used to be called "items"
-
-           according to
-           https://json-schema.org/understanding-json-schema/reference/array.html
-        *)
-        "items", `Bool false;
-        "prefixItems", `List (List.map type_expr_to_json xs);
-      ]
+      let shared =
+        [
+          make_type_property ~is_nullable "array";
+          "minItems", `Int (List.length xs);
+        ]
+      in
+      let tail =
+        match version with
+        | Draft_2020_12 ->
+            [
+              "items", `Bool false;
+              "prefixItems", `List (List.map (type_expr_to_json ~version) xs);
+            ]
+        | Draft_2019_09 ->
+            [
+              "additionalItems", `Bool false;
+              "items", `List (List.map (type_expr_to_json ~version) xs);
+            ]
+      in
+      shared @ tail
   | Object x ->
       let properties =
         List.map (fun (name, x, descr) ->
-          (name, type_expr_to_json ~descr x)
+          (name, type_expr_to_json ~descr ~version x)
         ) x.properties
       in
       let additional_properties =
@@ -281,49 +296,54 @@ let rec type_expr_to_assoc ?(is_nullable = false) (x : type_expr)
   | Map x ->
       [
         make_type_property ~is_nullable "object";
-        "additionalProperties", type_expr_to_json x
+        "additionalProperties", type_expr_to_json ~version x
       ]
   | Union xs ->
-      [ "oneOf", `List (List.map (type_expr_to_json ~is_nullable) xs) ]
+      [ "oneOf", `List (List.map (type_expr_to_json ~is_nullable ~version) xs) ]
   | Nullable x ->
-      type_expr_to_assoc ~is_nullable:true x
+      type_expr_to_assoc ~is_nullable:true ~version x
   | Const (json, descr) ->
       descr @ [ "const", json ]
 
 and type_expr_to_json
     ?(is_nullable = false)
     ?(descr = [])
+    ~version
     (x : type_expr) : json =
   `Assoc (
-    descr @ type_expr_to_assoc ~is_nullable x
+    descr @ type_expr_to_assoc ~is_nullable ~version x
   )
 
-let def_to_json (x : def) =
+let def_to_json ~version (x : def) =
   x.name, `Assoc (
     List.flatten [
       opt "description" string x.description;
-      type_expr_to_assoc x.type_expr;
+      type_expr_to_assoc ~version x.type_expr;
     ]
   )
 
-let to_json (x : t) : json =
+let to_json ~version (x : t) : json =
   let root_def =
-    match def_to_json x.root_def with
+    match def_to_json ~version x.root_def with
     | _, `Assoc fields -> fields
     | _ -> assert false
   in
   `Assoc (
     ("$schema", `String x.schema)
     :: root_def
-    @ ["definitions", `Assoc (List.map (fun x -> def_to_json x) x.defs)]
+    @ ["definitions",
+       `Assoc (List.map (fun x -> def_to_json ~version x) x.defs)]
   )
 
 let annot_schema =
   Json.annot_schema_json @ Doc.annot_schema
 
-let print ?(xprop = true) ~src_name ~root_type oc ast =
+let print
+    ?(version = default_version)
+    ?(xprop = true)
+    ~src_name ~root_type oc ast =
   ast
   |> trans_full_module ~xprop ~src_name ~root_type
-  |> to_json
+  |> to_json ~version
   |> Yojson.Safe.pretty_to_channel oc;
   output_char oc '\n'

--- a/atd/src/jsonschema.mli
+++ b/atd/src/jsonschema.mli
@@ -2,6 +2,17 @@
    Translate an ATD file to JSON Schema, honoring the <json ...> annotations.
 *)
 
+(** These are the versions of the JSON Schema currently supported.
+
+    See https://json-schema.org/draft/2020-12/release-notes.html
+    for the differences between 2019-09 and 2020-12.
+*)
+type version =
+  | Draft_2019_09
+  | Draft_2020_12
+
+val default_version : version
+
 (** This is for validating the ATD file, not for JSON Schema. *)
 val annot_schema : Annot.schema
 
@@ -11,6 +22,7 @@ val annot_schema : Annot.schema
     is true, which is JSON Schema's default.
  *)
 val print :
+  ?version:version ->
   ?xprop:bool ->
   src_name:string ->
   root_type:string ->

--- a/atdcat/src/atdcat.ml
+++ b/atdcat/src/atdcat.ml
@@ -5,6 +5,25 @@ type out_format =
   | Ocaml of string (* output file name [why?] *)
   | Jsonschema of string (* root type *)
 
+(* These string identifiers aren't standard, unlike the full URLs
+   such as "https://json-schema.org/draft/2020-12" that
+   are too cumbersome to use on the command line. *)
+let available_jsonschema_versions = [
+  "draft-2019-09", Atd.Jsonschema.Draft_2019_09;
+  "draft-2020-12", Atd.Jsonschema.Draft_2020_12;
+]
+
+let string_of_jsonschema_version x =
+  match List.find_opt (fun (s, x0) -> x = x0) available_jsonschema_versions
+  with
+  | Some (s, _) -> s
+  | None -> assert false
+
+let jsonschema_version_of_string s =
+  match List.assoc_opt s available_jsonschema_versions with
+  | Some x -> x
+  | None -> failwith (sprintf "Invalid JSON Schema version identifier: %S" s)
+
 let html_of_doc loc s =
   let doc = Atd.Doc.parse_text loc s in
   Atd.Doc.html_of_doc doc
@@ -73,12 +92,18 @@ let parse
   let m = first_head, List.flatten bodies in
   strip strip_all strip_sections m
 
-let print ~xprop ~src_name ~html_doc ~out_format ~out_channel:oc ast =
+let print
+    ~xprop ~jsonschema_version
+    ~src_name ~html_doc ~out_format ~out_channel:oc ast =
   let f =
     match out_format with
     | Atd -> print_atd ~html_doc
     | Ocaml name -> print_ml ~name
-    | Jsonschema root_type -> Atd.Jsonschema.print ~xprop ~src_name ~root_type
+    | Jsonschema root_type ->
+        Atd.Jsonschema.print
+          ~xprop
+          ~version:jsonschema_version
+          ~src_name ~root_type
   in
   f oc ast
 
@@ -94,7 +119,8 @@ let () =
   let strip_sections = ref [] in
   let strip_all = ref false in
   let out_format = ref Atd in
-  let allow_additional_properties = ref true in
+  let jsonschema_version = ref Atd.Jsonschema.default_version in
+  let jsonschema_allow_additional_properties = ref true in
   let html_doc = ref false in
   let input_files = ref [] in
   let output_file = ref None in
@@ -121,25 +147,35 @@ let () =
                       inherit_fields := true;
                       inherit_variants := true),
     "
-          expand all `inherit' statements";
+          expand all 'inherit' statements";
 
     "-if", Arg.Set inherit_fields,
     "
-          expand `inherit' statements in records";
+          expand 'inherit' statements in records";
 
     "-iv", Arg.Set inherit_variants,
     "
-          expand `inherit' statements in sum types";
+          expand 'inherit' statements in sum types";
 
     "-jsonschema", Arg.String (fun s -> out_format := Jsonschema s),
     "<root type name>
           translate the ATD file to JSON Schema.";
 
-    "-no-additional-properties",
-    Arg.Unit (fun () -> allow_additional_properties := false),
+    "-jsonschema-no-additional-properties",
+    Arg.Unit (fun () -> jsonschema_allow_additional_properties := false),
     "
           emit a JSON Schema that doesn't tolerate extra fields on JSON
           objects.";
+
+    "-jsonschema-version",
+    Arg.String (fun s ->
+      jsonschema_version := jsonschema_version_of_string s
+    ),
+    sprintf "{ %s }
+          specify which version of the JSON Schema standard to target.
+          Default: latest supported version, which is currently '%s'."
+      (available_jsonschema_versions |> List.map fst |> String.concat " | ")
+      (string_of_jsonschema_version Atd.Jsonschema.default_version);
 
     "-ml", Arg.String (fun s -> out_format := Ocaml s),
     "<name>
@@ -206,15 +242,17 @@ let () =
       | _ -> "multiple files"
     in
     print
-      ~xprop: !allow_additional_properties
+      ~jsonschema_version: !jsonschema_version
+      ~xprop: !jsonschema_allow_additional_properties
       ~src_name
       ~html_doc: !html_doc
       ~out_format: !out_format
       ~out_channel ast;
     close_out out_channel
   with
-      Atd.Ast.Atd_error s ->
-        flush stdout;
-        eprintf "%s\n%!" s;
-        exit 1
-    | e -> raise e
+  | Atd.Ast.Atd_error msg
+  | Failure msg ->
+      flush stdout;
+      eprintf "%s\n%!" msg;
+      exit 1
+  | e -> raise e

--- a/atdcat/test/dune
+++ b/atdcat/test/dune
@@ -63,7 +63,10 @@
      )
 
      ; Test other versions of the JSON Schema standard
-     (run python3 -m jsonschema -V Draft201909Validator
+     (run python3 -m jsonschema
+       ; we should use Draft201909Validator but it causes a stack overflow
+       ; apparently related to tuples.
+       -V Draft7Validator
        schema-draft-2019-09.json -i data.json
      )
    )

--- a/atdcat/test/dune
+++ b/atdcat/test/dune
@@ -31,7 +31,15 @@
  (targets schema-no-xprop.json)
  (deps schema.atd)
  (action (run %{bin:atdcat} %{deps} -o %{targets} -jsonschema root
-                -no-additional-properties)))
+                -jsonschema-no-additional-properties)))
+
+; Same, targeting an earlier version of the standard
+(rule
+ (targets schema-draft-2019-09.json)
+ (deps schema.atd)
+ (action (run %{bin:atdcat} %{deps} -o %{targets}
+                -jsonschema root
+                -jsonschema-version draft-2019-09)))
 
 (rule
  (alias runtest)
@@ -43,9 +51,8 @@
    (progn
      ; Check JSON Schema output
      (diff schema.expected.json schema.json)
-
-     ; Check JSON Schema output
      (diff schema-no-xprop.expected.json schema-no-xprop.json)
+     (diff schema-draft-2019-09.expected.json schema-draft-2019-09.json)
 
      ; Check that the JSON Schema is valid and compatible with some JSON data
      (run python3 -m jsonschema schema.json -i data.json)
@@ -53,6 +60,11 @@
      ; Check that validation fails due to an extra property in the JSON data
      (with-accepted-exit-codes 1
        (run python3 -m jsonschema schema-no-xprop.json -i data.json)
+     )
+
+     ; Test other versions of the JSON Schema standard
+     (run python3 -m jsonschema -V Draft201909Validator
+       schema-draft-2019-09.json -i data.json
      )
    )
  )

--- a/atdcat/test/schema-draft-2019-09.expected.json
+++ b/atdcat/test/schema-draft-2019-09.expected.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "description":
     "Translated by atdcat from 'schema.atd'.\n\nThis is the title. Here's a code block:\n\n{{{\nthis is line 1\nthis is line 2\n}}}\n\nThis is the root object. For example, the empty object {{ {} }} is invalid.",
   "type": "object",

--- a/atdcat/test/schema-draft-2019-09.expected.json
+++ b/atdcat/test/schema-draft-2019-09.expected.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description":
+    "Translated by atdcat from 'schema.atd'.\n\nThis is the title. Here's a code block:\n\n{{{\nthis is line 1\nthis is line 2\n}}}\n\nThis is the root object. For example, the empty object {{ {} }} is invalid.",
+  "type": "object",
+  "required": [
+    "ID", "items", "aliased", "point", "kinds", "assoc1", "assoc2"
+  ],
+  "properties": {
+    "ID": { "description": "This is the 'id' field.", "type": "string" },
+    "items": {
+      "description":
+        "An example of JSON value is {{[[1, 2], [3], [4, 5, 6]]}}",
+      "type": "array",
+      "items": { "type": "array", "items": { "type": "integer" } }
+    },
+    "maybe": { "type": "integer" },
+    "extras": { "type": "array", "items": { "type": "integer" } },
+    "answer": { "type": "integer" },
+    "aliased": { "$ref": "#/definitions/alias" },
+    "point": {
+      "type": "array",
+      "minItems": 2,
+      "additionalItems": false,
+      "items": [ { "type": "number" }, { "type": "number" } ]
+    },
+    "kinds": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/different_kinds_of_things" }
+    },
+    "assoc1": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "minItems": 2,
+        "additionalItems": false,
+        "items": [ { "type": "number" }, { "type": "integer" } ]
+      }
+    },
+    "assoc2": {
+      "type": "object",
+      "additionalProperties": { "type": "integer" }
+    },
+    "options": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "array",
+            "minItems": 2,
+            "additionalItems": false,
+            "items": [ { "const": "Some" }, { "type": "integer" } ]
+          },
+          { "const": "None" }
+        ]
+      }
+    },
+    "nullables": {
+      "type": "array",
+      "items": { "type": [ "integer", "null" ] }
+    }
+  },
+  "definitions": {
+    "different_kinds_of_things": {
+      "oneOf": [
+        { "description": "this is Root", "const": "Root" },
+        {
+          "type": "array",
+          "minItems": 2,
+          "additionalItems": false,
+          "items": [
+            { "description": "this is Thing", "const": "Thing" },
+            { "type": "integer" }
+          ]
+        },
+        { "const": "wow" },
+        {
+          "type": "array",
+          "minItems": 2,
+          "additionalItems": false,
+          "items": [
+            { "const": "!!!" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        }
+      ]
+    },
+    "alias": { "type": "array", "items": { "type": "integer" } },
+    "pair": {
+      "type": "array",
+      "minItems": 2,
+      "additionalItems": false,
+      "items": [ { "type": "string" }, { "type": "integer" } ]
+    }
+  }
+}

--- a/atdcat/test/schema-draft-2019-09.expected.json
+++ b/atdcat/test/schema-draft-2019-09.expected.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "root",
   "description":
     "Translated by atdcat from 'schema.atd'.\n\nThis is the title. Here's a code block:\n\n{{{\nthis is line 1\nthis is line 2\n}}}\n\nThis is the root object. For example, the empty object {{ {} }} is invalid.",
   "type": "object",

--- a/atdcat/test/schema-no-xprop.expected.json
+++ b/atdcat/test/schema-no-xprop.expected.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "root",
   "description":
     "Translated by atdcat from 'schema.atd'.\n\nThis is the title. Here's a code block:\n\n{{{\nthis is line 1\nthis is line 2\n}}}\n\nThis is the root object. For example, the empty object {{ {} }} is invalid.",
   "type": "object",

--- a/atdcat/test/schema.expected.json
+++ b/atdcat/test/schema.expected.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "root",
   "description":
     "Translated by atdcat from 'schema.atd'.\n\nThis is the title. Here's a code block:\n\n{{{\nthis is line 1\nthis is line 2\n}}}\n\nThis is the root object. For example, the empty object {{ {} }} is invalid.",
   "type": "object",

--- a/doc/atd-language-reference.rst
+++ b/doc/atd-language-reference.rst
@@ -244,48 +244,49 @@ of ``atdcat -help``:
 
 ::
 
-Usage: _build/install/default/bin/atdcat FILE
-  -o <path>
-          write to this file instead of stdout
-  -x 
-          make type expressions monomorphic
-  -xk 
-          keep parametrized type definitions and imply -x.
-          Default is to return only monomorphic type definitions
-  -xd 
-          debug mode implying -x
-  -i 
-          expand all 'inherit' statements
-  -if 
-          expand 'inherit' statements in records
-  -iv 
-          expand 'inherit' statements in sum types
-  -jsonschema <root type name>
-          translate the ATD file to JSON Schema.
-  -jsonschema-no-additional-properties 
-          emit a JSON Schema that doesn't tolerate extra fields on JSON
-          objects.
-  -jsonschema-version { draft-2019-09 | draft-2020-12 }
-          specify which version of the JSON Schema standard to target.
-          Default: latest supported version, which is currently 'draft-2020-12'.
-  -ml <name>
-          output the ocaml code of the ATD abstract syntax tree
-  -html-doc 
-          replace directly <doc html="..."> by (*html ... *)
-          or replace <doc text="..."> by (*html ... *)
-          where the contents are formatted as HTML
-          using <p>, <code> and <pre>.
-          This is suitable input for "caml2html -ext html:cat"
-          which converts ATD files into HTML.
-  -strip NAME1[,NAME2,...]
-          remove all annotations of the form <NAME1 ...>,
-          <NAME2 ...>, etc.
-  -strip-all 
-          remove all annotations
-  -version 
-          print the version of atd and exit
-  -help  Display this list of options
-  --help  Display this list of options
+  Usage: _build/install/default/bin/atdcat FILE
+    -o <path>
+            write to this file instead of stdout
+    -x 
+            make type expressions monomorphic
+    -xk 
+            keep parametrized type definitions and imply -x.
+            Default is to return only monomorphic type definitions
+    -xd 
+            debug mode implying -x
+    -i 
+            expand all 'inherit' statements
+    -if 
+            expand 'inherit' statements in records
+    -iv 
+            expand 'inherit' statements in sum types
+    -jsonschema <root type name>
+            translate the ATD file to JSON Schema.
+    -jsonschema-no-additional-properties 
+            emit a JSON Schema that doesn't tolerate extra fields on JSON
+            objects.
+    -jsonschema-version { draft-2019-09 | draft-2020-12 }
+            specify which version of the JSON Schema standard to target.
+            Default: latest supported version, which is currently
+            'draft-2020-12  '.
+    -ml <name>
+            output the ocaml code of the ATD abstract syntax tree
+    -html-doc 
+            replace directly <doc html="..."> by (*html ... *)
+            or replace <doc text="..."> by (*html ... *)
+            where the contents are formatted as HTML
+            using <p>, <code> and <pre>.
+            This is suitable input for "caml2html -ext html:cat"
+            which converts ATD files into HTML.
+    -strip NAME1[,NAME2,...]
+            remove all annotations of the form <NAME1 ...>,
+            <NAME2 ...>, etc.
+    -strip-all 
+            remove all annotations
+    -version 
+            print the version of atd and exit
+    -help  Display this list of options
+    --help  Display this list of options
 
 ATD language
 ------------

--- a/doc/atd-language-reference.rst
+++ b/doc/atd-language-reference.rst
@@ -244,45 +244,48 @@ of ``atdcat -help``:
 
 ::
 
-  Usage: atdcat FILE
-    -o <path>
-            write to this file instead of stdout
-    -x 
-            make type expressions monomorphic
-    -xk 
-            keep parametrized type definitions and imply -x.
-            Default is to return only monomorphic type definitions
-    -xd 
-            debug mode implying -x
-    -i 
-            expand all `inherit' statements
-    -if 
-            expand `inherit' statements in records
-    -iv 
-            expand `inherit' statements in sum types
-    -jsonschema <root type name>
-            translate the ATD file to JSON Schema.
-    -no-additional-properties 
-            emit a JSON Schema that doesn't tolerate extra fields on JSON
-            objects.
-    -ml <name>
-            output the ocaml code of the ATD abstract syntax tree
-    -html-doc 
-            replace directly <doc html="..."> by (*html ... *)
-            or replace <doc text="..."> by (*html ... *)
-            where the contents are formatted as HTML
-            using <p>, <code> and <pre>.
-            This is suitable input for "caml2html -ext html:cat"
-            which converts ATD files into HTML.
-    -strip NAME1[,NAME2,...]
-            remove all annotations of the form <NAME1 ...>,
-            <NAME2 ...>, etc.
-    -strip-all 
-            remove all annotations
-    -version 
-            print the version of atd and exit
-    -help  Display this list of options
-    --help  Display this list of options
+Usage: _build/install/default/bin/atdcat FILE
+  -o <path>
+          write to this file instead of stdout
+  -x 
+          make type expressions monomorphic
+  -xk 
+          keep parametrized type definitions and imply -x.
+          Default is to return only monomorphic type definitions
+  -xd 
+          debug mode implying -x
+  -i 
+          expand all 'inherit' statements
+  -if 
+          expand 'inherit' statements in records
+  -iv 
+          expand 'inherit' statements in sum types
+  -jsonschema <root type name>
+          translate the ATD file to JSON Schema.
+  -jsonschema-no-additional-properties 
+          emit a JSON Schema that doesn't tolerate extra fields on JSON
+          objects.
+  -jsonschema-version { draft-2019-09 | draft-2020-12 }
+          specify which version of the JSON Schema standard to target.
+          Default: latest supported version, which is currently 'draft-2020-12'.
+  -ml <name>
+          output the ocaml code of the ATD abstract syntax tree
+  -html-doc 
+          replace directly <doc html="..."> by (*html ... *)
+          or replace <doc text="..."> by (*html ... *)
+          where the contents are formatted as HTML
+          using <p>, <code> and <pre>.
+          This is suitable input for "caml2html -ext html:cat"
+          which converts ATD files into HTML.
+  -strip NAME1[,NAME2,...]
+          remove all annotations of the form <NAME1 ...>,
+          <NAME2 ...>, etc.
+  -strip-all 
+          remove all annotations
+  -version 
+          print the version of atd and exit
+  -help  Display this list of options
+  --help  Display this list of options
 
 ATD language
 ------------


### PR DESCRIPTION
This adds support for the previous version of JSON Schema, which changes how tuple types are specified. Atdcat takes an option to specify which version to target. The reason is that some tools still don't support the latest version "Draft 2020-12".

Other small things:
* a `title` field is generated that holds the name of the root type which otherwise gets lost. Note that the reason why we don't have all the types in the `definitions` section is that validators will assume the type of the input is the root definition. If there isn't one, any JSON object is accepted, which isn't great as validation goes.
* the command-line option `-no-additional-properties` is now `-jsonschema-no-additional-properties` (Gesundheit!) to [indicate that it's only relevant to JSON Schema output](https://github.com/ahrefs/atd/pull/293#discussion_r868808193).

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
