### PR TITLE
Add `{!type:…}` annot in docs to help odoc with ambiguities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Next release
+------------------
+
+* atdgen: use odoc syntax to disambiguate clashing names (#296).
+
 2.7.0 (2022-05-17)
 ------------------
 

--- a/atdgen/src/ob_emit.ml
+++ b/atdgen/src/ob_emit.ml
@@ -56,21 +56,21 @@ val %s_tag : Bi_io.node_tag
     bprintf buf "\
 val write_untagged_%s :%s
   Bi_outbuf.t -> %s -> unit
-  (** Output an untagged biniou value of type {!%s}. *)
+  (** Output an untagged biniou value of type {!type:%s}. *)
 
 " x.def_name writer_params full_name x.def_name;
 
     bprintf buf "\
 val write_%s :%s
   Bi_outbuf.t -> %s -> unit
-  (** Output a biniou value of type {!%s}. *)
+  (** Output a biniou value of type {!type:%s}. *)
 
 " x.def_name writer_params full_name x.def_name;
 
     bprintf buf "\
 val string_of_%s :%s
   ?len:int -> %s -> string
-  (** Serialize a value of type {!%s} into
+  (** Serialize a value of type {!type:%s} into
       a biniou string. *)
 
 " x.def_name writer_params full_name x.def_name;
@@ -81,21 +81,21 @@ val string_of_%s :%s
 val get_%s_reader :%s
   Bi_io.node_tag -> (Bi_inbuf.t -> %s)
   (** Return a function that reads an untagged
-      biniou value of type {!%s}. *)
+      biniou value of type {!type:%s}. *)
 
 " x.def_name reader_params full_name x.def_name;
 
     bprintf buf "\
 val read_%s :%s
   Bi_inbuf.t -> %s
-  (** Input a tagged biniou value of type {!%s}. *)
+  (** Input a tagged biniou value of type {!type:%s}. *)
 
 " x.def_name reader_params full_name x.def_name;
 
     bprintf buf "\
 val %s_of_string :%s
   ?pos:int -> string -> %s
-  (** Deserialize a biniou value of type {!%s}.
+  (** Deserialize a biniou value of type {!type:%s}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -59,7 +59,7 @@ let make_ocaml_json_intf ~with_create buf deref defs =
     bprintf buf "\
 val write_%s :%s
   Bi_outbuf.t -> %s -> unit
-  (** Output a JSON value of type {!%s}. *)
+  (** Output a JSON value of type {!type:%s}. *)
 
 "
       s writer_params
@@ -69,7 +69,7 @@ val write_%s :%s
     bprintf buf "\
 val string_of_%s :%s
   ?len:int -> %s -> string
-  (** Serialize a value of type {!%s}
+  (** Serialize a value of type {!type:%s}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -83,7 +83,7 @@ val string_of_%s :%s
     bprintf buf "\
 val read_%s :%s
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> %s
-  (** Input JSON data of type {!%s}. *)
+  (** Input JSON data of type {!type:%s}. *)
 
 "
       s reader_params
@@ -93,7 +93,7 @@ val read_%s :%s
     bprintf buf "\
 val %s_of_string :%s
   string -> %s
-  (** Deserialize JSON data of type {!%s}. *)
+  (** Deserialize JSON data of type {!type:%s}. *)
 
 "
       s reader_params

--- a/atdgen/src/ov_emit.ml
+++ b/atdgen/src/ov_emit.ml
@@ -37,7 +37,7 @@ let make_ocaml_validate_intf ~with_create buf deref defs =
       bprintf buf "\
 val validate_%s :%s
   Atdgen_runtime.Util.Validation.path -> %s -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!%s}. *)
+  (** Validate a value of type {!type:%s}. *)
 
 "
         s validator_params

--- a/atdgen/src/ox_emit.ml
+++ b/atdgen/src/ox_emit.ml
@@ -263,7 +263,7 @@ let make_record_creator deref x =
         sprintf "\
 val create_%s :%s
   unit -> %s
-  (** Create a record of type {!%s}. *)
+  (** Create a record of type {!type:%s}. *)
 
 "
           s (String.concat "" intf_params)

--- a/atdgen/test/test.expected.mli
+++ b/atdgen/test/test.expected.mli
@@ -174,15 +174,15 @@ val test_variant_tag : Bi_io.node_tag
 
 val write_untagged_test_variant :
   Bi_outbuf.t -> test_variant -> unit
-  (** Output an untagged biniou value of type {!test_variant}. *)
+  (** Output an untagged biniou value of type {!type:test_variant}. *)
 
 val write_test_variant :
   Bi_outbuf.t -> test_variant -> unit
-  (** Output a biniou value of type {!test_variant}. *)
+  (** Output a biniou value of type {!type:test_variant}. *)
 
 val string_of_test_variant :
   ?len:int -> test_variant -> string
-  (** Serialize a value of type {!test_variant} into
+  (** Serialize a value of type {!type:test_variant} into
       a biniou string. *)
 
 (* Readers for type test_variant *)
@@ -190,15 +190,15 @@ val string_of_test_variant :
 val get_test_variant_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> test_variant)
   (** Return a function that reads an untagged
-      biniou value of type {!test_variant}. *)
+      biniou value of type {!type:test_variant}. *)
 
 val read_test_variant :
   Bi_inbuf.t -> test_variant
-  (** Input a tagged biniou value of type {!test_variant}. *)
+  (** Input a tagged biniou value of type {!type:test_variant}. *)
 
 val test_variant_of_string :
   ?pos:int -> string -> test_variant
-  (** Deserialize a biniou value of type {!test_variant}.
+  (** Deserialize a biniou value of type {!type:test_variant}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -217,7 +217,7 @@ val write_untagged_poly :
   (Bi_outbuf.t -> 'y -> unit) ->
   (Bi_outbuf.t -> 'y -> unit) ->
   Bi_outbuf.t -> ('x, 'y) poly -> unit
-  (** Output an untagged biniou value of type {!poly}. *)
+  (** Output an untagged biniou value of type {!type:poly}. *)
 
 val write_poly :
   Bi_io.node_tag ->
@@ -227,7 +227,7 @@ val write_poly :
   (Bi_outbuf.t -> 'y -> unit) ->
   (Bi_outbuf.t -> 'y -> unit) ->
   Bi_outbuf.t -> ('x, 'y) poly -> unit
-  (** Output a biniou value of type {!poly}. *)
+  (** Output a biniou value of type {!type:poly}. *)
 
 val string_of_poly :
   Bi_io.node_tag ->
@@ -237,7 +237,7 @@ val string_of_poly :
   (Bi_outbuf.t -> 'y -> unit) ->
   (Bi_outbuf.t -> 'y -> unit) ->
   ?len:int -> ('x, 'y) poly -> string
-  (** Serialize a value of type {!poly} into
+  (** Serialize a value of type {!type:poly} into
       a biniou string. *)
 
 (* Readers for type poly *)
@@ -249,7 +249,7 @@ val get_poly_reader :
   (Bi_inbuf.t -> 'y) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> ('x, 'y) poly)
   (** Return a function that reads an untagged
-      biniou value of type {!poly}. *)
+      biniou value of type {!type:poly}. *)
 
 val read_poly :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'x)) ->
@@ -257,7 +257,7 @@ val read_poly :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'y)) ->
   (Bi_inbuf.t -> 'y) ->
   Bi_inbuf.t -> ('x, 'y) poly
-  (** Input a tagged biniou value of type {!poly}. *)
+  (** Input a tagged biniou value of type {!type:poly}. *)
 
 val poly_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'x)) ->
@@ -265,7 +265,7 @@ val poly_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'y)) ->
   (Bi_inbuf.t -> 'y) ->
   ?pos:int -> string -> ('x, 'y) poly
-  (** Deserialize a biniou value of type {!poly}.
+  (** Deserialize a biniou value of type {!type:poly}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -273,7 +273,7 @@ val create_poly :
   fst: 'x list ->
   snd: ('x, 'y) poly option ->
   unit -> ('x, 'y) poly
-  (** Create a record of type {!poly}. *)
+  (** Create a record of type {!type:poly}. *)
 
 
 (* Writers for type p' *)
@@ -287,21 +287,21 @@ val write_untagged_p' :
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a p' -> unit
-  (** Output an untagged biniou value of type {!p'}. *)
+  (** Output an untagged biniou value of type {!type:p'}. *)
 
 val write_p' :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a p' -> unit
-  (** Output a biniou value of type {!p'}. *)
+  (** Output a biniou value of type {!type:p'}. *)
 
 val string_of_p' :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a p' -> string
-  (** Serialize a value of type {!p'} into
+  (** Serialize a value of type {!type:p'} into
       a biniou string. *)
 
 (* Readers for type p' *)
@@ -311,19 +311,19 @@ val get_p'_reader :
   (Bi_inbuf.t -> 'a) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> 'a p')
   (** Return a function that reads an untagged
-      biniou value of type {!p'}. *)
+      biniou value of type {!type:p'}. *)
 
 val read_p' :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   Bi_inbuf.t -> 'a p'
-  (** Input a tagged biniou value of type {!p'}. *)
+  (** Input a tagged biniou value of type {!type:p'}. *)
 
 val p'_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   ?pos:int -> string -> 'a p'
-  (** Deserialize a biniou value of type {!p'}.
+  (** Deserialize a biniou value of type {!type:p'}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -336,15 +336,15 @@ val p_tag : Bi_io.node_tag
 
 val write_untagged_p :
   Bi_outbuf.t -> p -> unit
-  (** Output an untagged biniou value of type {!p}. *)
+  (** Output an untagged biniou value of type {!type:p}. *)
 
 val write_p :
   Bi_outbuf.t -> p -> unit
-  (** Output a biniou value of type {!p}. *)
+  (** Output a biniou value of type {!type:p}. *)
 
 val string_of_p :
   ?len:int -> p -> string
-  (** Serialize a value of type {!p} into
+  (** Serialize a value of type {!type:p} into
       a biniou string. *)
 
 (* Readers for type p *)
@@ -352,15 +352,15 @@ val string_of_p :
 val get_p_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> p)
   (** Return a function that reads an untagged
-      biniou value of type {!p}. *)
+      biniou value of type {!type:p}. *)
 
 val read_p :
   Bi_inbuf.t -> p
-  (** Input a tagged biniou value of type {!p}. *)
+  (** Input a tagged biniou value of type {!type:p}. *)
 
 val p_of_string :
   ?pos:int -> string -> p
-  (** Deserialize a biniou value of type {!p}.
+  (** Deserialize a biniou value of type {!type:p}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -373,15 +373,15 @@ val r_tag : Bi_io.node_tag
 
 val write_untagged_r :
   Bi_outbuf.t -> r -> unit
-  (** Output an untagged biniou value of type {!r}. *)
+  (** Output an untagged biniou value of type {!type:r}. *)
 
 val write_r :
   Bi_outbuf.t -> r -> unit
-  (** Output a biniou value of type {!r}. *)
+  (** Output a biniou value of type {!type:r}. *)
 
 val string_of_r :
   ?len:int -> r -> string
-  (** Serialize a value of type {!r} into
+  (** Serialize a value of type {!type:r} into
       a biniou string. *)
 
 (* Readers for type r *)
@@ -389,15 +389,15 @@ val string_of_r :
 val get_r_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> r)
   (** Return a function that reads an untagged
-      biniou value of type {!r}. *)
+      biniou value of type {!type:r}. *)
 
 val read_r :
   Bi_inbuf.t -> r
-  (** Input a tagged biniou value of type {!r}. *)
+  (** Input a tagged biniou value of type {!type:r}. *)
 
 val r_of_string :
   ?pos:int -> string -> r
-  (** Deserialize a biniou value of type {!r}.
+  (** Deserialize a biniou value of type {!type:r}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -406,7 +406,7 @@ val create_r :
   b: bool ->
   c: p ->
   unit -> r
-  (** Create a record of type {!r}. *)
+  (** Create a record of type {!type:r}. *)
 
 
 (* Writers for type validated_string_check *)
@@ -417,15 +417,15 @@ val validated_string_check_tag : Bi_io.node_tag
 
 val write_untagged_validated_string_check :
   Bi_outbuf.t -> validated_string_check -> unit
-  (** Output an untagged biniou value of type {!validated_string_check}. *)
+  (** Output an untagged biniou value of type {!type:validated_string_check}. *)
 
 val write_validated_string_check :
   Bi_outbuf.t -> validated_string_check -> unit
-  (** Output a biniou value of type {!validated_string_check}. *)
+  (** Output a biniou value of type {!type:validated_string_check}. *)
 
 val string_of_validated_string_check :
   ?len:int -> validated_string_check -> string
-  (** Serialize a value of type {!validated_string_check} into
+  (** Serialize a value of type {!type:validated_string_check} into
       a biniou string. *)
 
 (* Readers for type validated_string_check *)
@@ -433,15 +433,15 @@ val string_of_validated_string_check :
 val get_validated_string_check_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> validated_string_check)
   (** Return a function that reads an untagged
-      biniou value of type {!validated_string_check}. *)
+      biniou value of type {!type:validated_string_check}. *)
 
 val read_validated_string_check :
   Bi_inbuf.t -> validated_string_check
-  (** Input a tagged biniou value of type {!validated_string_check}. *)
+  (** Input a tagged biniou value of type {!type:validated_string_check}. *)
 
 val validated_string_check_of_string :
   ?pos:int -> string -> validated_string_check
-  (** Deserialize a biniou value of type {!validated_string_check}.
+  (** Deserialize a biniou value of type {!type:validated_string_check}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -454,15 +454,15 @@ val validate_me_tag : Bi_io.node_tag
 
 val write_untagged_validate_me :
   Bi_outbuf.t -> validate_me -> unit
-  (** Output an untagged biniou value of type {!validate_me}. *)
+  (** Output an untagged biniou value of type {!type:validate_me}. *)
 
 val write_validate_me :
   Bi_outbuf.t -> validate_me -> unit
-  (** Output a biniou value of type {!validate_me}. *)
+  (** Output a biniou value of type {!type:validate_me}. *)
 
 val string_of_validate_me :
   ?len:int -> validate_me -> string
-  (** Serialize a value of type {!validate_me} into
+  (** Serialize a value of type {!type:validate_me} into
       a biniou string. *)
 
 (* Readers for type validate_me *)
@@ -470,15 +470,15 @@ val string_of_validate_me :
 val get_validate_me_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> validate_me)
   (** Return a function that reads an untagged
-      biniou value of type {!validate_me}. *)
+      biniou value of type {!type:validate_me}. *)
 
 val read_validate_me :
   Bi_inbuf.t -> validate_me
-  (** Input a tagged biniou value of type {!validate_me}. *)
+  (** Input a tagged biniou value of type {!type:validate_me}. *)
 
 val validate_me_of_string :
   ?pos:int -> string -> validate_me
-  (** Deserialize a biniou value of type {!validate_me}.
+  (** Deserialize a biniou value of type {!type:validate_me}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -491,15 +491,15 @@ val val1_tag : Bi_io.node_tag
 
 val write_untagged_val1 :
   Bi_outbuf.t -> val1 -> unit
-  (** Output an untagged biniou value of type {!val1}. *)
+  (** Output an untagged biniou value of type {!type:val1}. *)
 
 val write_val1 :
   Bi_outbuf.t -> val1 -> unit
-  (** Output a biniou value of type {!val1}. *)
+  (** Output a biniou value of type {!type:val1}. *)
 
 val string_of_val1 :
   ?len:int -> val1 -> string
-  (** Serialize a value of type {!val1} into
+  (** Serialize a value of type {!type:val1} into
       a biniou string. *)
 
 (* Readers for type val1 *)
@@ -507,22 +507,22 @@ val string_of_val1 :
 val get_val1_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> val1)
   (** Return a function that reads an untagged
-      biniou value of type {!val1}. *)
+      biniou value of type {!type:val1}. *)
 
 val read_val1 :
   Bi_inbuf.t -> val1
-  (** Input a tagged biniou value of type {!val1}. *)
+  (** Input a tagged biniou value of type {!type:val1}. *)
 
 val val1_of_string :
   ?pos:int -> string -> val1
-  (** Deserialize a biniou value of type {!val1}.
+  (** Deserialize a biniou value of type {!type:val1}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
 val create_val1 :
   val1_x: int ->
   unit -> val1
-  (** Create a record of type {!val1}. *)
+  (** Create a record of type {!type:val1}. *)
 
 
 (* Writers for type val2 *)
@@ -533,15 +533,15 @@ val val2_tag : Bi_io.node_tag
 
 val write_untagged_val2 :
   Bi_outbuf.t -> val2 -> unit
-  (** Output an untagged biniou value of type {!val2}. *)
+  (** Output an untagged biniou value of type {!type:val2}. *)
 
 val write_val2 :
   Bi_outbuf.t -> val2 -> unit
-  (** Output a biniou value of type {!val2}. *)
+  (** Output a biniou value of type {!type:val2}. *)
 
 val string_of_val2 :
   ?len:int -> val2 -> string
-  (** Serialize a value of type {!val2} into
+  (** Serialize a value of type {!type:val2} into
       a biniou string. *)
 
 (* Readers for type val2 *)
@@ -549,15 +549,15 @@ val string_of_val2 :
 val get_val2_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> val2)
   (** Return a function that reads an untagged
-      biniou value of type {!val2}. *)
+      biniou value of type {!type:val2}. *)
 
 val read_val2 :
   Bi_inbuf.t -> val2
-  (** Input a tagged biniou value of type {!val2}. *)
+  (** Input a tagged biniou value of type {!type:val2}. *)
 
 val val2_of_string :
   ?pos:int -> string -> val2
-  (** Deserialize a biniou value of type {!val2}.
+  (** Deserialize a biniou value of type {!type:val2}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -565,7 +565,7 @@ val create_val2 :
   val2_x: val1 ->
   ?val2_y: val1 ->
   unit -> val2
-  (** Create a record of type {!val2}. *)
+  (** Create a record of type {!type:val2}. *)
 
 
 (* Writers for type unixtime_list *)
@@ -576,15 +576,15 @@ val unixtime_list_tag : Bi_io.node_tag
 
 val write_untagged_unixtime_list :
   Bi_outbuf.t -> unixtime_list -> unit
-  (** Output an untagged biniou value of type {!unixtime_list}. *)
+  (** Output an untagged biniou value of type {!type:unixtime_list}. *)
 
 val write_unixtime_list :
   Bi_outbuf.t -> unixtime_list -> unit
-  (** Output a biniou value of type {!unixtime_list}. *)
+  (** Output a biniou value of type {!type:unixtime_list}. *)
 
 val string_of_unixtime_list :
   ?len:int -> unixtime_list -> string
-  (** Serialize a value of type {!unixtime_list} into
+  (** Serialize a value of type {!type:unixtime_list} into
       a biniou string. *)
 
 (* Readers for type unixtime_list *)
@@ -592,15 +592,15 @@ val string_of_unixtime_list :
 val get_unixtime_list_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> unixtime_list)
   (** Return a function that reads an untagged
-      biniou value of type {!unixtime_list}. *)
+      biniou value of type {!type:unixtime_list}. *)
 
 val read_unixtime_list :
   Bi_inbuf.t -> unixtime_list
-  (** Input a tagged biniou value of type {!unixtime_list}. *)
+  (** Input a tagged biniou value of type {!type:unixtime_list}. *)
 
 val unixtime_list_of_string :
   ?pos:int -> string -> unixtime_list
-  (** Deserialize a biniou value of type {!unixtime_list}.
+  (** Deserialize a biniou value of type {!type:unixtime_list}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -613,15 +613,15 @@ val date_tag : Bi_io.node_tag
 
 val write_untagged_date :
   Bi_outbuf.t -> date -> unit
-  (** Output an untagged biniou value of type {!date}. *)
+  (** Output an untagged biniou value of type {!type:date}. *)
 
 val write_date :
   Bi_outbuf.t -> date -> unit
-  (** Output a biniou value of type {!date}. *)
+  (** Output a biniou value of type {!type:date}. *)
 
 val string_of_date :
   ?len:int -> date -> string
-  (** Serialize a value of type {!date} into
+  (** Serialize a value of type {!type:date} into
       a biniou string. *)
 
 (* Readers for type date *)
@@ -629,15 +629,15 @@ val string_of_date :
 val get_date_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> date)
   (** Return a function that reads an untagged
-      biniou value of type {!date}. *)
+      biniou value of type {!type:date}. *)
 
 val read_date :
   Bi_inbuf.t -> date
-  (** Input a tagged biniou value of type {!date}. *)
+  (** Input a tagged biniou value of type {!type:date}. *)
 
 val date_of_string :
   ?pos:int -> string -> date
-  (** Deserialize a biniou value of type {!date}.
+  (** Deserialize a biniou value of type {!type:date}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -650,15 +650,15 @@ val mixed_record_tag : Bi_io.node_tag
 
 val write_untagged_mixed_record :
   Bi_outbuf.t -> mixed_record -> unit
-  (** Output an untagged biniou value of type {!mixed_record}. *)
+  (** Output an untagged biniou value of type {!type:mixed_record}. *)
 
 val write_mixed_record :
   Bi_outbuf.t -> mixed_record -> unit
-  (** Output a biniou value of type {!mixed_record}. *)
+  (** Output a biniou value of type {!type:mixed_record}. *)
 
 val string_of_mixed_record :
   ?len:int -> mixed_record -> string
-  (** Serialize a value of type {!mixed_record} into
+  (** Serialize a value of type {!type:mixed_record} into
       a biniou string. *)
 
 (* Readers for type mixed_record *)
@@ -666,15 +666,15 @@ val string_of_mixed_record :
 val get_mixed_record_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> mixed_record)
   (** Return a function that reads an untagged
-      biniou value of type {!mixed_record}. *)
+      biniou value of type {!type:mixed_record}. *)
 
 val read_mixed_record :
   Bi_inbuf.t -> mixed_record
-  (** Input a tagged biniou value of type {!mixed_record}. *)
+  (** Input a tagged biniou value of type {!type:mixed_record}. *)
 
 val mixed_record_of_string :
   ?pos:int -> string -> mixed_record
-  (** Deserialize a biniou value of type {!mixed_record}.
+  (** Deserialize a biniou value of type {!type:mixed_record}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -695,7 +695,7 @@ val create_mixed_record :
   field13: string option list ->
   field14: date ->
   unit -> mixed_record
-  (** Create a record of type {!mixed_record}. *)
+  (** Create a record of type {!type:mixed_record}. *)
 
 
 (* Writers for type mixed *)
@@ -706,15 +706,15 @@ val mixed_tag : Bi_io.node_tag
 
 val write_untagged_mixed :
   Bi_outbuf.t -> mixed -> unit
-  (** Output an untagged biniou value of type {!mixed}. *)
+  (** Output an untagged biniou value of type {!type:mixed}. *)
 
 val write_mixed :
   Bi_outbuf.t -> mixed -> unit
-  (** Output a biniou value of type {!mixed}. *)
+  (** Output a biniou value of type {!type:mixed}. *)
 
 val string_of_mixed :
   ?len:int -> mixed -> string
-  (** Serialize a value of type {!mixed} into
+  (** Serialize a value of type {!type:mixed} into
       a biniou string. *)
 
 (* Readers for type mixed *)
@@ -722,15 +722,15 @@ val string_of_mixed :
 val get_mixed_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> mixed)
   (** Return a function that reads an untagged
-      biniou value of type {!mixed}. *)
+      biniou value of type {!type:mixed}. *)
 
 val read_mixed :
   Bi_inbuf.t -> mixed
-  (** Input a tagged biniou value of type {!mixed}. *)
+  (** Input a tagged biniou value of type {!type:mixed}. *)
 
 val mixed_of_string :
   ?pos:int -> string -> mixed
-  (** Deserialize a biniou value of type {!mixed}.
+  (** Deserialize a biniou value of type {!type:mixed}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -743,15 +743,15 @@ val test_tag : Bi_io.node_tag
 
 val write_untagged_test :
   Bi_outbuf.t -> test -> unit
-  (** Output an untagged biniou value of type {!test}. *)
+  (** Output an untagged biniou value of type {!type:test}. *)
 
 val write_test :
   Bi_outbuf.t -> test -> unit
-  (** Output a biniou value of type {!test}. *)
+  (** Output a biniou value of type {!type:test}. *)
 
 val string_of_test :
   ?len:int -> test -> string
-  (** Serialize a value of type {!test} into
+  (** Serialize a value of type {!type:test} into
       a biniou string. *)
 
 (* Readers for type test *)
@@ -759,15 +759,15 @@ val string_of_test :
 val get_test_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> test)
   (** Return a function that reads an untagged
-      biniou value of type {!test}. *)
+      biniou value of type {!type:test}. *)
 
 val read_test :
   Bi_inbuf.t -> test
-  (** Input a tagged biniou value of type {!test}. *)
+  (** Input a tagged biniou value of type {!type:test}. *)
 
 val test_of_string :
   ?pos:int -> string -> test
-  (** Deserialize a biniou value of type {!test}.
+  (** Deserialize a biniou value of type {!type:test}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -778,7 +778,7 @@ val create_test :
   x3: mixed_record list ->
   x4: Int64.t ->
   unit -> test
-  (** Create a record of type {!test}. *)
+  (** Create a record of type {!type:test}. *)
 
 
 (* Writers for type tup *)
@@ -789,15 +789,15 @@ val tup_tag : Bi_io.node_tag
 
 val write_untagged_tup :
   Bi_outbuf.t -> tup -> unit
-  (** Output an untagged biniou value of type {!tup}. *)
+  (** Output an untagged biniou value of type {!type:tup}. *)
 
 val write_tup :
   Bi_outbuf.t -> tup -> unit
-  (** Output a biniou value of type {!tup}. *)
+  (** Output a biniou value of type {!type:tup}. *)
 
 val string_of_tup :
   ?len:int -> tup -> string
-  (** Serialize a value of type {!tup} into
+  (** Serialize a value of type {!type:tup} into
       a biniou string. *)
 
 (* Readers for type tup *)
@@ -805,15 +805,15 @@ val string_of_tup :
 val get_tup_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> tup)
   (** Return a function that reads an untagged
-      biniou value of type {!tup}. *)
+      biniou value of type {!type:tup}. *)
 
 val read_tup :
   Bi_inbuf.t -> tup
-  (** Input a tagged biniou value of type {!tup}. *)
+  (** Input a tagged biniou value of type {!type:tup}. *)
 
 val tup_of_string :
   ?pos:int -> string -> tup
-  (** Deserialize a biniou value of type {!tup}.
+  (** Deserialize a biniou value of type {!type:tup}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -826,15 +826,15 @@ val test_field_prefix_tag : Bi_io.node_tag
 
 val write_untagged_test_field_prefix :
   Bi_outbuf.t -> test_field_prefix -> unit
-  (** Output an untagged biniou value of type {!test_field_prefix}. *)
+  (** Output an untagged biniou value of type {!type:test_field_prefix}. *)
 
 val write_test_field_prefix :
   Bi_outbuf.t -> test_field_prefix -> unit
-  (** Output a biniou value of type {!test_field_prefix}. *)
+  (** Output a biniou value of type {!type:test_field_prefix}. *)
 
 val string_of_test_field_prefix :
   ?len:int -> test_field_prefix -> string
-  (** Serialize a value of type {!test_field_prefix} into
+  (** Serialize a value of type {!type:test_field_prefix} into
       a biniou string. *)
 
 (* Readers for type test_field_prefix *)
@@ -842,15 +842,15 @@ val string_of_test_field_prefix :
 val get_test_field_prefix_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> test_field_prefix)
   (** Return a function that reads an untagged
-      biniou value of type {!test_field_prefix}. *)
+      biniou value of type {!type:test_field_prefix}. *)
 
 val read_test_field_prefix :
   Bi_inbuf.t -> test_field_prefix
-  (** Input a tagged biniou value of type {!test_field_prefix}. *)
+  (** Input a tagged biniou value of type {!type:test_field_prefix}. *)
 
 val test_field_prefix_of_string :
   ?pos:int -> string -> test_field_prefix
-  (** Deserialize a biniou value of type {!test_field_prefix}.
+  (** Deserialize a biniou value of type {!type:test_field_prefix}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -858,7 +858,7 @@ val create_test_field_prefix :
   theprefix_hello: bool ->
   theprefix_world: int ->
   unit -> test_field_prefix
-  (** Create a record of type {!test_field_prefix}. *)
+  (** Create a record of type {!type:test_field_prefix}. *)
 
 
 (* Writers for type star_rating *)
@@ -869,15 +869,15 @@ val star_rating_tag : Bi_io.node_tag
 
 val write_untagged_star_rating :
   Bi_outbuf.t -> star_rating -> unit
-  (** Output an untagged biniou value of type {!star_rating}. *)
+  (** Output an untagged biniou value of type {!type:star_rating}. *)
 
 val write_star_rating :
   Bi_outbuf.t -> star_rating -> unit
-  (** Output a biniou value of type {!star_rating}. *)
+  (** Output a biniou value of type {!type:star_rating}. *)
 
 val string_of_star_rating :
   ?len:int -> star_rating -> string
-  (** Serialize a value of type {!star_rating} into
+  (** Serialize a value of type {!type:star_rating} into
       a biniou string. *)
 
 (* Readers for type star_rating *)
@@ -885,15 +885,15 @@ val string_of_star_rating :
 val get_star_rating_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> star_rating)
   (** Return a function that reads an untagged
-      biniou value of type {!star_rating}. *)
+      biniou value of type {!type:star_rating}. *)
 
 val read_star_rating :
   Bi_inbuf.t -> star_rating
-  (** Input a tagged biniou value of type {!star_rating}. *)
+  (** Input a tagged biniou value of type {!type:star_rating}. *)
 
 val star_rating_of_string :
   ?pos:int -> string -> star_rating
-  (** Deserialize a biniou value of type {!star_rating}.
+  (** Deserialize a biniou value of type {!type:star_rating}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -909,21 +909,21 @@ val write_untagged_generic :
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a generic -> unit
-  (** Output an untagged biniou value of type {!generic}. *)
+  (** Output an untagged biniou value of type {!type:generic}. *)
 
 val write_generic :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a generic -> unit
-  (** Output a biniou value of type {!generic}. *)
+  (** Output a biniou value of type {!type:generic}. *)
 
 val string_of_generic :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a generic -> string
-  (** Serialize a value of type {!generic} into
+  (** Serialize a value of type {!type:generic} into
       a biniou string. *)
 
 (* Readers for type generic *)
@@ -933,26 +933,26 @@ val get_generic_reader :
   (Bi_inbuf.t -> 'a) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> 'a generic)
   (** Return a function that reads an untagged
-      biniou value of type {!generic}. *)
+      biniou value of type {!type:generic}. *)
 
 val read_generic :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   Bi_inbuf.t -> 'a generic
-  (** Input a tagged biniou value of type {!generic}. *)
+  (** Input a tagged biniou value of type {!type:generic}. *)
 
 val generic_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   ?pos:int -> string -> 'a generic
-  (** Deserialize a biniou value of type {!generic}.
+  (** Deserialize a biniou value of type {!type:generic}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
 val create_generic :
   x294623: int ->
   unit -> 'a generic
-  (** Create a record of type {!generic}. *)
+  (** Create a record of type {!type:generic}. *)
 
 
 (* Writers for type specialized *)
@@ -963,15 +963,15 @@ val specialized_tag : Bi_io.node_tag
 
 val write_untagged_specialized :
   Bi_outbuf.t -> specialized -> unit
-  (** Output an untagged biniou value of type {!specialized}. *)
+  (** Output an untagged biniou value of type {!type:specialized}. *)
 
 val write_specialized :
   Bi_outbuf.t -> specialized -> unit
-  (** Output a biniou value of type {!specialized}. *)
+  (** Output a biniou value of type {!type:specialized}. *)
 
 val string_of_specialized :
   ?len:int -> specialized -> string
-  (** Serialize a value of type {!specialized} into
+  (** Serialize a value of type {!type:specialized} into
       a biniou string. *)
 
 (* Readers for type specialized *)
@@ -979,15 +979,15 @@ val string_of_specialized :
 val get_specialized_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> specialized)
   (** Return a function that reads an untagged
-      biniou value of type {!specialized}. *)
+      biniou value of type {!type:specialized}. *)
 
 val read_specialized :
   Bi_inbuf.t -> specialized
-  (** Input a tagged biniou value of type {!specialized}. *)
+  (** Input a tagged biniou value of type {!type:specialized}. *)
 
 val specialized_of_string :
   ?pos:int -> string -> specialized
-  (** Deserialize a biniou value of type {!specialized}.
+  (** Deserialize a biniou value of type {!type:specialized}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1000,15 +1000,15 @@ val some_record_tag : Bi_io.node_tag
 
 val write_untagged_some_record :
   Bi_outbuf.t -> some_record -> unit
-  (** Output an untagged biniou value of type {!some_record}. *)
+  (** Output an untagged biniou value of type {!type:some_record}. *)
 
 val write_some_record :
   Bi_outbuf.t -> some_record -> unit
-  (** Output a biniou value of type {!some_record}. *)
+  (** Output a biniou value of type {!type:some_record}. *)
 
 val string_of_some_record :
   ?len:int -> some_record -> string
-  (** Serialize a value of type {!some_record} into
+  (** Serialize a value of type {!type:some_record} into
       a biniou string. *)
 
 (* Readers for type some_record *)
@@ -1016,22 +1016,22 @@ val string_of_some_record :
 val get_some_record_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> some_record)
   (** Return a function that reads an untagged
-      biniou value of type {!some_record}. *)
+      biniou value of type {!type:some_record}. *)
 
 val read_some_record :
   Bi_inbuf.t -> some_record
-  (** Input a tagged biniou value of type {!some_record}. *)
+  (** Input a tagged biniou value of type {!type:some_record}. *)
 
 val some_record_of_string :
   ?pos:int -> string -> some_record
-  (** Deserialize a biniou value of type {!some_record}.
+  (** Deserialize a biniou value of type {!type:some_record}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
 val create_some_record :
   some_field: int ->
   unit -> some_record
-  (** Create a record of type {!some_record}. *)
+  (** Create a record of type {!type:some_record}. *)
 
 
 (* Writers for type precision *)
@@ -1042,15 +1042,15 @@ val precision_tag : Bi_io.node_tag
 
 val write_untagged_precision :
   Bi_outbuf.t -> precision -> unit
-  (** Output an untagged biniou value of type {!precision}. *)
+  (** Output an untagged biniou value of type {!type:precision}. *)
 
 val write_precision :
   Bi_outbuf.t -> precision -> unit
-  (** Output a biniou value of type {!precision}. *)
+  (** Output a biniou value of type {!type:precision}. *)
 
 val string_of_precision :
   ?len:int -> precision -> string
-  (** Serialize a value of type {!precision} into
+  (** Serialize a value of type {!type:precision} into
       a biniou string. *)
 
 (* Readers for type precision *)
@@ -1058,15 +1058,15 @@ val string_of_precision :
 val get_precision_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> precision)
   (** Return a function that reads an untagged
-      biniou value of type {!precision}. *)
+      biniou value of type {!type:precision}. *)
 
 val read_precision :
   Bi_inbuf.t -> precision
-  (** Input a tagged biniou value of type {!precision}. *)
+  (** Input a tagged biniou value of type {!type:precision}. *)
 
 val precision_of_string :
   ?pos:int -> string -> precision
-  (** Deserialize a biniou value of type {!precision}.
+  (** Deserialize a biniou value of type {!type:precision}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1075,7 +1075,7 @@ val create_precision :
   small_2: float ->
   large_2: float ->
   unit -> precision
-  (** Create a record of type {!precision}. *)
+  (** Create a record of type {!type:precision}. *)
 
 
 (* Writers for type p'' *)
@@ -1086,15 +1086,15 @@ val p''_tag : Bi_io.node_tag
 
 val write_untagged_p'' :
   Bi_outbuf.t -> p'' -> unit
-  (** Output an untagged biniou value of type {!p''}. *)
+  (** Output an untagged biniou value of type {!type:p''}. *)
 
 val write_p'' :
   Bi_outbuf.t -> p'' -> unit
-  (** Output a biniou value of type {!p''}. *)
+  (** Output a biniou value of type {!type:p''}. *)
 
 val string_of_p'' :
   ?len:int -> p'' -> string
-  (** Serialize a value of type {!p''} into
+  (** Serialize a value of type {!type:p''} into
       a biniou string. *)
 
 (* Readers for type p'' *)
@@ -1102,15 +1102,15 @@ val string_of_p'' :
 val get_p''_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> p'')
   (** Return a function that reads an untagged
-      biniou value of type {!p''}. *)
+      biniou value of type {!type:p''}. *)
 
 val read_p'' :
   Bi_inbuf.t -> p''
-  (** Input a tagged biniou value of type {!p''}. *)
+  (** Input a tagged biniou value of type {!type:p''}. *)
 
 val p''_of_string :
   ?pos:int -> string -> p''
-  (** Deserialize a biniou value of type {!p''}.
+  (** Deserialize a biniou value of type {!type:p''}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1123,15 +1123,15 @@ val option_validation_tag : Bi_io.node_tag
 
 val write_untagged_option_validation :
   Bi_outbuf.t -> option_validation -> unit
-  (** Output an untagged biniou value of type {!option_validation}. *)
+  (** Output an untagged biniou value of type {!type:option_validation}. *)
 
 val write_option_validation :
   Bi_outbuf.t -> option_validation -> unit
-  (** Output a biniou value of type {!option_validation}. *)
+  (** Output a biniou value of type {!type:option_validation}. *)
 
 val string_of_option_validation :
   ?len:int -> option_validation -> string
-  (** Serialize a value of type {!option_validation} into
+  (** Serialize a value of type {!type:option_validation} into
       a biniou string. *)
 
 (* Readers for type option_validation *)
@@ -1139,15 +1139,15 @@ val string_of_option_validation :
 val get_option_validation_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> option_validation)
   (** Return a function that reads an untagged
-      biniou value of type {!option_validation}. *)
+      biniou value of type {!type:option_validation}. *)
 
 val read_option_validation :
   Bi_inbuf.t -> option_validation
-  (** Input a tagged biniou value of type {!option_validation}. *)
+  (** Input a tagged biniou value of type {!type:option_validation}. *)
 
 val option_validation_of_string :
   ?pos:int -> string -> option_validation
-  (** Deserialize a biniou value of type {!option_validation}.
+  (** Deserialize a biniou value of type {!type:option_validation}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1160,15 +1160,15 @@ val no_real_wrap_tag : Bi_io.node_tag
 
 val write_untagged_no_real_wrap :
   Bi_outbuf.t -> no_real_wrap -> unit
-  (** Output an untagged biniou value of type {!no_real_wrap}. *)
+  (** Output an untagged biniou value of type {!type:no_real_wrap}. *)
 
 val write_no_real_wrap :
   Bi_outbuf.t -> no_real_wrap -> unit
-  (** Output a biniou value of type {!no_real_wrap}. *)
+  (** Output a biniou value of type {!type:no_real_wrap}. *)
 
 val string_of_no_real_wrap :
   ?len:int -> no_real_wrap -> string
-  (** Serialize a value of type {!no_real_wrap} into
+  (** Serialize a value of type {!type:no_real_wrap} into
       a biniou string. *)
 
 (* Readers for type no_real_wrap *)
@@ -1176,15 +1176,15 @@ val string_of_no_real_wrap :
 val get_no_real_wrap_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> no_real_wrap)
   (** Return a function that reads an untagged
-      biniou value of type {!no_real_wrap}. *)
+      biniou value of type {!type:no_real_wrap}. *)
 
 val read_no_real_wrap :
   Bi_inbuf.t -> no_real_wrap
-  (** Input a tagged biniou value of type {!no_real_wrap}. *)
+  (** Input a tagged biniou value of type {!type:no_real_wrap}. *)
 
 val no_real_wrap_of_string :
   ?pos:int -> string -> no_real_wrap
-  (** Deserialize a biniou value of type {!no_real_wrap}.
+  (** Deserialize a biniou value of type {!type:no_real_wrap}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1197,15 +1197,15 @@ val natural_tag : Bi_io.node_tag
 
 val write_untagged_natural :
   Bi_outbuf.t -> natural -> unit
-  (** Output an untagged biniou value of type {!natural}. *)
+  (** Output an untagged biniou value of type {!type:natural}. *)
 
 val write_natural :
   Bi_outbuf.t -> natural -> unit
-  (** Output a biniou value of type {!natural}. *)
+  (** Output a biniou value of type {!type:natural}. *)
 
 val string_of_natural :
   ?len:int -> natural -> string
-  (** Serialize a value of type {!natural} into
+  (** Serialize a value of type {!type:natural} into
       a biniou string. *)
 
 (* Readers for type natural *)
@@ -1213,15 +1213,15 @@ val string_of_natural :
 val get_natural_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> natural)
   (** Return a function that reads an untagged
-      biniou value of type {!natural}. *)
+      biniou value of type {!type:natural}. *)
 
 val read_natural :
   Bi_inbuf.t -> natural
-  (** Input a tagged biniou value of type {!natural}. *)
+  (** Input a tagged biniou value of type {!type:natural}. *)
 
 val natural_of_string :
   ?pos:int -> string -> natural
-  (** Deserialize a biniou value of type {!natural}.
+  (** Deserialize a biniou value of type {!type:natural}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1234,15 +1234,15 @@ val id_tag : Bi_io.node_tag
 
 val write_untagged_id :
   Bi_outbuf.t -> id -> unit
-  (** Output an untagged biniou value of type {!id}. *)
+  (** Output an untagged biniou value of type {!type:id}. *)
 
 val write_id :
   Bi_outbuf.t -> id -> unit
-  (** Output a biniou value of type {!id}. *)
+  (** Output a biniou value of type {!type:id}. *)
 
 val string_of_id :
   ?len:int -> id -> string
-  (** Serialize a value of type {!id} into
+  (** Serialize a value of type {!type:id} into
       a biniou string. *)
 
 (* Readers for type id *)
@@ -1250,15 +1250,15 @@ val string_of_id :
 val get_id_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> id)
   (** Return a function that reads an untagged
-      biniou value of type {!id}. *)
+      biniou value of type {!type:id}. *)
 
 val read_id :
   Bi_inbuf.t -> id
-  (** Input a tagged biniou value of type {!id}. *)
+  (** Input a tagged biniou value of type {!type:id}. *)
 
 val id_of_string :
   ?pos:int -> string -> id
-  (** Deserialize a biniou value of type {!id}.
+  (** Deserialize a biniou value of type {!type:id}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1271,15 +1271,15 @@ val json_map_tag : Bi_io.node_tag
 
 val write_untagged_json_map :
   Bi_outbuf.t -> json_map -> unit
-  (** Output an untagged biniou value of type {!json_map}. *)
+  (** Output an untagged biniou value of type {!type:json_map}. *)
 
 val write_json_map :
   Bi_outbuf.t -> json_map -> unit
-  (** Output a biniou value of type {!json_map}. *)
+  (** Output a biniou value of type {!type:json_map}. *)
 
 val string_of_json_map :
   ?len:int -> json_map -> string
-  (** Serialize a value of type {!json_map} into
+  (** Serialize a value of type {!type:json_map} into
       a biniou string. *)
 
 (* Readers for type json_map *)
@@ -1287,15 +1287,15 @@ val string_of_json_map :
 val get_json_map_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> json_map)
   (** Return a function that reads an untagged
-      biniou value of type {!json_map}. *)
+      biniou value of type {!type:json_map}. *)
 
 val read_json_map :
   Bi_inbuf.t -> json_map
-  (** Input a tagged biniou value of type {!json_map}. *)
+  (** Input a tagged biniou value of type {!type:json_map}. *)
 
 val json_map_of_string :
   ?pos:int -> string -> json_map
-  (** Deserialize a biniou value of type {!json_map}.
+  (** Deserialize a biniou value of type {!type:json_map}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1308,15 +1308,15 @@ val intopt_tag : Bi_io.node_tag
 
 val write_untagged_intopt :
   Bi_outbuf.t -> intopt -> unit
-  (** Output an untagged biniou value of type {!intopt}. *)
+  (** Output an untagged biniou value of type {!type:intopt}. *)
 
 val write_intopt :
   Bi_outbuf.t -> intopt -> unit
-  (** Output a biniou value of type {!intopt}. *)
+  (** Output a biniou value of type {!type:intopt}. *)
 
 val string_of_intopt :
   ?len:int -> intopt -> string
-  (** Serialize a value of type {!intopt} into
+  (** Serialize a value of type {!type:intopt} into
       a biniou string. *)
 
 (* Readers for type intopt *)
@@ -1324,15 +1324,15 @@ val string_of_intopt :
 val get_intopt_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> intopt)
   (** Return a function that reads an untagged
-      biniou value of type {!intopt}. *)
+      biniou value of type {!type:intopt}. *)
 
 val read_intopt :
   Bi_inbuf.t -> intopt
-  (** Input a tagged biniou value of type {!intopt}. *)
+  (** Input a tagged biniou value of type {!type:intopt}. *)
 
 val intopt_of_string :
   ?pos:int -> string -> intopt
-  (** Deserialize a biniou value of type {!intopt}.
+  (** Deserialize a biniou value of type {!type:intopt}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1345,15 +1345,15 @@ val int_assoc_list_tag : Bi_io.node_tag
 
 val write_untagged_int_assoc_list :
   Bi_outbuf.t -> int_assoc_list -> unit
-  (** Output an untagged biniou value of type {!int_assoc_list}. *)
+  (** Output an untagged biniou value of type {!type:int_assoc_list}. *)
 
 val write_int_assoc_list :
   Bi_outbuf.t -> int_assoc_list -> unit
-  (** Output a biniou value of type {!int_assoc_list}. *)
+  (** Output a biniou value of type {!type:int_assoc_list}. *)
 
 val string_of_int_assoc_list :
   ?len:int -> int_assoc_list -> string
-  (** Serialize a value of type {!int_assoc_list} into
+  (** Serialize a value of type {!type:int_assoc_list} into
       a biniou string. *)
 
 (* Readers for type int_assoc_list *)
@@ -1361,15 +1361,15 @@ val string_of_int_assoc_list :
 val get_int_assoc_list_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> int_assoc_list)
   (** Return a function that reads an untagged
-      biniou value of type {!int_assoc_list}. *)
+      biniou value of type {!type:int_assoc_list}. *)
 
 val read_int_assoc_list :
   Bi_inbuf.t -> int_assoc_list
-  (** Input a tagged biniou value of type {!int_assoc_list}. *)
+  (** Input a tagged biniou value of type {!type:int_assoc_list}. *)
 
 val int_assoc_list_of_string :
   ?pos:int -> string -> int_assoc_list
-  (** Deserialize a biniou value of type {!int_assoc_list}.
+  (** Deserialize a biniou value of type {!type:int_assoc_list}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1382,15 +1382,15 @@ val int_assoc_array_tag : Bi_io.node_tag
 
 val write_untagged_int_assoc_array :
   Bi_outbuf.t -> int_assoc_array -> unit
-  (** Output an untagged biniou value of type {!int_assoc_array}. *)
+  (** Output an untagged biniou value of type {!type:int_assoc_array}. *)
 
 val write_int_assoc_array :
   Bi_outbuf.t -> int_assoc_array -> unit
-  (** Output a biniou value of type {!int_assoc_array}. *)
+  (** Output a biniou value of type {!type:int_assoc_array}. *)
 
 val string_of_int_assoc_array :
   ?len:int -> int_assoc_array -> string
-  (** Serialize a value of type {!int_assoc_array} into
+  (** Serialize a value of type {!type:int_assoc_array} into
       a biniou string. *)
 
 (* Readers for type int_assoc_array *)
@@ -1398,15 +1398,15 @@ val string_of_int_assoc_array :
 val get_int_assoc_array_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> int_assoc_array)
   (** Return a function that reads an untagged
-      biniou value of type {!int_assoc_array}. *)
+      biniou value of type {!type:int_assoc_array}. *)
 
 val read_int_assoc_array :
   Bi_inbuf.t -> int_assoc_array
-  (** Input a tagged biniou value of type {!int_assoc_array}. *)
+  (** Input a tagged biniou value of type {!type:int_assoc_array}. *)
 
 val int_assoc_array_of_string :
   ?pos:int -> string -> int_assoc_array
-  (** Deserialize a biniou value of type {!int_assoc_array}.
+  (** Deserialize a biniou value of type {!type:int_assoc_array}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1419,15 +1419,15 @@ val int8_tag : Bi_io.node_tag
 
 val write_untagged_int8 :
   Bi_outbuf.t -> int8 -> unit
-  (** Output an untagged biniou value of type {!int8}. *)
+  (** Output an untagged biniou value of type {!type:int8}. *)
 
 val write_int8 :
   Bi_outbuf.t -> int8 -> unit
-  (** Output a biniou value of type {!int8}. *)
+  (** Output a biniou value of type {!type:int8}. *)
 
 val string_of_int8 :
   ?len:int -> int8 -> string
-  (** Serialize a value of type {!int8} into
+  (** Serialize a value of type {!type:int8} into
       a biniou string. *)
 
 (* Readers for type int8 *)
@@ -1435,15 +1435,15 @@ val string_of_int8 :
 val get_int8_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> int8)
   (** Return a function that reads an untagged
-      biniou value of type {!int8}. *)
+      biniou value of type {!type:int8}. *)
 
 val read_int8 :
   Bi_inbuf.t -> int8
-  (** Input a tagged biniou value of type {!int8}. *)
+  (** Input a tagged biniou value of type {!type:int8}. *)
 
 val int8_of_string :
   ?pos:int -> string -> int8
-  (** Deserialize a biniou value of type {!int8}.
+  (** Deserialize a biniou value of type {!type:int8}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1456,15 +1456,15 @@ val int64_tag : Bi_io.node_tag
 
 val write_untagged_int64 :
   Bi_outbuf.t -> int64 -> unit
-  (** Output an untagged biniou value of type {!int64}. *)
+  (** Output an untagged biniou value of type {!type:int64}. *)
 
 val write_int64 :
   Bi_outbuf.t -> int64 -> unit
-  (** Output a biniou value of type {!int64}. *)
+  (** Output a biniou value of type {!type:int64}. *)
 
 val string_of_int64 :
   ?len:int -> int64 -> string
-  (** Serialize a value of type {!int64} into
+  (** Serialize a value of type {!type:int64} into
       a biniou string. *)
 
 (* Readers for type int64 *)
@@ -1472,15 +1472,15 @@ val string_of_int64 :
 val get_int64_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> int64)
   (** Return a function that reads an untagged
-      biniou value of type {!int64}. *)
+      biniou value of type {!type:int64}. *)
 
 val read_int64 :
   Bi_inbuf.t -> int64
-  (** Input a tagged biniou value of type {!int64}. *)
+  (** Input a tagged biniou value of type {!type:int64}. *)
 
 val int64_of_string :
   ?pos:int -> string -> int64
-  (** Deserialize a biniou value of type {!int64}.
+  (** Deserialize a biniou value of type {!type:int64}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1493,15 +1493,15 @@ val int32_tag : Bi_io.node_tag
 
 val write_untagged_int32 :
   Bi_outbuf.t -> int32 -> unit
-  (** Output an untagged biniou value of type {!int32}. *)
+  (** Output an untagged biniou value of type {!type:int32}. *)
 
 val write_int32 :
   Bi_outbuf.t -> int32 -> unit
-  (** Output a biniou value of type {!int32}. *)
+  (** Output a biniou value of type {!type:int32}. *)
 
 val string_of_int32 :
   ?len:int -> int32 -> string
-  (** Serialize a value of type {!int32} into
+  (** Serialize a value of type {!type:int32} into
       a biniou string. *)
 
 (* Readers for type int32 *)
@@ -1509,15 +1509,15 @@ val string_of_int32 :
 val get_int32_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> int32)
   (** Return a function that reads an untagged
-      biniou value of type {!int32}. *)
+      biniou value of type {!type:int32}. *)
 
 val read_int32 :
   Bi_inbuf.t -> int32
-  (** Input a tagged biniou value of type {!int32}. *)
+  (** Input a tagged biniou value of type {!type:int32}. *)
 
 val int32_of_string :
   ?pos:int -> string -> int32
-  (** Deserialize a biniou value of type {!int32}.
+  (** Deserialize a biniou value of type {!type:int32}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1530,15 +1530,15 @@ val hello_tag : Bi_io.node_tag
 
 val write_untagged_hello :
   Bi_outbuf.t -> hello -> unit
-  (** Output an untagged biniou value of type {!hello}. *)
+  (** Output an untagged biniou value of type {!type:hello}. *)
 
 val write_hello :
   Bi_outbuf.t -> hello -> unit
-  (** Output a biniou value of type {!hello}. *)
+  (** Output a biniou value of type {!type:hello}. *)
 
 val string_of_hello :
   ?len:int -> hello -> string
-  (** Serialize a value of type {!hello} into
+  (** Serialize a value of type {!type:hello} into
       a biniou string. *)
 
 (* Readers for type hello *)
@@ -1546,15 +1546,15 @@ val string_of_hello :
 val get_hello_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> hello)
   (** Return a function that reads an untagged
-      biniou value of type {!hello}. *)
+      biniou value of type {!type:hello}. *)
 
 val read_hello :
   Bi_inbuf.t -> hello
-  (** Input a tagged biniou value of type {!hello}. *)
+  (** Input a tagged biniou value of type {!type:hello}. *)
 
 val hello_of_string :
   ?pos:int -> string -> hello
-  (** Deserialize a biniou value of type {!hello}.
+  (** Deserialize a biniou value of type {!type:hello}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1567,15 +1567,15 @@ val floats_tag : Bi_io.node_tag
 
 val write_untagged_floats :
   Bi_outbuf.t -> floats -> unit
-  (** Output an untagged biniou value of type {!floats}. *)
+  (** Output an untagged biniou value of type {!type:floats}. *)
 
 val write_floats :
   Bi_outbuf.t -> floats -> unit
-  (** Output a biniou value of type {!floats}. *)
+  (** Output a biniou value of type {!type:floats}. *)
 
 val string_of_floats :
   ?len:int -> floats -> string
-  (** Serialize a value of type {!floats} into
+  (** Serialize a value of type {!type:floats} into
       a biniou string. *)
 
 (* Readers for type floats *)
@@ -1583,15 +1583,15 @@ val string_of_floats :
 val get_floats_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> floats)
   (** Return a function that reads an untagged
-      biniou value of type {!floats}. *)
+      biniou value of type {!type:floats}. *)
 
 val read_floats :
   Bi_inbuf.t -> floats
-  (** Input a tagged biniou value of type {!floats}. *)
+  (** Input a tagged biniou value of type {!type:floats}. *)
 
 val floats_of_string :
   ?pos:int -> string -> floats
-  (** Deserialize a biniou value of type {!floats}.
+  (** Deserialize a biniou value of type {!type:floats}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1599,7 +1599,7 @@ val create_floats :
   f32: float ->
   f64: float ->
   unit -> floats
-  (** Create a record of type {!floats}. *)
+  (** Create a record of type {!type:floats}. *)
 
 
 (* Writers for type extended_tuple *)
@@ -1610,15 +1610,15 @@ val extended_tuple_tag : Bi_io.node_tag
 
 val write_untagged_extended_tuple :
   Bi_outbuf.t -> extended_tuple -> unit
-  (** Output an untagged biniou value of type {!extended_tuple}. *)
+  (** Output an untagged biniou value of type {!type:extended_tuple}. *)
 
 val write_extended_tuple :
   Bi_outbuf.t -> extended_tuple -> unit
-  (** Output a biniou value of type {!extended_tuple}. *)
+  (** Output a biniou value of type {!type:extended_tuple}. *)
 
 val string_of_extended_tuple :
   ?len:int -> extended_tuple -> string
-  (** Serialize a value of type {!extended_tuple} into
+  (** Serialize a value of type {!type:extended_tuple} into
       a biniou string. *)
 
 (* Readers for type extended_tuple *)
@@ -1626,15 +1626,15 @@ val string_of_extended_tuple :
 val get_extended_tuple_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> extended_tuple)
   (** Return a function that reads an untagged
-      biniou value of type {!extended_tuple}. *)
+      biniou value of type {!type:extended_tuple}. *)
 
 val read_extended_tuple :
   Bi_inbuf.t -> extended_tuple
-  (** Input a tagged biniou value of type {!extended_tuple}. *)
+  (** Input a tagged biniou value of type {!type:extended_tuple}. *)
 
 val extended_tuple_of_string :
   ?pos:int -> string -> extended_tuple
-  (** Deserialize a biniou value of type {!extended_tuple}.
+  (** Deserialize a biniou value of type {!type:extended_tuple}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1647,15 +1647,15 @@ val extended_tag : Bi_io.node_tag
 
 val write_untagged_extended :
   Bi_outbuf.t -> extended -> unit
-  (** Output an untagged biniou value of type {!extended}. *)
+  (** Output an untagged biniou value of type {!type:extended}. *)
 
 val write_extended :
   Bi_outbuf.t -> extended -> unit
-  (** Output a biniou value of type {!extended}. *)
+  (** Output a biniou value of type {!type:extended}. *)
 
 val string_of_extended :
   ?len:int -> extended -> string
-  (** Serialize a value of type {!extended} into
+  (** Serialize a value of type {!type:extended} into
       a biniou string. *)
 
 (* Readers for type extended *)
@@ -1663,15 +1663,15 @@ val string_of_extended :
 val get_extended_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> extended)
   (** Return a function that reads an untagged
-      biniou value of type {!extended}. *)
+      biniou value of type {!type:extended}. *)
 
 val read_extended :
   Bi_inbuf.t -> extended
-  (** Input a tagged biniou value of type {!extended}. *)
+  (** Input a tagged biniou value of type {!type:extended}. *)
 
 val extended_of_string :
   ?pos:int -> string -> extended
-  (** Deserialize a biniou value of type {!extended}.
+  (** Deserialize a biniou value of type {!type:extended}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1683,7 +1683,7 @@ val create_extended :
   b4x: string option ->
   ?b5x: float ->
   unit -> extended
-  (** Create a record of type {!extended}. *)
+  (** Create a record of type {!type:extended}. *)
 
 
 (* Writers for type even_natural *)
@@ -1694,15 +1694,15 @@ val even_natural_tag : Bi_io.node_tag
 
 val write_untagged_even_natural :
   Bi_outbuf.t -> even_natural -> unit
-  (** Output an untagged biniou value of type {!even_natural}. *)
+  (** Output an untagged biniou value of type {!type:even_natural}. *)
 
 val write_even_natural :
   Bi_outbuf.t -> even_natural -> unit
-  (** Output a biniou value of type {!even_natural}. *)
+  (** Output a biniou value of type {!type:even_natural}. *)
 
 val string_of_even_natural :
   ?len:int -> even_natural -> string
-  (** Serialize a value of type {!even_natural} into
+  (** Serialize a value of type {!type:even_natural} into
       a biniou string. *)
 
 (* Readers for type even_natural *)
@@ -1710,15 +1710,15 @@ val string_of_even_natural :
 val get_even_natural_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> even_natural)
   (** Return a function that reads an untagged
-      biniou value of type {!even_natural}. *)
+      biniou value of type {!type:even_natural}. *)
 
 val read_even_natural :
   Bi_inbuf.t -> even_natural
-  (** Input a tagged biniou value of type {!even_natural}. *)
+  (** Input a tagged biniou value of type {!type:even_natural}. *)
 
 val even_natural_of_string :
   ?pos:int -> string -> even_natural
-  (** Deserialize a biniou value of type {!even_natural}.
+  (** Deserialize a biniou value of type {!type:even_natural}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1731,15 +1731,15 @@ val def_tag : Bi_io.node_tag
 
 val write_untagged_def :
   Bi_outbuf.t -> def -> unit
-  (** Output an untagged biniou value of type {!def}. *)
+  (** Output an untagged biniou value of type {!type:def}. *)
 
 val write_def :
   Bi_outbuf.t -> def -> unit
-  (** Output a biniou value of type {!def}. *)
+  (** Output a biniou value of type {!type:def}. *)
 
 val string_of_def :
   ?len:int -> def -> string
-  (** Serialize a value of type {!def} into
+  (** Serialize a value of type {!type:def} into
       a biniou string. *)
 
 (* Readers for type def *)
@@ -1747,15 +1747,15 @@ val string_of_def :
 val get_def_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> def)
   (** Return a function that reads an untagged
-      biniou value of type {!def}. *)
+      biniou value of type {!type:def}. *)
 
 val read_def :
   Bi_inbuf.t -> def
-  (** Input a tagged biniou value of type {!def}. *)
+  (** Input a tagged biniou value of type {!type:def}. *)
 
 val def_of_string :
   ?pos:int -> string -> def
-  (** Deserialize a biniou value of type {!def}.
+  (** Deserialize a biniou value of type {!type:def}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1768,15 +1768,15 @@ val char_tag : Bi_io.node_tag
 
 val write_untagged_char :
   Bi_outbuf.t -> char -> unit
-  (** Output an untagged biniou value of type {!char}. *)
+  (** Output an untagged biniou value of type {!type:char}. *)
 
 val write_char :
   Bi_outbuf.t -> char -> unit
-  (** Output a biniou value of type {!char}. *)
+  (** Output a biniou value of type {!type:char}. *)
 
 val string_of_char :
   ?len:int -> char -> string
-  (** Serialize a value of type {!char} into
+  (** Serialize a value of type {!type:char} into
       a biniou string. *)
 
 (* Readers for type char *)
@@ -1784,15 +1784,15 @@ val string_of_char :
 val get_char_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> char)
   (** Return a function that reads an untagged
-      biniou value of type {!char}. *)
+      biniou value of type {!type:char}. *)
 
 val read_char :
   Bi_inbuf.t -> char
-  (** Input a tagged biniou value of type {!char}. *)
+  (** Input a tagged biniou value of type {!type:char}. *)
 
 val char_of_string :
   ?pos:int -> string -> char
-  (** Deserialize a biniou value of type {!char}.
+  (** Deserialize a biniou value of type {!type:char}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1805,15 +1805,15 @@ val base_tuple_tag : Bi_io.node_tag
 
 val write_untagged_base_tuple :
   Bi_outbuf.t -> base_tuple -> unit
-  (** Output an untagged biniou value of type {!base_tuple}. *)
+  (** Output an untagged biniou value of type {!type:base_tuple}. *)
 
 val write_base_tuple :
   Bi_outbuf.t -> base_tuple -> unit
-  (** Output a biniou value of type {!base_tuple}. *)
+  (** Output a biniou value of type {!type:base_tuple}. *)
 
 val string_of_base_tuple :
   ?len:int -> base_tuple -> string
-  (** Serialize a value of type {!base_tuple} into
+  (** Serialize a value of type {!type:base_tuple} into
       a biniou string. *)
 
 (* Readers for type base_tuple *)
@@ -1821,15 +1821,15 @@ val string_of_base_tuple :
 val get_base_tuple_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> base_tuple)
   (** Return a function that reads an untagged
-      biniou value of type {!base_tuple}. *)
+      biniou value of type {!type:base_tuple}. *)
 
 val read_base_tuple :
   Bi_inbuf.t -> base_tuple
-  (** Input a tagged biniou value of type {!base_tuple}. *)
+  (** Input a tagged biniou value of type {!type:base_tuple}. *)
 
 val base_tuple_of_string :
   ?pos:int -> string -> base_tuple
-  (** Deserialize a biniou value of type {!base_tuple}.
+  (** Deserialize a biniou value of type {!type:base_tuple}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1842,15 +1842,15 @@ val base_tag : Bi_io.node_tag
 
 val write_untagged_base :
   Bi_outbuf.t -> base -> unit
-  (** Output an untagged biniou value of type {!base}. *)
+  (** Output an untagged biniou value of type {!type:base}. *)
 
 val write_base :
   Bi_outbuf.t -> base -> unit
-  (** Output a biniou value of type {!base}. *)
+  (** Output a biniou value of type {!type:base}. *)
 
 val string_of_base :
   ?len:int -> base -> string
-  (** Serialize a value of type {!base} into
+  (** Serialize a value of type {!type:base} into
       a biniou string. *)
 
 (* Readers for type base *)
@@ -1858,15 +1858,15 @@ val string_of_base :
 val get_base_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> base)
   (** Return a function that reads an untagged
-      biniou value of type {!base}. *)
+      biniou value of type {!type:base}. *)
 
 val read_base :
   Bi_inbuf.t -> base
-  (** Input a tagged biniou value of type {!base}. *)
+  (** Input a tagged biniou value of type {!type:base}. *)
 
 val base_of_string :
   ?pos:int -> string -> base
-  (** Deserialize a biniou value of type {!base}.
+  (** Deserialize a biniou value of type {!type:base}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1874,7 +1874,7 @@ val create_base :
   b0: int ->
   b1: bool ->
   unit -> base
-  (** Create a record of type {!base}. *)
+  (** Create a record of type {!type:base}. *)
 
 
 (* Writers for type array *)
@@ -1888,21 +1888,21 @@ val write_untagged_array :
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a array -> unit
-  (** Output an untagged biniou value of type {!array}. *)
+  (** Output an untagged biniou value of type {!type:array}. *)
 
 val write_array :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a array -> unit
-  (** Output a biniou value of type {!array}. *)
+  (** Output a biniou value of type {!type:array}. *)
 
 val string_of_array :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a array -> string
-  (** Serialize a value of type {!array} into
+  (** Serialize a value of type {!type:array} into
       a biniou string. *)
 
 (* Readers for type array *)
@@ -1912,19 +1912,19 @@ val get_array_reader :
   (Bi_inbuf.t -> 'a) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> 'a array)
   (** Return a function that reads an untagged
-      biniou value of type {!array}. *)
+      biniou value of type {!type:array}. *)
 
 val read_array :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   Bi_inbuf.t -> 'a array
-  (** Input a tagged biniou value of type {!array}. *)
+  (** Input a tagged biniou value of type {!type:array}. *)
 
 val array_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   ?pos:int -> string -> 'a array
-  (** Deserialize a biniou value of type {!array}.
+  (** Deserialize a biniou value of type {!type:array}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1940,21 +1940,21 @@ val write_untagged_abs3 :
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs3 -> unit
-  (** Output an untagged biniou value of type {!abs3}. *)
+  (** Output an untagged biniou value of type {!type:abs3}. *)
 
 val write_abs3 :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs3 -> unit
-  (** Output a biniou value of type {!abs3}. *)
+  (** Output a biniou value of type {!type:abs3}. *)
 
 val string_of_abs3 :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs3 -> string
-  (** Serialize a value of type {!abs3} into
+  (** Serialize a value of type {!type:abs3} into
       a biniou string. *)
 
 (* Readers for type abs3 *)
@@ -1964,19 +1964,19 @@ val get_abs3_reader :
   (Bi_inbuf.t -> 'a) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> 'a abs3)
   (** Return a function that reads an untagged
-      biniou value of type {!abs3}. *)
+      biniou value of type {!type:abs3}. *)
 
 val read_abs3 :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   Bi_inbuf.t -> 'a abs3
-  (** Input a tagged biniou value of type {!abs3}. *)
+  (** Input a tagged biniou value of type {!type:abs3}. *)
 
 val abs3_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   ?pos:int -> string -> 'a abs3
-  (** Deserialize a biniou value of type {!abs3}.
+  (** Deserialize a biniou value of type {!type:abs3}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -1992,21 +1992,21 @@ val write_untagged_abs2 :
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs2 -> unit
-  (** Output an untagged biniou value of type {!abs2}. *)
+  (** Output an untagged biniou value of type {!type:abs2}. *)
 
 val write_abs2 :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs2 -> unit
-  (** Output a biniou value of type {!abs2}. *)
+  (** Output a biniou value of type {!type:abs2}. *)
 
 val string_of_abs2 :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs2 -> string
-  (** Serialize a value of type {!abs2} into
+  (** Serialize a value of type {!type:abs2} into
       a biniou string. *)
 
 (* Readers for type abs2 *)
@@ -2016,19 +2016,19 @@ val get_abs2_reader :
   (Bi_inbuf.t -> 'a) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> 'a abs2)
   (** Return a function that reads an untagged
-      biniou value of type {!abs2}. *)
+      biniou value of type {!type:abs2}. *)
 
 val read_abs2 :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   Bi_inbuf.t -> 'a abs2
-  (** Input a tagged biniou value of type {!abs2}. *)
+  (** Input a tagged biniou value of type {!type:abs2}. *)
 
 val abs2_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   ?pos:int -> string -> 'a abs2
-  (** Deserialize a biniou value of type {!abs2}.
+  (** Deserialize a biniou value of type {!type:abs2}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -2044,21 +2044,21 @@ val write_untagged_abs1 :
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs1 -> unit
-  (** Output an untagged biniou value of type {!abs1}. *)
+  (** Output an untagged biniou value of type {!type:abs1}. *)
 
 val write_abs1 :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs1 -> unit
-  (** Output a biniou value of type {!abs1}. *)
+  (** Output a biniou value of type {!type:abs1}. *)
 
 val string_of_abs1 :
   Bi_io.node_tag ->
   (Bi_outbuf.t -> 'a -> unit) ->
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs1 -> string
-  (** Serialize a value of type {!abs1} into
+  (** Serialize a value of type {!type:abs1} into
       a biniou string. *)
 
 (* Readers for type abs1 *)
@@ -2068,19 +2068,19 @@ val get_abs1_reader :
   (Bi_inbuf.t -> 'a) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> 'a abs1)
   (** Return a function that reads an untagged
-      biniou value of type {!abs1}. *)
+      biniou value of type {!type:abs1}. *)
 
 val read_abs1 :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   Bi_inbuf.t -> 'a abs1
-  (** Input a tagged biniou value of type {!abs1}. *)
+  (** Input a tagged biniou value of type {!type:abs1}. *)
 
 val abs1_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'a)) ->
   (Bi_inbuf.t -> 'a) ->
   ?pos:int -> string -> 'a abs1
-  (** Deserialize a biniou value of type {!abs1}.
+  (** Deserialize a biniou value of type {!type:abs1}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 

--- a/atdgen/test/test2.expected.mli
+++ b/atdgen/test/test2.expected.mli
@@ -24,7 +24,7 @@ val write_untagged_poly :
   (Bi_outbuf.t -> 'bb -> unit) ->
   (Bi_outbuf.t -> 'bb -> unit) ->
   Bi_outbuf.t -> ('aa, 'bb) poly -> unit
-  (** Output an untagged biniou value of type {!poly}. *)
+  (** Output an untagged biniou value of type {!type:poly}. *)
 
 val write_poly :
   Bi_io.node_tag ->
@@ -34,7 +34,7 @@ val write_poly :
   (Bi_outbuf.t -> 'bb -> unit) ->
   (Bi_outbuf.t -> 'bb -> unit) ->
   Bi_outbuf.t -> ('aa, 'bb) poly -> unit
-  (** Output a biniou value of type {!poly}. *)
+  (** Output a biniou value of type {!type:poly}. *)
 
 val string_of_poly :
   Bi_io.node_tag ->
@@ -44,7 +44,7 @@ val string_of_poly :
   (Bi_outbuf.t -> 'bb -> unit) ->
   (Bi_outbuf.t -> 'bb -> unit) ->
   ?len:int -> ('aa, 'bb) poly -> string
-  (** Serialize a value of type {!poly} into
+  (** Serialize a value of type {!type:poly} into
       a biniou string. *)
 
 (* Readers for type poly *)
@@ -56,7 +56,7 @@ val get_poly_reader :
   (Bi_inbuf.t -> 'bb) ->
   Bi_io.node_tag -> (Bi_inbuf.t -> ('aa, 'bb) poly)
   (** Return a function that reads an untagged
-      biniou value of type {!poly}. *)
+      biniou value of type {!type:poly}. *)
 
 val read_poly :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'aa)) ->
@@ -64,7 +64,7 @@ val read_poly :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'bb)) ->
   (Bi_inbuf.t -> 'bb) ->
   Bi_inbuf.t -> ('aa, 'bb) poly
-  (** Input a tagged biniou value of type {!poly}. *)
+  (** Input a tagged biniou value of type {!type:poly}. *)
 
 val poly_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'aa)) ->
@@ -72,7 +72,7 @@ val poly_of_string :
   (Bi_io.node_tag -> (Bi_inbuf.t -> 'bb)) ->
   (Bi_inbuf.t -> 'bb) ->
   ?pos:int -> string -> ('aa, 'bb) poly
-  (** Deserialize a biniou value of type {!poly}.
+  (** Deserialize a biniou value of type {!type:poly}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -85,15 +85,15 @@ val poly_int2_tag : Bi_io.node_tag
 
 val write_untagged_poly_int2 :
   Bi_outbuf.t -> poly_int2 -> unit
-  (** Output an untagged biniou value of type {!poly_int2}. *)
+  (** Output an untagged biniou value of type {!type:poly_int2}. *)
 
 val write_poly_int2 :
   Bi_outbuf.t -> poly_int2 -> unit
-  (** Output a biniou value of type {!poly_int2}. *)
+  (** Output a biniou value of type {!type:poly_int2}. *)
 
 val string_of_poly_int2 :
   ?len:int -> poly_int2 -> string
-  (** Serialize a value of type {!poly_int2} into
+  (** Serialize a value of type {!type:poly_int2} into
       a biniou string. *)
 
 (* Readers for type poly_int2 *)
@@ -101,15 +101,15 @@ val string_of_poly_int2 :
 val get_poly_int2_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> poly_int2)
   (** Return a function that reads an untagged
-      biniou value of type {!poly_int2}. *)
+      biniou value of type {!type:poly_int2}. *)
 
 val read_poly_int2 :
   Bi_inbuf.t -> poly_int2
-  (** Input a tagged biniou value of type {!poly_int2}. *)
+  (** Input a tagged biniou value of type {!type:poly_int2}. *)
 
 val poly_int2_of_string :
   ?pos:int -> string -> poly_int2
-  (** Deserialize a biniou value of type {!poly_int2}.
+  (** Deserialize a biniou value of type {!type:poly_int2}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -122,15 +122,15 @@ val test2_tag : Bi_io.node_tag
 
 val write_untagged_test2 :
   Bi_outbuf.t -> test2 -> unit
-  (** Output an untagged biniou value of type {!test2}. *)
+  (** Output an untagged biniou value of type {!type:test2}. *)
 
 val write_test2 :
   Bi_outbuf.t -> test2 -> unit
-  (** Output a biniou value of type {!test2}. *)
+  (** Output a biniou value of type {!type:test2}. *)
 
 val string_of_test2 :
   ?len:int -> test2 -> string
-  (** Serialize a value of type {!test2} into
+  (** Serialize a value of type {!type:test2} into
       a biniou string. *)
 
 (* Readers for type test2 *)
@@ -138,15 +138,15 @@ val string_of_test2 :
 val get_test2_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> test2)
   (** Return a function that reads an untagged
-      biniou value of type {!test2}. *)
+      biniou value of type {!type:test2}. *)
 
 val read_test2 :
   Bi_inbuf.t -> test2
-  (** Input a tagged biniou value of type {!test2}. *)
+  (** Input a tagged biniou value of type {!type:test2}. *)
 
 val test2_of_string :
   ?pos:int -> string -> test2
-  (** Deserialize a biniou value of type {!test2}.
+  (** Deserialize a biniou value of type {!type:test2}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 
@@ -154,7 +154,7 @@ val create_test2 :
   test0: poly_int2 ->
   test1: (int, string option) poly ->
   unit -> test2
-  (** Create a record of type {!test2}. *)
+  (** Create a record of type {!type:test2}. *)
 
 
 (* Writers for type poly_int_string *)
@@ -165,15 +165,15 @@ val poly_int_string_tag : Bi_io.node_tag
 
 val write_untagged_poly_int_string :
   Bi_outbuf.t -> poly_int_string -> unit
-  (** Output an untagged biniou value of type {!poly_int_string}. *)
+  (** Output an untagged biniou value of type {!type:poly_int_string}. *)
 
 val write_poly_int_string :
   Bi_outbuf.t -> poly_int_string -> unit
-  (** Output a biniou value of type {!poly_int_string}. *)
+  (** Output a biniou value of type {!type:poly_int_string}. *)
 
 val string_of_poly_int_string :
   ?len:int -> poly_int_string -> string
-  (** Serialize a value of type {!poly_int_string} into
+  (** Serialize a value of type {!type:poly_int_string} into
       a biniou string. *)
 
 (* Readers for type poly_int_string *)
@@ -181,15 +181,15 @@ val string_of_poly_int_string :
 val get_poly_int_string_reader :
   Bi_io.node_tag -> (Bi_inbuf.t -> poly_int_string)
   (** Return a function that reads an untagged
-      biniou value of type {!poly_int_string}. *)
+      biniou value of type {!type:poly_int_string}. *)
 
 val read_poly_int_string :
   Bi_inbuf.t -> poly_int_string
-  (** Input a tagged biniou value of type {!poly_int_string}. *)
+  (** Input a tagged biniou value of type {!type:poly_int_string}. *)
 
 val poly_int_string_of_string :
   ?pos:int -> string -> poly_int_string
-  (** Deserialize a biniou value of type {!poly_int_string}.
+  (** Deserialize a biniou value of type {!type:poly_int_string}.
       @param pos specifies the position where
                  reading starts. Default: 0. *)
 

--- a/atdgen/test/test2j.expected.mli
+++ b/atdgen/test/test2j.expected.mli
@@ -8,13 +8,13 @@ val write_poly :
   (Bi_outbuf.t -> 'aa -> unit) ->
   (Bi_outbuf.t -> 'bb -> unit) ->
   Bi_outbuf.t -> ('aa, 'bb) poly -> unit
-  (** Output a JSON value of type {!poly}. *)
+  (** Output a JSON value of type {!type:poly}. *)
 
 val string_of_poly :
   (Bi_outbuf.t -> 'aa -> unit) ->
   (Bi_outbuf.t -> 'bb -> unit) ->
   ?len:int -> ('aa, 'bb) poly -> string
-  (** Serialize a value of type {!poly}
+  (** Serialize a value of type {!type:poly}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -24,22 +24,22 @@ val read_poly :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'aa) ->
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'bb) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> ('aa, 'bb) poly
-  (** Input JSON data of type {!poly}. *)
+  (** Input JSON data of type {!type:poly}. *)
 
 val poly_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'aa) ->
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'bb) ->
   string -> ('aa, 'bb) poly
-  (** Deserialize JSON data of type {!poly}. *)
+  (** Deserialize JSON data of type {!type:poly}. *)
 
 
 val write_poly_int2 :
   Bi_outbuf.t -> poly_int2 -> unit
-  (** Output a JSON value of type {!poly_int2}. *)
+  (** Output a JSON value of type {!type:poly_int2}. *)
 
 val string_of_poly_int2 :
   ?len:int -> poly_int2 -> string
-  (** Serialize a value of type {!poly_int2}
+  (** Serialize a value of type {!type:poly_int2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -47,20 +47,20 @@ val string_of_poly_int2 :
 
 val read_poly_int2 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> poly_int2
-  (** Input JSON data of type {!poly_int2}. *)
+  (** Input JSON data of type {!type:poly_int2}. *)
 
 val poly_int2_of_string :
   string -> poly_int2
-  (** Deserialize JSON data of type {!poly_int2}. *)
+  (** Deserialize JSON data of type {!type:poly_int2}. *)
 
 
 val write_test2 :
   Bi_outbuf.t -> test2 -> unit
-  (** Output a JSON value of type {!test2}. *)
+  (** Output a JSON value of type {!type:test2}. *)
 
 val string_of_test2 :
   ?len:int -> test2 -> string
-  (** Serialize a value of type {!test2}
+  (** Serialize a value of type {!type:test2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -68,26 +68,26 @@ val string_of_test2 :
 
 val read_test2 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> test2
-  (** Input JSON data of type {!test2}. *)
+  (** Input JSON data of type {!type:test2}. *)
 
 val test2_of_string :
   string -> test2
-  (** Deserialize JSON data of type {!test2}. *)
+  (** Deserialize JSON data of type {!type:test2}. *)
 
 val create_test2 :
   test0: poly_int2 ->
   test1: (int, string option) poly ->
   unit -> test2
-  (** Create a record of type {!test2}. *)
+  (** Create a record of type {!type:test2}. *)
 
 
 val write_poly_int_string :
   Bi_outbuf.t -> poly_int_string -> unit
-  (** Output a JSON value of type {!poly_int_string}. *)
+  (** Output a JSON value of type {!type:poly_int_string}. *)
 
 val string_of_poly_int_string :
   ?len:int -> poly_int_string -> string
-  (** Serialize a value of type {!poly_int_string}
+  (** Serialize a value of type {!type:poly_int_string}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -95,10 +95,10 @@ val string_of_poly_int_string :
 
 val read_poly_int_string :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> poly_int_string
-  (** Input JSON data of type {!poly_int_string}. *)
+  (** Input JSON data of type {!type:poly_int_string}. *)
 
 val poly_int_string_of_string :
   string -> poly_int_string
-  (** Deserialize JSON data of type {!poly_int_string}. *)
+  (** Deserialize JSON data of type {!type:poly_int_string}. *)
 
 

--- a/atdgen/test/test3j_j.expected.mli
+++ b/atdgen/test/test3j_j.expected.mli
@@ -44,11 +44,11 @@ type adapted = Test3j_t.adapted
 
 val write_rec_type :
   Bi_outbuf.t -> rec_type -> unit
-  (** Output a JSON value of type {!rec_type}. *)
+  (** Output a JSON value of type {!type:rec_type}. *)
 
 val string_of_rec_type :
   ?len:int -> rec_type -> string
-  (** Serialize a value of type {!rec_type}
+  (** Serialize a value of type {!type:rec_type}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -56,19 +56,19 @@ val string_of_rec_type :
 
 val read_rec_type :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> rec_type
-  (** Input JSON data of type {!rec_type}. *)
+  (** Input JSON data of type {!type:rec_type}. *)
 
 val rec_type_of_string :
   string -> rec_type
-  (** Deserialize JSON data of type {!rec_type}. *)
+  (** Deserialize JSON data of type {!type:rec_type}. *)
 
 val write_unixtime_list :
   Bi_outbuf.t -> unixtime_list -> unit
-  (** Output a JSON value of type {!unixtime_list}. *)
+  (** Output a JSON value of type {!type:unixtime_list}. *)
 
 val string_of_unixtime_list :
   ?len:int -> unixtime_list -> string
-  (** Serialize a value of type {!unixtime_list}
+  (** Serialize a value of type {!type:unixtime_list}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -76,19 +76,19 @@ val string_of_unixtime_list :
 
 val read_unixtime_list :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> unixtime_list
-  (** Input JSON data of type {!unixtime_list}. *)
+  (** Input JSON data of type {!type:unixtime_list}. *)
 
 val unixtime_list_of_string :
   string -> unixtime_list
-  (** Deserialize JSON data of type {!unixtime_list}. *)
+  (** Deserialize JSON data of type {!type:unixtime_list}. *)
 
 val write_json :
   Bi_outbuf.t -> json -> unit
-  (** Output a JSON value of type {!json}. *)
+  (** Output a JSON value of type {!type:json}. *)
 
 val string_of_json :
   ?len:int -> json -> string
-  (** Serialize a value of type {!json}
+  (** Serialize a value of type {!type:json}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -96,19 +96,19 @@ val string_of_json :
 
 val read_json :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> json
-  (** Input JSON data of type {!json}. *)
+  (** Input JSON data of type {!type:json}. *)
 
 val json_of_string :
   string -> json
-  (** Deserialize JSON data of type {!json}. *)
+  (** Deserialize JSON data of type {!type:json}. *)
 
 val write_tf_variant2 :
   Bi_outbuf.t -> tf_variant2 -> unit
-  (** Output a JSON value of type {!tf_variant2}. *)
+  (** Output a JSON value of type {!type:tf_variant2}. *)
 
 val string_of_tf_variant2 :
   ?len:int -> tf_variant2 -> string
-  (** Serialize a value of type {!tf_variant2}
+  (** Serialize a value of type {!type:tf_variant2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -116,19 +116,19 @@ val string_of_tf_variant2 :
 
 val read_tf_variant2 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> tf_variant2
-  (** Input JSON data of type {!tf_variant2}. *)
+  (** Input JSON data of type {!type:tf_variant2}. *)
 
 val tf_variant2_of_string :
   string -> tf_variant2
-  (** Deserialize JSON data of type {!tf_variant2}. *)
+  (** Deserialize JSON data of type {!type:tf_variant2}. *)
 
 val write_tf_variant :
   Bi_outbuf.t -> tf_variant -> unit
-  (** Output a JSON value of type {!tf_variant}. *)
+  (** Output a JSON value of type {!type:tf_variant}. *)
 
 val string_of_tf_variant :
   ?len:int -> tf_variant -> string
-  (** Serialize a value of type {!tf_variant}
+  (** Serialize a value of type {!type:tf_variant}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -136,19 +136,19 @@ val string_of_tf_variant :
 
 val read_tf_variant :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> tf_variant
-  (** Input JSON data of type {!tf_variant}. *)
+  (** Input JSON data of type {!type:tf_variant}. *)
 
 val tf_variant_of_string :
   string -> tf_variant
-  (** Deserialize JSON data of type {!tf_variant}. *)
+  (** Deserialize JSON data of type {!type:tf_variant}. *)
 
 val write_tf_record2 :
   Bi_outbuf.t -> tf_record2 -> unit
-  (** Output a JSON value of type {!tf_record2}. *)
+  (** Output a JSON value of type {!type:tf_record2}. *)
 
 val string_of_tf_record2 :
   ?len:int -> tf_record2 -> string
-  (** Serialize a value of type {!tf_record2}
+  (** Serialize a value of type {!type:tf_record2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -156,19 +156,19 @@ val string_of_tf_record2 :
 
 val read_tf_record2 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> tf_record2
-  (** Input JSON data of type {!tf_record2}. *)
+  (** Input JSON data of type {!type:tf_record2}. *)
 
 val tf_record2_of_string :
   string -> tf_record2
-  (** Deserialize JSON data of type {!tf_record2}. *)
+  (** Deserialize JSON data of type {!type:tf_record2}. *)
 
 val write_tf_record :
   Bi_outbuf.t -> tf_record -> unit
-  (** Output a JSON value of type {!tf_record}. *)
+  (** Output a JSON value of type {!type:tf_record}. *)
 
 val string_of_tf_record :
   ?len:int -> tf_record -> string
-  (** Serialize a value of type {!tf_record}
+  (** Serialize a value of type {!type:tf_record}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -176,19 +176,19 @@ val string_of_tf_record :
 
 val read_tf_record :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> tf_record
-  (** Input JSON data of type {!tf_record}. *)
+  (** Input JSON data of type {!type:tf_record}. *)
 
 val tf_record_of_string :
   string -> tf_record
-  (** Deserialize JSON data of type {!tf_record}. *)
+  (** Deserialize JSON data of type {!type:tf_record}. *)
 
 val write_dyn :
   Bi_outbuf.t -> dyn -> unit
-  (** Output a JSON value of type {!dyn}. *)
+  (** Output a JSON value of type {!type:dyn}. *)
 
 val string_of_dyn :
   ?len:int -> dyn -> string
-  (** Serialize a value of type {!dyn}
+  (** Serialize a value of type {!type:dyn}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -196,19 +196,19 @@ val string_of_dyn :
 
 val read_dyn :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> dyn
-  (** Input JSON data of type {!dyn}. *)
+  (** Input JSON data of type {!type:dyn}. *)
 
 val dyn_of_string :
   string -> dyn
-  (** Deserialize JSON data of type {!dyn}. *)
+  (** Deserialize JSON data of type {!type:dyn}. *)
 
 val write_t :
   Bi_outbuf.t -> t -> unit
-  (** Output a JSON value of type {!t}. *)
+  (** Output a JSON value of type {!type:t}. *)
 
 val string_of_t :
   ?len:int -> t -> string
-  (** Serialize a value of type {!t}
+  (** Serialize a value of type {!type:t}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -216,19 +216,19 @@ val string_of_t :
 
 val read_t :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> t
-  (** Input JSON data of type {!t}. *)
+  (** Input JSON data of type {!type:t}. *)
 
 val t_of_string :
   string -> t
-  (** Deserialize JSON data of type {!t}. *)
+  (** Deserialize JSON data of type {!type:t}. *)
 
 val write_sf_adapted :
   Bi_outbuf.t -> sf_adapted -> unit
-  (** Output a JSON value of type {!sf_adapted}. *)
+  (** Output a JSON value of type {!type:sf_adapted}. *)
 
 val string_of_sf_adapted :
   ?len:int -> sf_adapted -> string
-  (** Serialize a value of type {!sf_adapted}
+  (** Serialize a value of type {!type:sf_adapted}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -236,19 +236,19 @@ val string_of_sf_adapted :
 
 val read_sf_adapted :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> sf_adapted
-  (** Input JSON data of type {!sf_adapted}. *)
+  (** Input JSON data of type {!type:sf_adapted}. *)
 
 val sf_adapted_of_string :
   string -> sf_adapted
-  (** Deserialize JSON data of type {!sf_adapted}. *)
+  (** Deserialize JSON data of type {!type:sf_adapted}. *)
 
 val write_sample_open_enum :
   Bi_outbuf.t -> sample_open_enum -> unit
-  (** Output a JSON value of type {!sample_open_enum}. *)
+  (** Output a JSON value of type {!type:sample_open_enum}. *)
 
 val string_of_sample_open_enum :
   ?len:int -> sample_open_enum -> string
-  (** Serialize a value of type {!sample_open_enum}
+  (** Serialize a value of type {!type:sample_open_enum}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -256,19 +256,19 @@ val string_of_sample_open_enum :
 
 val read_sample_open_enum :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> sample_open_enum
-  (** Input JSON data of type {!sample_open_enum}. *)
+  (** Input JSON data of type {!type:sample_open_enum}. *)
 
 val sample_open_enum_of_string :
   string -> sample_open_enum
-  (** Deserialize JSON data of type {!sample_open_enum}. *)
+  (** Deserialize JSON data of type {!type:sample_open_enum}. *)
 
 val write_sample_open_enums :
   Bi_outbuf.t -> sample_open_enums -> unit
-  (** Output a JSON value of type {!sample_open_enums}. *)
+  (** Output a JSON value of type {!type:sample_open_enums}. *)
 
 val string_of_sample_open_enums :
   ?len:int -> sample_open_enums -> string
-  (** Serialize a value of type {!sample_open_enums}
+  (** Serialize a value of type {!type:sample_open_enums}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -276,19 +276,19 @@ val string_of_sample_open_enums :
 
 val read_sample_open_enums :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> sample_open_enums
-  (** Input JSON data of type {!sample_open_enums}. *)
+  (** Input JSON data of type {!type:sample_open_enums}. *)
 
 val sample_open_enums_of_string :
   string -> sample_open_enums
-  (** Deserialize JSON data of type {!sample_open_enums}. *)
+  (** Deserialize JSON data of type {!type:sample_open_enums}. *)
 
 val write_patch :
   Bi_outbuf.t -> patch -> unit
-  (** Output a JSON value of type {!patch}. *)
+  (** Output a JSON value of type {!type:patch}. *)
 
 val string_of_patch :
   ?len:int -> patch -> string
-  (** Serialize a value of type {!patch}
+  (** Serialize a value of type {!type:patch}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -296,19 +296,19 @@ val string_of_patch :
 
 val read_patch :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> patch
-  (** Input JSON data of type {!patch}. *)
+  (** Input JSON data of type {!type:patch}. *)
 
 val patch_of_string :
   string -> patch
-  (** Deserialize JSON data of type {!patch}. *)
+  (** Deserialize JSON data of type {!type:patch}. *)
 
 val write_b :
   Bi_outbuf.t -> b -> unit
-  (** Output a JSON value of type {!b}. *)
+  (** Output a JSON value of type {!type:b}. *)
 
 val string_of_b :
   ?len:int -> b -> string
-  (** Serialize a value of type {!b}
+  (** Serialize a value of type {!type:b}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -316,19 +316,19 @@ val string_of_b :
 
 val read_b :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> b
-  (** Input JSON data of type {!b}. *)
+  (** Input JSON data of type {!type:b}. *)
 
 val b_of_string :
   string -> b
-  (** Deserialize JSON data of type {!b}. *)
+  (** Deserialize JSON data of type {!type:b}. *)
 
 val write_a :
   Bi_outbuf.t -> a -> unit
-  (** Output a JSON value of type {!a}. *)
+  (** Output a JSON value of type {!type:a}. *)
 
 val string_of_a :
   ?len:int -> a -> string
-  (** Serialize a value of type {!a}
+  (** Serialize a value of type {!type:a}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -336,19 +336,19 @@ val string_of_a :
 
 val read_a :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> a
-  (** Input JSON data of type {!a}. *)
+  (** Input JSON data of type {!type:a}. *)
 
 val a_of_string :
   string -> a
-  (** Deserialize JSON data of type {!a}. *)
+  (** Deserialize JSON data of type {!type:a}. *)
 
 val write_adapted_f :
   Bi_outbuf.t -> adapted_f -> unit
-  (** Output a JSON value of type {!adapted_f}. *)
+  (** Output a JSON value of type {!type:adapted_f}. *)
 
 val string_of_adapted_f :
   ?len:int -> adapted_f -> string
-  (** Serialize a value of type {!adapted_f}
+  (** Serialize a value of type {!type:adapted_f}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -356,19 +356,19 @@ val string_of_adapted_f :
 
 val read_adapted_f :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> adapted_f
-  (** Input JSON data of type {!adapted_f}. *)
+  (** Input JSON data of type {!type:adapted_f}. *)
 
 val adapted_f_of_string :
   string -> adapted_f
-  (** Deserialize JSON data of type {!adapted_f}. *)
+  (** Deserialize JSON data of type {!type:adapted_f}. *)
 
 val write_adapted :
   Bi_outbuf.t -> adapted -> unit
-  (** Output a JSON value of type {!adapted}. *)
+  (** Output a JSON value of type {!type:adapted}. *)
 
 val string_of_adapted :
   ?len:int -> adapted -> string
-  (** Serialize a value of type {!adapted}
+  (** Serialize a value of type {!type:adapted}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -376,9 +376,9 @@ val string_of_adapted :
 
 val read_adapted :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> adapted
-  (** Input JSON data of type {!adapted}. *)
+  (** Input JSON data of type {!type:adapted}. *)
 
 val adapted_of_string :
   string -> adapted
-  (** Deserialize JSON data of type {!adapted}. *)
+  (** Deserialize JSON data of type {!type:adapted}. *)
 

--- a/atdgen/test/test_abstract_j.expected.mli
+++ b/atdgen/test/test_abstract_j.expected.mli
@@ -13,11 +13,11 @@ type 'x abs1 = 'x Testj.abs1
 
 val write_int_assoc_list :
   Bi_outbuf.t -> int_assoc_list -> unit
-  (** Output a JSON value of type {!int_assoc_list}. *)
+  (** Output a JSON value of type {!type:int_assoc_list}. *)
 
 val string_of_int_assoc_list :
   ?len:int -> int_assoc_list -> string
-  (** Serialize a value of type {!int_assoc_list}
+  (** Serialize a value of type {!type:int_assoc_list}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -25,19 +25,19 @@ val string_of_int_assoc_list :
 
 val read_int_assoc_list :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int_assoc_list
-  (** Input JSON data of type {!int_assoc_list}. *)
+  (** Input JSON data of type {!type:int_assoc_list}. *)
 
 val int_assoc_list_of_string :
   string -> int_assoc_list
-  (** Deserialize JSON data of type {!int_assoc_list}. *)
+  (** Deserialize JSON data of type {!type:int_assoc_list}. *)
 
 val write_any_items :
   Bi_outbuf.t -> any_items -> unit
-  (** Output a JSON value of type {!any_items}. *)
+  (** Output a JSON value of type {!type:any_items}. *)
 
 val string_of_any_items :
   ?len:int -> any_items -> string
-  (** Serialize a value of type {!any_items}
+  (** Serialize a value of type {!type:any_items}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -45,21 +45,21 @@ val string_of_any_items :
 
 val read_any_items :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> any_items
-  (** Input JSON data of type {!any_items}. *)
+  (** Input JSON data of type {!type:any_items}. *)
 
 val any_items_of_string :
   string -> any_items
-  (** Deserialize JSON data of type {!any_items}. *)
+  (** Deserialize JSON data of type {!type:any_items}. *)
 
 val write_abs2 :
   (Bi_outbuf.t -> 'x -> unit) ->
   Bi_outbuf.t -> 'x abs2 -> unit
-  (** Output a JSON value of type {!abs2}. *)
+  (** Output a JSON value of type {!type:abs2}. *)
 
 val string_of_abs2 :
   (Bi_outbuf.t -> 'x -> unit) ->
   ?len:int -> 'x abs2 -> string
-  (** Serialize a value of type {!abs2}
+  (** Serialize a value of type {!type:abs2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -68,22 +68,22 @@ val string_of_abs2 :
 val read_abs2 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x abs2
-  (** Input JSON data of type {!abs2}. *)
+  (** Input JSON data of type {!type:abs2}. *)
 
 val abs2_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   string -> 'x abs2
-  (** Deserialize JSON data of type {!abs2}. *)
+  (** Deserialize JSON data of type {!type:abs2}. *)
 
 val write_abs1 :
   (Bi_outbuf.t -> 'x -> unit) ->
   Bi_outbuf.t -> 'x abs1 -> unit
-  (** Output a JSON value of type {!abs1}. *)
+  (** Output a JSON value of type {!type:abs1}. *)
 
 val string_of_abs1 :
   (Bi_outbuf.t -> 'x -> unit) ->
   ?len:int -> 'x abs1 -> string
-  (** Serialize a value of type {!abs1}
+  (** Serialize a value of type {!type:abs1}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -92,10 +92,10 @@ val string_of_abs1 :
 val read_abs1 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x abs1
-  (** Input JSON data of type {!abs1}. *)
+  (** Input JSON data of type {!type:abs1}. *)
 
 val abs1_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   string -> 'x abs1
-  (** Deserialize JSON data of type {!abs1}. *)
+  (** Deserialize JSON data of type {!type:abs1}. *)
 

--- a/atdgen/test/test_annot_j.expected.mli
+++ b/atdgen/test/test_annot_j.expected.mli
@@ -9,11 +9,11 @@ type pointA = ProtoA_t.pointA = { f: float }
 
 val write_pointC :
   Bi_outbuf.t -> pointC -> unit
-  (** Output a JSON value of type {!pointC}. *)
+  (** Output a JSON value of type {!type:pointC}. *)
 
 val string_of_pointC :
   ?len:int -> pointC -> string
-  (** Serialize a value of type {!pointC}
+  (** Serialize a value of type {!type:pointC}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -21,19 +21,19 @@ val string_of_pointC :
 
 val read_pointC :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> pointC
-  (** Input JSON data of type {!pointC}. *)
+  (** Input JSON data of type {!type:pointC}. *)
 
 val pointC_of_string :
   string -> pointC
-  (** Deserialize JSON data of type {!pointC}. *)
+  (** Deserialize JSON data of type {!type:pointC}. *)
 
 val write_pointB :
   Bi_outbuf.t -> pointB -> unit
-  (** Output a JSON value of type {!pointB}. *)
+  (** Output a JSON value of type {!type:pointB}. *)
 
 val string_of_pointB :
   ?len:int -> pointB -> string
-  (** Serialize a value of type {!pointB}
+  (** Serialize a value of type {!type:pointB}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -41,19 +41,19 @@ val string_of_pointB :
 
 val read_pointB :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> pointB
-  (** Input JSON data of type {!pointB}. *)
+  (** Input JSON data of type {!type:pointB}. *)
 
 val pointB_of_string :
   string -> pointB
-  (** Deserialize JSON data of type {!pointB}. *)
+  (** Deserialize JSON data of type {!type:pointB}. *)
 
 val write_pointA :
   Bi_outbuf.t -> pointA -> unit
-  (** Output a JSON value of type {!pointA}. *)
+  (** Output a JSON value of type {!type:pointA}. *)
 
 val string_of_pointA :
   ?len:int -> pointA -> string
-  (** Serialize a value of type {!pointA}
+  (** Serialize a value of type {!type:pointA}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -61,9 +61,9 @@ val string_of_pointA :
 
 val read_pointA :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> pointA
-  (** Input JSON data of type {!pointA}. *)
+  (** Input JSON data of type {!type:pointA}. *)
 
 val pointA_of_string :
   string -> pointA
-  (** Deserialize JSON data of type {!pointA}. *)
+  (** Deserialize JSON data of type {!type:pointA}. *)
 

--- a/atdgen/test/testj.expected.mli
+++ b/atdgen/test/testj.expected.mli
@@ -159,11 +159,11 @@ type 'a abs1 = 'a Test.abs1
 
 val write_test_variant :
   Bi_outbuf.t -> test_variant -> unit
-  (** Output a JSON value of type {!test_variant}. *)
+  (** Output a JSON value of type {!type:test_variant}. *)
 
 val string_of_test_variant :
   ?len:int -> test_variant -> string
-  (** Serialize a value of type {!test_variant}
+  (** Serialize a value of type {!type:test_variant}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -171,24 +171,24 @@ val string_of_test_variant :
 
 val read_test_variant :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> test_variant
-  (** Input JSON data of type {!test_variant}. *)
+  (** Input JSON data of type {!type:test_variant}. *)
 
 val test_variant_of_string :
   string -> test_variant
-  (** Deserialize JSON data of type {!test_variant}. *)
+  (** Deserialize JSON data of type {!type:test_variant}. *)
 
 
 val write_poly :
   (Bi_outbuf.t -> 'x -> unit) ->
   (Bi_outbuf.t -> 'y -> unit) ->
   Bi_outbuf.t -> ('x, 'y) poly -> unit
-  (** Output a JSON value of type {!poly}. *)
+  (** Output a JSON value of type {!type:poly}. *)
 
 val string_of_poly :
   (Bi_outbuf.t -> 'x -> unit) ->
   (Bi_outbuf.t -> 'y -> unit) ->
   ?len:int -> ('x, 'y) poly -> string
-  (** Serialize a value of type {!poly}
+  (** Serialize a value of type {!type:poly}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -198,30 +198,30 @@ val read_poly :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'y) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> ('x, 'y) poly
-  (** Input JSON data of type {!poly}. *)
+  (** Input JSON data of type {!type:poly}. *)
 
 val poly_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'y) ->
   string -> ('x, 'y) poly
-  (** Deserialize JSON data of type {!poly}. *)
+  (** Deserialize JSON data of type {!type:poly}. *)
 
 val create_poly :
   fst: 'x list ->
   snd: ('x, 'y) poly option ->
   unit -> ('x, 'y) poly
-  (** Create a record of type {!poly}. *)
+  (** Create a record of type {!type:poly}. *)
 
 
 val write_p' :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a p' -> unit
-  (** Output a JSON value of type {!p'}. *)
+  (** Output a JSON value of type {!type:p'}. *)
 
 val string_of_p' :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a p' -> string
-  (** Serialize a value of type {!p'}
+  (** Serialize a value of type {!type:p'}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -230,21 +230,21 @@ val string_of_p' :
 val read_p' :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a p'
-  (** Input JSON data of type {!p'}. *)
+  (** Input JSON data of type {!type:p'}. *)
 
 val p'_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a p'
-  (** Deserialize JSON data of type {!p'}. *)
+  (** Deserialize JSON data of type {!type:p'}. *)
 
 
 val write_p :
   Bi_outbuf.t -> p -> unit
-  (** Output a JSON value of type {!p}. *)
+  (** Output a JSON value of type {!type:p}. *)
 
 val string_of_p :
   ?len:int -> p -> string
-  (** Serialize a value of type {!p}
+  (** Serialize a value of type {!type:p}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -252,20 +252,20 @@ val string_of_p :
 
 val read_p :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> p
-  (** Input JSON data of type {!p}. *)
+  (** Input JSON data of type {!type:p}. *)
 
 val p_of_string :
   string -> p
-  (** Deserialize JSON data of type {!p}. *)
+  (** Deserialize JSON data of type {!type:p}. *)
 
 
 val write_r :
   Bi_outbuf.t -> r -> unit
-  (** Output a JSON value of type {!r}. *)
+  (** Output a JSON value of type {!type:r}. *)
 
 val string_of_r :
   ?len:int -> r -> string
-  (** Serialize a value of type {!r}
+  (** Serialize a value of type {!type:r}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -273,27 +273,27 @@ val string_of_r :
 
 val read_r :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> r
-  (** Input JSON data of type {!r}. *)
+  (** Input JSON data of type {!type:r}. *)
 
 val r_of_string :
   string -> r
-  (** Deserialize JSON data of type {!r}. *)
+  (** Deserialize JSON data of type {!type:r}. *)
 
 val create_r :
   a: int ->
   b: bool ->
   c: p ->
   unit -> r
-  (** Create a record of type {!r}. *)
+  (** Create a record of type {!type:r}. *)
 
 
 val write_validated_string_check :
   Bi_outbuf.t -> validated_string_check -> unit
-  (** Output a JSON value of type {!validated_string_check}. *)
+  (** Output a JSON value of type {!type:validated_string_check}. *)
 
 val string_of_validated_string_check :
   ?len:int -> validated_string_check -> string
-  (** Serialize a value of type {!validated_string_check}
+  (** Serialize a value of type {!type:validated_string_check}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -301,20 +301,20 @@ val string_of_validated_string_check :
 
 val read_validated_string_check :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> validated_string_check
-  (** Input JSON data of type {!validated_string_check}. *)
+  (** Input JSON data of type {!type:validated_string_check}. *)
 
 val validated_string_check_of_string :
   string -> validated_string_check
-  (** Deserialize JSON data of type {!validated_string_check}. *)
+  (** Deserialize JSON data of type {!type:validated_string_check}. *)
 
 
 val write_validate_me :
   Bi_outbuf.t -> validate_me -> unit
-  (** Output a JSON value of type {!validate_me}. *)
+  (** Output a JSON value of type {!type:validate_me}. *)
 
 val string_of_validate_me :
   ?len:int -> validate_me -> string
-  (** Serialize a value of type {!validate_me}
+  (** Serialize a value of type {!type:validate_me}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -322,20 +322,20 @@ val string_of_validate_me :
 
 val read_validate_me :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> validate_me
-  (** Input JSON data of type {!validate_me}. *)
+  (** Input JSON data of type {!type:validate_me}. *)
 
 val validate_me_of_string :
   string -> validate_me
-  (** Deserialize JSON data of type {!validate_me}. *)
+  (** Deserialize JSON data of type {!type:validate_me}. *)
 
 
 val write_val1 :
   Bi_outbuf.t -> val1 -> unit
-  (** Output a JSON value of type {!val1}. *)
+  (** Output a JSON value of type {!type:val1}. *)
 
 val string_of_val1 :
   ?len:int -> val1 -> string
-  (** Serialize a value of type {!val1}
+  (** Serialize a value of type {!type:val1}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -343,25 +343,25 @@ val string_of_val1 :
 
 val read_val1 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> val1
-  (** Input JSON data of type {!val1}. *)
+  (** Input JSON data of type {!type:val1}. *)
 
 val val1_of_string :
   string -> val1
-  (** Deserialize JSON data of type {!val1}. *)
+  (** Deserialize JSON data of type {!type:val1}. *)
 
 val create_val1 :
   val1_x: int ->
   unit -> val1
-  (** Create a record of type {!val1}. *)
+  (** Create a record of type {!type:val1}. *)
 
 
 val write_val2 :
   Bi_outbuf.t -> val2 -> unit
-  (** Output a JSON value of type {!val2}. *)
+  (** Output a JSON value of type {!type:val2}. *)
 
 val string_of_val2 :
   ?len:int -> val2 -> string
-  (** Serialize a value of type {!val2}
+  (** Serialize a value of type {!type:val2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -369,26 +369,26 @@ val string_of_val2 :
 
 val read_val2 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> val2
-  (** Input JSON data of type {!val2}. *)
+  (** Input JSON data of type {!type:val2}. *)
 
 val val2_of_string :
   string -> val2
-  (** Deserialize JSON data of type {!val2}. *)
+  (** Deserialize JSON data of type {!type:val2}. *)
 
 val create_val2 :
   val2_x: val1 ->
   ?val2_y: val1 ->
   unit -> val2
-  (** Create a record of type {!val2}. *)
+  (** Create a record of type {!type:val2}. *)
 
 
 val write_unixtime_list :
   Bi_outbuf.t -> unixtime_list -> unit
-  (** Output a JSON value of type {!unixtime_list}. *)
+  (** Output a JSON value of type {!type:unixtime_list}. *)
 
 val string_of_unixtime_list :
   ?len:int -> unixtime_list -> string
-  (** Serialize a value of type {!unixtime_list}
+  (** Serialize a value of type {!type:unixtime_list}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -396,20 +396,20 @@ val string_of_unixtime_list :
 
 val read_unixtime_list :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> unixtime_list
-  (** Input JSON data of type {!unixtime_list}. *)
+  (** Input JSON data of type {!type:unixtime_list}. *)
 
 val unixtime_list_of_string :
   string -> unixtime_list
-  (** Deserialize JSON data of type {!unixtime_list}. *)
+  (** Deserialize JSON data of type {!type:unixtime_list}. *)
 
 
 val write_date :
   Bi_outbuf.t -> date -> unit
-  (** Output a JSON value of type {!date}. *)
+  (** Output a JSON value of type {!type:date}. *)
 
 val string_of_date :
   ?len:int -> date -> string
-  (** Serialize a value of type {!date}
+  (** Serialize a value of type {!type:date}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -417,20 +417,20 @@ val string_of_date :
 
 val read_date :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> date
-  (** Input JSON data of type {!date}. *)
+  (** Input JSON data of type {!type:date}. *)
 
 val date_of_string :
   string -> date
-  (** Deserialize JSON data of type {!date}. *)
+  (** Deserialize JSON data of type {!type:date}. *)
 
 
 val write_mixed_record :
   Bi_outbuf.t -> mixed_record -> unit
-  (** Output a JSON value of type {!mixed_record}. *)
+  (** Output a JSON value of type {!type:mixed_record}. *)
 
 val string_of_mixed_record :
   ?len:int -> mixed_record -> string
-  (** Serialize a value of type {!mixed_record}
+  (** Serialize a value of type {!type:mixed_record}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -438,11 +438,11 @@ val string_of_mixed_record :
 
 val read_mixed_record :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> mixed_record
-  (** Input JSON data of type {!mixed_record}. *)
+  (** Input JSON data of type {!type:mixed_record}. *)
 
 val mixed_record_of_string :
   string -> mixed_record
-  (** Deserialize JSON data of type {!mixed_record}. *)
+  (** Deserialize JSON data of type {!type:mixed_record}. *)
 
 val create_mixed_record :
   ?field0: int ->
@@ -461,16 +461,16 @@ val create_mixed_record :
   field13: string option list ->
   field14: date ->
   unit -> mixed_record
-  (** Create a record of type {!mixed_record}. *)
+  (** Create a record of type {!type:mixed_record}. *)
 
 
 val write_mixed :
   Bi_outbuf.t -> mixed -> unit
-  (** Output a JSON value of type {!mixed}. *)
+  (** Output a JSON value of type {!type:mixed}. *)
 
 val string_of_mixed :
   ?len:int -> mixed -> string
-  (** Serialize a value of type {!mixed}
+  (** Serialize a value of type {!type:mixed}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -478,20 +478,20 @@ val string_of_mixed :
 
 val read_mixed :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> mixed
-  (** Input JSON data of type {!mixed}. *)
+  (** Input JSON data of type {!type:mixed}. *)
 
 val mixed_of_string :
   string -> mixed
-  (** Deserialize JSON data of type {!mixed}. *)
+  (** Deserialize JSON data of type {!type:mixed}. *)
 
 
 val write_test :
   Bi_outbuf.t -> test -> unit
-  (** Output a JSON value of type {!test}. *)
+  (** Output a JSON value of type {!type:test}. *)
 
 val string_of_test :
   ?len:int -> test -> string
-  (** Serialize a value of type {!test}
+  (** Serialize a value of type {!type:test}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -499,11 +499,11 @@ val string_of_test :
 
 val read_test :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> test
-  (** Input JSON data of type {!test}. *)
+  (** Input JSON data of type {!type:test}. *)
 
 val test_of_string :
   string -> test
-  (** Deserialize JSON data of type {!test}. *)
+  (** Deserialize JSON data of type {!type:test}. *)
 
 val create_test :
   ?x0: int ->
@@ -512,16 +512,16 @@ val create_test :
   x3: mixed_record list ->
   x4: Int64.t ->
   unit -> test
-  (** Create a record of type {!test}. *)
+  (** Create a record of type {!type:test}. *)
 
 
 val write_tup :
   Bi_outbuf.t -> tup -> unit
-  (** Output a JSON value of type {!tup}. *)
+  (** Output a JSON value of type {!type:tup}. *)
 
 val string_of_tup :
   ?len:int -> tup -> string
-  (** Serialize a value of type {!tup}
+  (** Serialize a value of type {!type:tup}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -529,20 +529,20 @@ val string_of_tup :
 
 val read_tup :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> tup
-  (** Input JSON data of type {!tup}. *)
+  (** Input JSON data of type {!type:tup}. *)
 
 val tup_of_string :
   string -> tup
-  (** Deserialize JSON data of type {!tup}. *)
+  (** Deserialize JSON data of type {!type:tup}. *)
 
 
 val write_test_field_prefix :
   Bi_outbuf.t -> test_field_prefix -> unit
-  (** Output a JSON value of type {!test_field_prefix}. *)
+  (** Output a JSON value of type {!type:test_field_prefix}. *)
 
 val string_of_test_field_prefix :
   ?len:int -> test_field_prefix -> string
-  (** Serialize a value of type {!test_field_prefix}
+  (** Serialize a value of type {!type:test_field_prefix}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -550,26 +550,26 @@ val string_of_test_field_prefix :
 
 val read_test_field_prefix :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> test_field_prefix
-  (** Input JSON data of type {!test_field_prefix}. *)
+  (** Input JSON data of type {!type:test_field_prefix}. *)
 
 val test_field_prefix_of_string :
   string -> test_field_prefix
-  (** Deserialize JSON data of type {!test_field_prefix}. *)
+  (** Deserialize JSON data of type {!type:test_field_prefix}. *)
 
 val create_test_field_prefix :
   theprefix_hello: bool ->
   theprefix_world: int ->
   unit -> test_field_prefix
-  (** Create a record of type {!test_field_prefix}. *)
+  (** Create a record of type {!type:test_field_prefix}. *)
 
 
 val write_star_rating :
   Bi_outbuf.t -> star_rating -> unit
-  (** Output a JSON value of type {!star_rating}. *)
+  (** Output a JSON value of type {!type:star_rating}. *)
 
 val string_of_star_rating :
   ?len:int -> star_rating -> string
-  (** Serialize a value of type {!star_rating}
+  (** Serialize a value of type {!type:star_rating}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -577,22 +577,22 @@ val string_of_star_rating :
 
 val read_star_rating :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> star_rating
-  (** Input JSON data of type {!star_rating}. *)
+  (** Input JSON data of type {!type:star_rating}. *)
 
 val star_rating_of_string :
   string -> star_rating
-  (** Deserialize JSON data of type {!star_rating}. *)
+  (** Deserialize JSON data of type {!type:star_rating}. *)
 
 
 val write_generic :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a generic -> unit
-  (** Output a JSON value of type {!generic}. *)
+  (** Output a JSON value of type {!type:generic}. *)
 
 val string_of_generic :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a generic -> string
-  (** Serialize a value of type {!generic}
+  (** Serialize a value of type {!type:generic}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -601,26 +601,26 @@ val string_of_generic :
 val read_generic :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a generic
-  (** Input JSON data of type {!generic}. *)
+  (** Input JSON data of type {!type:generic}. *)
 
 val generic_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a generic
-  (** Deserialize JSON data of type {!generic}. *)
+  (** Deserialize JSON data of type {!type:generic}. *)
 
 val create_generic :
   x294623: int ->
   unit -> 'a generic
-  (** Create a record of type {!generic}. *)
+  (** Create a record of type {!type:generic}. *)
 
 
 val write_specialized :
   Bi_outbuf.t -> specialized -> unit
-  (** Output a JSON value of type {!specialized}. *)
+  (** Output a JSON value of type {!type:specialized}. *)
 
 val string_of_specialized :
   ?len:int -> specialized -> string
-  (** Serialize a value of type {!specialized}
+  (** Serialize a value of type {!type:specialized}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -628,20 +628,20 @@ val string_of_specialized :
 
 val read_specialized :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> specialized
-  (** Input JSON data of type {!specialized}. *)
+  (** Input JSON data of type {!type:specialized}. *)
 
 val specialized_of_string :
   string -> specialized
-  (** Deserialize JSON data of type {!specialized}. *)
+  (** Deserialize JSON data of type {!type:specialized}. *)
 
 
 val write_some_record :
   Bi_outbuf.t -> some_record -> unit
-  (** Output a JSON value of type {!some_record}. *)
+  (** Output a JSON value of type {!type:some_record}. *)
 
 val string_of_some_record :
   ?len:int -> some_record -> string
-  (** Serialize a value of type {!some_record}
+  (** Serialize a value of type {!type:some_record}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -649,25 +649,25 @@ val string_of_some_record :
 
 val read_some_record :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> some_record
-  (** Input JSON data of type {!some_record}. *)
+  (** Input JSON data of type {!type:some_record}. *)
 
 val some_record_of_string :
   string -> some_record
-  (** Deserialize JSON data of type {!some_record}. *)
+  (** Deserialize JSON data of type {!type:some_record}. *)
 
 val create_some_record :
   some_field: int ->
   unit -> some_record
-  (** Create a record of type {!some_record}. *)
+  (** Create a record of type {!type:some_record}. *)
 
 
 val write_precision :
   Bi_outbuf.t -> precision -> unit
-  (** Output a JSON value of type {!precision}. *)
+  (** Output a JSON value of type {!type:precision}. *)
 
 val string_of_precision :
   ?len:int -> precision -> string
-  (** Serialize a value of type {!precision}
+  (** Serialize a value of type {!type:precision}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -675,27 +675,27 @@ val string_of_precision :
 
 val read_precision :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> precision
-  (** Input JSON data of type {!precision}. *)
+  (** Input JSON data of type {!type:precision}. *)
 
 val precision_of_string :
   string -> precision
-  (** Deserialize JSON data of type {!precision}. *)
+  (** Deserialize JSON data of type {!type:precision}. *)
 
 val create_precision :
   sqrt2_5: float ->
   small_2: float ->
   large_2: float ->
   unit -> precision
-  (** Create a record of type {!precision}. *)
+  (** Create a record of type {!type:precision}. *)
 
 
 val write_p'' :
   Bi_outbuf.t -> p'' -> unit
-  (** Output a JSON value of type {!p''}. *)
+  (** Output a JSON value of type {!type:p''}. *)
 
 val string_of_p'' :
   ?len:int -> p'' -> string
-  (** Serialize a value of type {!p''}
+  (** Serialize a value of type {!type:p''}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -703,20 +703,20 @@ val string_of_p'' :
 
 val read_p'' :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> p''
-  (** Input JSON data of type {!p''}. *)
+  (** Input JSON data of type {!type:p''}. *)
 
 val p''_of_string :
   string -> p''
-  (** Deserialize JSON data of type {!p''}. *)
+  (** Deserialize JSON data of type {!type:p''}. *)
 
 
 val write_option_validation :
   Bi_outbuf.t -> option_validation -> unit
-  (** Output a JSON value of type {!option_validation}. *)
+  (** Output a JSON value of type {!type:option_validation}. *)
 
 val string_of_option_validation :
   ?len:int -> option_validation -> string
-  (** Serialize a value of type {!option_validation}
+  (** Serialize a value of type {!type:option_validation}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -724,20 +724,20 @@ val string_of_option_validation :
 
 val read_option_validation :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> option_validation
-  (** Input JSON data of type {!option_validation}. *)
+  (** Input JSON data of type {!type:option_validation}. *)
 
 val option_validation_of_string :
   string -> option_validation
-  (** Deserialize JSON data of type {!option_validation}. *)
+  (** Deserialize JSON data of type {!type:option_validation}. *)
 
 
 val write_no_real_wrap :
   Bi_outbuf.t -> no_real_wrap -> unit
-  (** Output a JSON value of type {!no_real_wrap}. *)
+  (** Output a JSON value of type {!type:no_real_wrap}. *)
 
 val string_of_no_real_wrap :
   ?len:int -> no_real_wrap -> string
-  (** Serialize a value of type {!no_real_wrap}
+  (** Serialize a value of type {!type:no_real_wrap}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -745,20 +745,20 @@ val string_of_no_real_wrap :
 
 val read_no_real_wrap :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> no_real_wrap
-  (** Input JSON data of type {!no_real_wrap}. *)
+  (** Input JSON data of type {!type:no_real_wrap}. *)
 
 val no_real_wrap_of_string :
   string -> no_real_wrap
-  (** Deserialize JSON data of type {!no_real_wrap}. *)
+  (** Deserialize JSON data of type {!type:no_real_wrap}. *)
 
 
 val write_natural :
   Bi_outbuf.t -> natural -> unit
-  (** Output a JSON value of type {!natural}. *)
+  (** Output a JSON value of type {!type:natural}. *)
 
 val string_of_natural :
   ?len:int -> natural -> string
-  (** Serialize a value of type {!natural}
+  (** Serialize a value of type {!type:natural}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -766,20 +766,20 @@ val string_of_natural :
 
 val read_natural :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> natural
-  (** Input JSON data of type {!natural}. *)
+  (** Input JSON data of type {!type:natural}. *)
 
 val natural_of_string :
   string -> natural
-  (** Deserialize JSON data of type {!natural}. *)
+  (** Deserialize JSON data of type {!type:natural}. *)
 
 
 val write_id :
   Bi_outbuf.t -> id -> unit
-  (** Output a JSON value of type {!id}. *)
+  (** Output a JSON value of type {!type:id}. *)
 
 val string_of_id :
   ?len:int -> id -> string
-  (** Serialize a value of type {!id}
+  (** Serialize a value of type {!type:id}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -787,20 +787,20 @@ val string_of_id :
 
 val read_id :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> id
-  (** Input JSON data of type {!id}. *)
+  (** Input JSON data of type {!type:id}. *)
 
 val id_of_string :
   string -> id
-  (** Deserialize JSON data of type {!id}. *)
+  (** Deserialize JSON data of type {!type:id}. *)
 
 
 val write_json_map :
   Bi_outbuf.t -> json_map -> unit
-  (** Output a JSON value of type {!json_map}. *)
+  (** Output a JSON value of type {!type:json_map}. *)
 
 val string_of_json_map :
   ?len:int -> json_map -> string
-  (** Serialize a value of type {!json_map}
+  (** Serialize a value of type {!type:json_map}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -808,20 +808,20 @@ val string_of_json_map :
 
 val read_json_map :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> json_map
-  (** Input JSON data of type {!json_map}. *)
+  (** Input JSON data of type {!type:json_map}. *)
 
 val json_map_of_string :
   string -> json_map
-  (** Deserialize JSON data of type {!json_map}. *)
+  (** Deserialize JSON data of type {!type:json_map}. *)
 
 
 val write_intopt :
   Bi_outbuf.t -> intopt -> unit
-  (** Output a JSON value of type {!intopt}. *)
+  (** Output a JSON value of type {!type:intopt}. *)
 
 val string_of_intopt :
   ?len:int -> intopt -> string
-  (** Serialize a value of type {!intopt}
+  (** Serialize a value of type {!type:intopt}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -829,20 +829,20 @@ val string_of_intopt :
 
 val read_intopt :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> intopt
-  (** Input JSON data of type {!intopt}. *)
+  (** Input JSON data of type {!type:intopt}. *)
 
 val intopt_of_string :
   string -> intopt
-  (** Deserialize JSON data of type {!intopt}. *)
+  (** Deserialize JSON data of type {!type:intopt}. *)
 
 
 val write_int_assoc_list :
   Bi_outbuf.t -> int_assoc_list -> unit
-  (** Output a JSON value of type {!int_assoc_list}. *)
+  (** Output a JSON value of type {!type:int_assoc_list}. *)
 
 val string_of_int_assoc_list :
   ?len:int -> int_assoc_list -> string
-  (** Serialize a value of type {!int_assoc_list}
+  (** Serialize a value of type {!type:int_assoc_list}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -850,20 +850,20 @@ val string_of_int_assoc_list :
 
 val read_int_assoc_list :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int_assoc_list
-  (** Input JSON data of type {!int_assoc_list}. *)
+  (** Input JSON data of type {!type:int_assoc_list}. *)
 
 val int_assoc_list_of_string :
   string -> int_assoc_list
-  (** Deserialize JSON data of type {!int_assoc_list}. *)
+  (** Deserialize JSON data of type {!type:int_assoc_list}. *)
 
 
 val write_int_assoc_array :
   Bi_outbuf.t -> int_assoc_array -> unit
-  (** Output a JSON value of type {!int_assoc_array}. *)
+  (** Output a JSON value of type {!type:int_assoc_array}. *)
 
 val string_of_int_assoc_array :
   ?len:int -> int_assoc_array -> string
-  (** Serialize a value of type {!int_assoc_array}
+  (** Serialize a value of type {!type:int_assoc_array}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -871,20 +871,20 @@ val string_of_int_assoc_array :
 
 val read_int_assoc_array :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int_assoc_array
-  (** Input JSON data of type {!int_assoc_array}. *)
+  (** Input JSON data of type {!type:int_assoc_array}. *)
 
 val int_assoc_array_of_string :
   string -> int_assoc_array
-  (** Deserialize JSON data of type {!int_assoc_array}. *)
+  (** Deserialize JSON data of type {!type:int_assoc_array}. *)
 
 
 val write_int8 :
   Bi_outbuf.t -> int8 -> unit
-  (** Output a JSON value of type {!int8}. *)
+  (** Output a JSON value of type {!type:int8}. *)
 
 val string_of_int8 :
   ?len:int -> int8 -> string
-  (** Serialize a value of type {!int8}
+  (** Serialize a value of type {!type:int8}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -892,20 +892,20 @@ val string_of_int8 :
 
 val read_int8 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int8
-  (** Input JSON data of type {!int8}. *)
+  (** Input JSON data of type {!type:int8}. *)
 
 val int8_of_string :
   string -> int8
-  (** Deserialize JSON data of type {!int8}. *)
+  (** Deserialize JSON data of type {!type:int8}. *)
 
 
 val write_int64 :
   Bi_outbuf.t -> int64 -> unit
-  (** Output a JSON value of type {!int64}. *)
+  (** Output a JSON value of type {!type:int64}. *)
 
 val string_of_int64 :
   ?len:int -> int64 -> string
-  (** Serialize a value of type {!int64}
+  (** Serialize a value of type {!type:int64}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -913,20 +913,20 @@ val string_of_int64 :
 
 val read_int64 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int64
-  (** Input JSON data of type {!int64}. *)
+  (** Input JSON data of type {!type:int64}. *)
 
 val int64_of_string :
   string -> int64
-  (** Deserialize JSON data of type {!int64}. *)
+  (** Deserialize JSON data of type {!type:int64}. *)
 
 
 val write_int32 :
   Bi_outbuf.t -> int32 -> unit
-  (** Output a JSON value of type {!int32}. *)
+  (** Output a JSON value of type {!type:int32}. *)
 
 val string_of_int32 :
   ?len:int -> int32 -> string
-  (** Serialize a value of type {!int32}
+  (** Serialize a value of type {!type:int32}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -934,20 +934,20 @@ val string_of_int32 :
 
 val read_int32 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int32
-  (** Input JSON data of type {!int32}. *)
+  (** Input JSON data of type {!type:int32}. *)
 
 val int32_of_string :
   string -> int32
-  (** Deserialize JSON data of type {!int32}. *)
+  (** Deserialize JSON data of type {!type:int32}. *)
 
 
 val write_hello :
   Bi_outbuf.t -> hello -> unit
-  (** Output a JSON value of type {!hello}. *)
+  (** Output a JSON value of type {!type:hello}. *)
 
 val string_of_hello :
   ?len:int -> hello -> string
-  (** Serialize a value of type {!hello}
+  (** Serialize a value of type {!type:hello}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -955,20 +955,20 @@ val string_of_hello :
 
 val read_hello :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> hello
-  (** Input JSON data of type {!hello}. *)
+  (** Input JSON data of type {!type:hello}. *)
 
 val hello_of_string :
   string -> hello
-  (** Deserialize JSON data of type {!hello}. *)
+  (** Deserialize JSON data of type {!type:hello}. *)
 
 
 val write_floats :
   Bi_outbuf.t -> floats -> unit
-  (** Output a JSON value of type {!floats}. *)
+  (** Output a JSON value of type {!type:floats}. *)
 
 val string_of_floats :
   ?len:int -> floats -> string
-  (** Serialize a value of type {!floats}
+  (** Serialize a value of type {!type:floats}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -976,26 +976,26 @@ val string_of_floats :
 
 val read_floats :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> floats
-  (** Input JSON data of type {!floats}. *)
+  (** Input JSON data of type {!type:floats}. *)
 
 val floats_of_string :
   string -> floats
-  (** Deserialize JSON data of type {!floats}. *)
+  (** Deserialize JSON data of type {!type:floats}. *)
 
 val create_floats :
   f32: float ->
   f64: float ->
   unit -> floats
-  (** Create a record of type {!floats}. *)
+  (** Create a record of type {!type:floats}. *)
 
 
 val write_extended_tuple :
   Bi_outbuf.t -> extended_tuple -> unit
-  (** Output a JSON value of type {!extended_tuple}. *)
+  (** Output a JSON value of type {!type:extended_tuple}. *)
 
 val string_of_extended_tuple :
   ?len:int -> extended_tuple -> string
-  (** Serialize a value of type {!extended_tuple}
+  (** Serialize a value of type {!type:extended_tuple}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1003,20 +1003,20 @@ val string_of_extended_tuple :
 
 val read_extended_tuple :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> extended_tuple
-  (** Input JSON data of type {!extended_tuple}. *)
+  (** Input JSON data of type {!type:extended_tuple}. *)
 
 val extended_tuple_of_string :
   string -> extended_tuple
-  (** Deserialize JSON data of type {!extended_tuple}. *)
+  (** Deserialize JSON data of type {!type:extended_tuple}. *)
 
 
 val write_extended :
   Bi_outbuf.t -> extended -> unit
-  (** Output a JSON value of type {!extended}. *)
+  (** Output a JSON value of type {!type:extended}. *)
 
 val string_of_extended :
   ?len:int -> extended -> string
-  (** Serialize a value of type {!extended}
+  (** Serialize a value of type {!type:extended}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1024,11 +1024,11 @@ val string_of_extended :
 
 val read_extended :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> extended
-  (** Input JSON data of type {!extended}. *)
+  (** Input JSON data of type {!type:extended}. *)
 
 val extended_of_string :
   string -> extended
-  (** Deserialize JSON data of type {!extended}. *)
+  (** Deserialize JSON data of type {!type:extended}. *)
 
 val create_extended :
   b0x: int ->
@@ -1038,16 +1038,16 @@ val create_extended :
   b4x: string option ->
   ?b5x: float ->
   unit -> extended
-  (** Create a record of type {!extended}. *)
+  (** Create a record of type {!type:extended}. *)
 
 
 val write_even_natural :
   Bi_outbuf.t -> even_natural -> unit
-  (** Output a JSON value of type {!even_natural}. *)
+  (** Output a JSON value of type {!type:even_natural}. *)
 
 val string_of_even_natural :
   ?len:int -> even_natural -> string
-  (** Serialize a value of type {!even_natural}
+  (** Serialize a value of type {!type:even_natural}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1055,20 +1055,20 @@ val string_of_even_natural :
 
 val read_even_natural :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> even_natural
-  (** Input JSON data of type {!even_natural}. *)
+  (** Input JSON data of type {!type:even_natural}. *)
 
 val even_natural_of_string :
   string -> even_natural
-  (** Deserialize JSON data of type {!even_natural}. *)
+  (** Deserialize JSON data of type {!type:even_natural}. *)
 
 
 val write_def :
   Bi_outbuf.t -> def -> unit
-  (** Output a JSON value of type {!def}. *)
+  (** Output a JSON value of type {!type:def}. *)
 
 val string_of_def :
   ?len:int -> def -> string
-  (** Serialize a value of type {!def}
+  (** Serialize a value of type {!type:def}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1076,20 +1076,20 @@ val string_of_def :
 
 val read_def :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> def
-  (** Input JSON data of type {!def}. *)
+  (** Input JSON data of type {!type:def}. *)
 
 val def_of_string :
   string -> def
-  (** Deserialize JSON data of type {!def}. *)
+  (** Deserialize JSON data of type {!type:def}. *)
 
 
 val write_char :
   Bi_outbuf.t -> char -> unit
-  (** Output a JSON value of type {!char}. *)
+  (** Output a JSON value of type {!type:char}. *)
 
 val string_of_char :
   ?len:int -> char -> string
-  (** Serialize a value of type {!char}
+  (** Serialize a value of type {!type:char}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1097,20 +1097,20 @@ val string_of_char :
 
 val read_char :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> char
-  (** Input JSON data of type {!char}. *)
+  (** Input JSON data of type {!type:char}. *)
 
 val char_of_string :
   string -> char
-  (** Deserialize JSON data of type {!char}. *)
+  (** Deserialize JSON data of type {!type:char}. *)
 
 
 val write_base_tuple :
   Bi_outbuf.t -> base_tuple -> unit
-  (** Output a JSON value of type {!base_tuple}. *)
+  (** Output a JSON value of type {!type:base_tuple}. *)
 
 val string_of_base_tuple :
   ?len:int -> base_tuple -> string
-  (** Serialize a value of type {!base_tuple}
+  (** Serialize a value of type {!type:base_tuple}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1118,20 +1118,20 @@ val string_of_base_tuple :
 
 val read_base_tuple :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> base_tuple
-  (** Input JSON data of type {!base_tuple}. *)
+  (** Input JSON data of type {!type:base_tuple}. *)
 
 val base_tuple_of_string :
   string -> base_tuple
-  (** Deserialize JSON data of type {!base_tuple}. *)
+  (** Deserialize JSON data of type {!type:base_tuple}. *)
 
 
 val write_base :
   Bi_outbuf.t -> base -> unit
-  (** Output a JSON value of type {!base}. *)
+  (** Output a JSON value of type {!type:base}. *)
 
 val string_of_base :
   ?len:int -> base -> string
-  (** Serialize a value of type {!base}
+  (** Serialize a value of type {!type:base}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1139,28 +1139,28 @@ val string_of_base :
 
 val read_base :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> base
-  (** Input JSON data of type {!base}. *)
+  (** Input JSON data of type {!type:base}. *)
 
 val base_of_string :
   string -> base
-  (** Deserialize JSON data of type {!base}. *)
+  (** Deserialize JSON data of type {!type:base}. *)
 
 val create_base :
   b0: int ->
   b1: bool ->
   unit -> base
-  (** Create a record of type {!base}. *)
+  (** Create a record of type {!type:base}. *)
 
 
 val write_array :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a array -> unit
-  (** Output a JSON value of type {!array}. *)
+  (** Output a JSON value of type {!type:array}. *)
 
 val string_of_array :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a array -> string
-  (** Serialize a value of type {!array}
+  (** Serialize a value of type {!type:array}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1169,23 +1169,23 @@ val string_of_array :
 val read_array :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a array
-  (** Input JSON data of type {!array}. *)
+  (** Input JSON data of type {!type:array}. *)
 
 val array_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a array
-  (** Deserialize JSON data of type {!array}. *)
+  (** Deserialize JSON data of type {!type:array}. *)
 
 
 val write_abs3 :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs3 -> unit
-  (** Output a JSON value of type {!abs3}. *)
+  (** Output a JSON value of type {!type:abs3}. *)
 
 val string_of_abs3 :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs3 -> string
-  (** Serialize a value of type {!abs3}
+  (** Serialize a value of type {!type:abs3}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1194,23 +1194,23 @@ val string_of_abs3 :
 val read_abs3 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a abs3
-  (** Input JSON data of type {!abs3}. *)
+  (** Input JSON data of type {!type:abs3}. *)
 
 val abs3_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a abs3
-  (** Deserialize JSON data of type {!abs3}. *)
+  (** Deserialize JSON data of type {!type:abs3}. *)
 
 
 val write_abs2 :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs2 -> unit
-  (** Output a JSON value of type {!abs2}. *)
+  (** Output a JSON value of type {!type:abs2}. *)
 
 val string_of_abs2 :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs2 -> string
-  (** Serialize a value of type {!abs2}
+  (** Serialize a value of type {!type:abs2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1219,23 +1219,23 @@ val string_of_abs2 :
 val read_abs2 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a abs2
-  (** Input JSON data of type {!abs2}. *)
+  (** Input JSON data of type {!type:abs2}. *)
 
 val abs2_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a abs2
-  (** Deserialize JSON data of type {!abs2}. *)
+  (** Deserialize JSON data of type {!type:abs2}. *)
 
 
 val write_abs1 :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs1 -> unit
-  (** Output a JSON value of type {!abs1}. *)
+  (** Output a JSON value of type {!type:abs1}. *)
 
 val string_of_abs1 :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs1 -> string
-  (** Serialize a value of type {!abs1}
+  (** Serialize a value of type {!type:abs1}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1244,11 +1244,11 @@ val string_of_abs1 :
 val read_abs1 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a abs1
-  (** Input JSON data of type {!abs1}. *)
+  (** Input JSON data of type {!type:abs1}. *)
 
 val abs1_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a abs1
-  (** Deserialize JSON data of type {!abs1}. *)
+  (** Deserialize JSON data of type {!type:abs1}. *)
 
 

--- a/atdgen/test/testjstd.expected.mli
+++ b/atdgen/test/testjstd.expected.mli
@@ -159,11 +159,11 @@ type 'a abs1 = 'a Test.abs1
 
 val write_test_variant :
   Bi_outbuf.t -> test_variant -> unit
-  (** Output a JSON value of type {!test_variant}. *)
+  (** Output a JSON value of type {!type:test_variant}. *)
 
 val string_of_test_variant :
   ?len:int -> test_variant -> string
-  (** Serialize a value of type {!test_variant}
+  (** Serialize a value of type {!type:test_variant}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -171,24 +171,24 @@ val string_of_test_variant :
 
 val read_test_variant :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> test_variant
-  (** Input JSON data of type {!test_variant}. *)
+  (** Input JSON data of type {!type:test_variant}. *)
 
 val test_variant_of_string :
   string -> test_variant
-  (** Deserialize JSON data of type {!test_variant}. *)
+  (** Deserialize JSON data of type {!type:test_variant}. *)
 
 
 val write_poly :
   (Bi_outbuf.t -> 'x -> unit) ->
   (Bi_outbuf.t -> 'y -> unit) ->
   Bi_outbuf.t -> ('x, 'y) poly -> unit
-  (** Output a JSON value of type {!poly}. *)
+  (** Output a JSON value of type {!type:poly}. *)
 
 val string_of_poly :
   (Bi_outbuf.t -> 'x -> unit) ->
   (Bi_outbuf.t -> 'y -> unit) ->
   ?len:int -> ('x, 'y) poly -> string
-  (** Serialize a value of type {!poly}
+  (** Serialize a value of type {!type:poly}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -198,30 +198,30 @@ val read_poly :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'y) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> ('x, 'y) poly
-  (** Input JSON data of type {!poly}. *)
+  (** Input JSON data of type {!type:poly}. *)
 
 val poly_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'x) ->
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'y) ->
   string -> ('x, 'y) poly
-  (** Deserialize JSON data of type {!poly}. *)
+  (** Deserialize JSON data of type {!type:poly}. *)
 
 val create_poly :
   fst: 'x list ->
   snd: ('x, 'y) poly option ->
   unit -> ('x, 'y) poly
-  (** Create a record of type {!poly}. *)
+  (** Create a record of type {!type:poly}. *)
 
 
 val write_p' :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a p' -> unit
-  (** Output a JSON value of type {!p'}. *)
+  (** Output a JSON value of type {!type:p'}. *)
 
 val string_of_p' :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a p' -> string
-  (** Serialize a value of type {!p'}
+  (** Serialize a value of type {!type:p'}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -230,21 +230,21 @@ val string_of_p' :
 val read_p' :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a p'
-  (** Input JSON data of type {!p'}. *)
+  (** Input JSON data of type {!type:p'}. *)
 
 val p'_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a p'
-  (** Deserialize JSON data of type {!p'}. *)
+  (** Deserialize JSON data of type {!type:p'}. *)
 
 
 val write_p :
   Bi_outbuf.t -> p -> unit
-  (** Output a JSON value of type {!p}. *)
+  (** Output a JSON value of type {!type:p}. *)
 
 val string_of_p :
   ?len:int -> p -> string
-  (** Serialize a value of type {!p}
+  (** Serialize a value of type {!type:p}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -252,20 +252,20 @@ val string_of_p :
 
 val read_p :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> p
-  (** Input JSON data of type {!p}. *)
+  (** Input JSON data of type {!type:p}. *)
 
 val p_of_string :
   string -> p
-  (** Deserialize JSON data of type {!p}. *)
+  (** Deserialize JSON data of type {!type:p}. *)
 
 
 val write_r :
   Bi_outbuf.t -> r -> unit
-  (** Output a JSON value of type {!r}. *)
+  (** Output a JSON value of type {!type:r}. *)
 
 val string_of_r :
   ?len:int -> r -> string
-  (** Serialize a value of type {!r}
+  (** Serialize a value of type {!type:r}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -273,27 +273,27 @@ val string_of_r :
 
 val read_r :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> r
-  (** Input JSON data of type {!r}. *)
+  (** Input JSON data of type {!type:r}. *)
 
 val r_of_string :
   string -> r
-  (** Deserialize JSON data of type {!r}. *)
+  (** Deserialize JSON data of type {!type:r}. *)
 
 val create_r :
   a: int ->
   b: bool ->
   c: p ->
   unit -> r
-  (** Create a record of type {!r}. *)
+  (** Create a record of type {!type:r}. *)
 
 
 val write_validated_string_check :
   Bi_outbuf.t -> validated_string_check -> unit
-  (** Output a JSON value of type {!validated_string_check}. *)
+  (** Output a JSON value of type {!type:validated_string_check}. *)
 
 val string_of_validated_string_check :
   ?len:int -> validated_string_check -> string
-  (** Serialize a value of type {!validated_string_check}
+  (** Serialize a value of type {!type:validated_string_check}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -301,20 +301,20 @@ val string_of_validated_string_check :
 
 val read_validated_string_check :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> validated_string_check
-  (** Input JSON data of type {!validated_string_check}. *)
+  (** Input JSON data of type {!type:validated_string_check}. *)
 
 val validated_string_check_of_string :
   string -> validated_string_check
-  (** Deserialize JSON data of type {!validated_string_check}. *)
+  (** Deserialize JSON data of type {!type:validated_string_check}. *)
 
 
 val write_validate_me :
   Bi_outbuf.t -> validate_me -> unit
-  (** Output a JSON value of type {!validate_me}. *)
+  (** Output a JSON value of type {!type:validate_me}. *)
 
 val string_of_validate_me :
   ?len:int -> validate_me -> string
-  (** Serialize a value of type {!validate_me}
+  (** Serialize a value of type {!type:validate_me}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -322,20 +322,20 @@ val string_of_validate_me :
 
 val read_validate_me :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> validate_me
-  (** Input JSON data of type {!validate_me}. *)
+  (** Input JSON data of type {!type:validate_me}. *)
 
 val validate_me_of_string :
   string -> validate_me
-  (** Deserialize JSON data of type {!validate_me}. *)
+  (** Deserialize JSON data of type {!type:validate_me}. *)
 
 
 val write_val1 :
   Bi_outbuf.t -> val1 -> unit
-  (** Output a JSON value of type {!val1}. *)
+  (** Output a JSON value of type {!type:val1}. *)
 
 val string_of_val1 :
   ?len:int -> val1 -> string
-  (** Serialize a value of type {!val1}
+  (** Serialize a value of type {!type:val1}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -343,25 +343,25 @@ val string_of_val1 :
 
 val read_val1 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> val1
-  (** Input JSON data of type {!val1}. *)
+  (** Input JSON data of type {!type:val1}. *)
 
 val val1_of_string :
   string -> val1
-  (** Deserialize JSON data of type {!val1}. *)
+  (** Deserialize JSON data of type {!type:val1}. *)
 
 val create_val1 :
   val1_x: int ->
   unit -> val1
-  (** Create a record of type {!val1}. *)
+  (** Create a record of type {!type:val1}. *)
 
 
 val write_val2 :
   Bi_outbuf.t -> val2 -> unit
-  (** Output a JSON value of type {!val2}. *)
+  (** Output a JSON value of type {!type:val2}. *)
 
 val string_of_val2 :
   ?len:int -> val2 -> string
-  (** Serialize a value of type {!val2}
+  (** Serialize a value of type {!type:val2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -369,26 +369,26 @@ val string_of_val2 :
 
 val read_val2 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> val2
-  (** Input JSON data of type {!val2}. *)
+  (** Input JSON data of type {!type:val2}. *)
 
 val val2_of_string :
   string -> val2
-  (** Deserialize JSON data of type {!val2}. *)
+  (** Deserialize JSON data of type {!type:val2}. *)
 
 val create_val2 :
   val2_x: val1 ->
   ?val2_y: val1 ->
   unit -> val2
-  (** Create a record of type {!val2}. *)
+  (** Create a record of type {!type:val2}. *)
 
 
 val write_unixtime_list :
   Bi_outbuf.t -> unixtime_list -> unit
-  (** Output a JSON value of type {!unixtime_list}. *)
+  (** Output a JSON value of type {!type:unixtime_list}. *)
 
 val string_of_unixtime_list :
   ?len:int -> unixtime_list -> string
-  (** Serialize a value of type {!unixtime_list}
+  (** Serialize a value of type {!type:unixtime_list}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -396,20 +396,20 @@ val string_of_unixtime_list :
 
 val read_unixtime_list :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> unixtime_list
-  (** Input JSON data of type {!unixtime_list}. *)
+  (** Input JSON data of type {!type:unixtime_list}. *)
 
 val unixtime_list_of_string :
   string -> unixtime_list
-  (** Deserialize JSON data of type {!unixtime_list}. *)
+  (** Deserialize JSON data of type {!type:unixtime_list}. *)
 
 
 val write_date :
   Bi_outbuf.t -> date -> unit
-  (** Output a JSON value of type {!date}. *)
+  (** Output a JSON value of type {!type:date}. *)
 
 val string_of_date :
   ?len:int -> date -> string
-  (** Serialize a value of type {!date}
+  (** Serialize a value of type {!type:date}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -417,20 +417,20 @@ val string_of_date :
 
 val read_date :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> date
-  (** Input JSON data of type {!date}. *)
+  (** Input JSON data of type {!type:date}. *)
 
 val date_of_string :
   string -> date
-  (** Deserialize JSON data of type {!date}. *)
+  (** Deserialize JSON data of type {!type:date}. *)
 
 
 val write_mixed_record :
   Bi_outbuf.t -> mixed_record -> unit
-  (** Output a JSON value of type {!mixed_record}. *)
+  (** Output a JSON value of type {!type:mixed_record}. *)
 
 val string_of_mixed_record :
   ?len:int -> mixed_record -> string
-  (** Serialize a value of type {!mixed_record}
+  (** Serialize a value of type {!type:mixed_record}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -438,11 +438,11 @@ val string_of_mixed_record :
 
 val read_mixed_record :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> mixed_record
-  (** Input JSON data of type {!mixed_record}. *)
+  (** Input JSON data of type {!type:mixed_record}. *)
 
 val mixed_record_of_string :
   string -> mixed_record
-  (** Deserialize JSON data of type {!mixed_record}. *)
+  (** Deserialize JSON data of type {!type:mixed_record}. *)
 
 val create_mixed_record :
   ?field0: int ->
@@ -461,16 +461,16 @@ val create_mixed_record :
   field13: string option list ->
   field14: date ->
   unit -> mixed_record
-  (** Create a record of type {!mixed_record}. *)
+  (** Create a record of type {!type:mixed_record}. *)
 
 
 val write_mixed :
   Bi_outbuf.t -> mixed -> unit
-  (** Output a JSON value of type {!mixed}. *)
+  (** Output a JSON value of type {!type:mixed}. *)
 
 val string_of_mixed :
   ?len:int -> mixed -> string
-  (** Serialize a value of type {!mixed}
+  (** Serialize a value of type {!type:mixed}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -478,20 +478,20 @@ val string_of_mixed :
 
 val read_mixed :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> mixed
-  (** Input JSON data of type {!mixed}. *)
+  (** Input JSON data of type {!type:mixed}. *)
 
 val mixed_of_string :
   string -> mixed
-  (** Deserialize JSON data of type {!mixed}. *)
+  (** Deserialize JSON data of type {!type:mixed}. *)
 
 
 val write_test :
   Bi_outbuf.t -> test -> unit
-  (** Output a JSON value of type {!test}. *)
+  (** Output a JSON value of type {!type:test}. *)
 
 val string_of_test :
   ?len:int -> test -> string
-  (** Serialize a value of type {!test}
+  (** Serialize a value of type {!type:test}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -499,11 +499,11 @@ val string_of_test :
 
 val read_test :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> test
-  (** Input JSON data of type {!test}. *)
+  (** Input JSON data of type {!type:test}. *)
 
 val test_of_string :
   string -> test
-  (** Deserialize JSON data of type {!test}. *)
+  (** Deserialize JSON data of type {!type:test}. *)
 
 val create_test :
   ?x0: int ->
@@ -512,16 +512,16 @@ val create_test :
   x3: mixed_record list ->
   x4: Int64.t ->
   unit -> test
-  (** Create a record of type {!test}. *)
+  (** Create a record of type {!type:test}. *)
 
 
 val write_tup :
   Bi_outbuf.t -> tup -> unit
-  (** Output a JSON value of type {!tup}. *)
+  (** Output a JSON value of type {!type:tup}. *)
 
 val string_of_tup :
   ?len:int -> tup -> string
-  (** Serialize a value of type {!tup}
+  (** Serialize a value of type {!type:tup}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -529,20 +529,20 @@ val string_of_tup :
 
 val read_tup :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> tup
-  (** Input JSON data of type {!tup}. *)
+  (** Input JSON data of type {!type:tup}. *)
 
 val tup_of_string :
   string -> tup
-  (** Deserialize JSON data of type {!tup}. *)
+  (** Deserialize JSON data of type {!type:tup}. *)
 
 
 val write_test_field_prefix :
   Bi_outbuf.t -> test_field_prefix -> unit
-  (** Output a JSON value of type {!test_field_prefix}. *)
+  (** Output a JSON value of type {!type:test_field_prefix}. *)
 
 val string_of_test_field_prefix :
   ?len:int -> test_field_prefix -> string
-  (** Serialize a value of type {!test_field_prefix}
+  (** Serialize a value of type {!type:test_field_prefix}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -550,26 +550,26 @@ val string_of_test_field_prefix :
 
 val read_test_field_prefix :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> test_field_prefix
-  (** Input JSON data of type {!test_field_prefix}. *)
+  (** Input JSON data of type {!type:test_field_prefix}. *)
 
 val test_field_prefix_of_string :
   string -> test_field_prefix
-  (** Deserialize JSON data of type {!test_field_prefix}. *)
+  (** Deserialize JSON data of type {!type:test_field_prefix}. *)
 
 val create_test_field_prefix :
   theprefix_hello: bool ->
   theprefix_world: int ->
   unit -> test_field_prefix
-  (** Create a record of type {!test_field_prefix}. *)
+  (** Create a record of type {!type:test_field_prefix}. *)
 
 
 val write_star_rating :
   Bi_outbuf.t -> star_rating -> unit
-  (** Output a JSON value of type {!star_rating}. *)
+  (** Output a JSON value of type {!type:star_rating}. *)
 
 val string_of_star_rating :
   ?len:int -> star_rating -> string
-  (** Serialize a value of type {!star_rating}
+  (** Serialize a value of type {!type:star_rating}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -577,22 +577,22 @@ val string_of_star_rating :
 
 val read_star_rating :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> star_rating
-  (** Input JSON data of type {!star_rating}. *)
+  (** Input JSON data of type {!type:star_rating}. *)
 
 val star_rating_of_string :
   string -> star_rating
-  (** Deserialize JSON data of type {!star_rating}. *)
+  (** Deserialize JSON data of type {!type:star_rating}. *)
 
 
 val write_generic :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a generic -> unit
-  (** Output a JSON value of type {!generic}. *)
+  (** Output a JSON value of type {!type:generic}. *)
 
 val string_of_generic :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a generic -> string
-  (** Serialize a value of type {!generic}
+  (** Serialize a value of type {!type:generic}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -601,26 +601,26 @@ val string_of_generic :
 val read_generic :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a generic
-  (** Input JSON data of type {!generic}. *)
+  (** Input JSON data of type {!type:generic}. *)
 
 val generic_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a generic
-  (** Deserialize JSON data of type {!generic}. *)
+  (** Deserialize JSON data of type {!type:generic}. *)
 
 val create_generic :
   x294623: int ->
   unit -> 'a generic
-  (** Create a record of type {!generic}. *)
+  (** Create a record of type {!type:generic}. *)
 
 
 val write_specialized :
   Bi_outbuf.t -> specialized -> unit
-  (** Output a JSON value of type {!specialized}. *)
+  (** Output a JSON value of type {!type:specialized}. *)
 
 val string_of_specialized :
   ?len:int -> specialized -> string
-  (** Serialize a value of type {!specialized}
+  (** Serialize a value of type {!type:specialized}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -628,20 +628,20 @@ val string_of_specialized :
 
 val read_specialized :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> specialized
-  (** Input JSON data of type {!specialized}. *)
+  (** Input JSON data of type {!type:specialized}. *)
 
 val specialized_of_string :
   string -> specialized
-  (** Deserialize JSON data of type {!specialized}. *)
+  (** Deserialize JSON data of type {!type:specialized}. *)
 
 
 val write_some_record :
   Bi_outbuf.t -> some_record -> unit
-  (** Output a JSON value of type {!some_record}. *)
+  (** Output a JSON value of type {!type:some_record}. *)
 
 val string_of_some_record :
   ?len:int -> some_record -> string
-  (** Serialize a value of type {!some_record}
+  (** Serialize a value of type {!type:some_record}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -649,25 +649,25 @@ val string_of_some_record :
 
 val read_some_record :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> some_record
-  (** Input JSON data of type {!some_record}. *)
+  (** Input JSON data of type {!type:some_record}. *)
 
 val some_record_of_string :
   string -> some_record
-  (** Deserialize JSON data of type {!some_record}. *)
+  (** Deserialize JSON data of type {!type:some_record}. *)
 
 val create_some_record :
   some_field: int ->
   unit -> some_record
-  (** Create a record of type {!some_record}. *)
+  (** Create a record of type {!type:some_record}. *)
 
 
 val write_precision :
   Bi_outbuf.t -> precision -> unit
-  (** Output a JSON value of type {!precision}. *)
+  (** Output a JSON value of type {!type:precision}. *)
 
 val string_of_precision :
   ?len:int -> precision -> string
-  (** Serialize a value of type {!precision}
+  (** Serialize a value of type {!type:precision}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -675,27 +675,27 @@ val string_of_precision :
 
 val read_precision :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> precision
-  (** Input JSON data of type {!precision}. *)
+  (** Input JSON data of type {!type:precision}. *)
 
 val precision_of_string :
   string -> precision
-  (** Deserialize JSON data of type {!precision}. *)
+  (** Deserialize JSON data of type {!type:precision}. *)
 
 val create_precision :
   sqrt2_5: float ->
   small_2: float ->
   large_2: float ->
   unit -> precision
-  (** Create a record of type {!precision}. *)
+  (** Create a record of type {!type:precision}. *)
 
 
 val write_p'' :
   Bi_outbuf.t -> p'' -> unit
-  (** Output a JSON value of type {!p''}. *)
+  (** Output a JSON value of type {!type:p''}. *)
 
 val string_of_p'' :
   ?len:int -> p'' -> string
-  (** Serialize a value of type {!p''}
+  (** Serialize a value of type {!type:p''}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -703,20 +703,20 @@ val string_of_p'' :
 
 val read_p'' :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> p''
-  (** Input JSON data of type {!p''}. *)
+  (** Input JSON data of type {!type:p''}. *)
 
 val p''_of_string :
   string -> p''
-  (** Deserialize JSON data of type {!p''}. *)
+  (** Deserialize JSON data of type {!type:p''}. *)
 
 
 val write_option_validation :
   Bi_outbuf.t -> option_validation -> unit
-  (** Output a JSON value of type {!option_validation}. *)
+  (** Output a JSON value of type {!type:option_validation}. *)
 
 val string_of_option_validation :
   ?len:int -> option_validation -> string
-  (** Serialize a value of type {!option_validation}
+  (** Serialize a value of type {!type:option_validation}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -724,20 +724,20 @@ val string_of_option_validation :
 
 val read_option_validation :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> option_validation
-  (** Input JSON data of type {!option_validation}. *)
+  (** Input JSON data of type {!type:option_validation}. *)
 
 val option_validation_of_string :
   string -> option_validation
-  (** Deserialize JSON data of type {!option_validation}. *)
+  (** Deserialize JSON data of type {!type:option_validation}. *)
 
 
 val write_no_real_wrap :
   Bi_outbuf.t -> no_real_wrap -> unit
-  (** Output a JSON value of type {!no_real_wrap}. *)
+  (** Output a JSON value of type {!type:no_real_wrap}. *)
 
 val string_of_no_real_wrap :
   ?len:int -> no_real_wrap -> string
-  (** Serialize a value of type {!no_real_wrap}
+  (** Serialize a value of type {!type:no_real_wrap}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -745,20 +745,20 @@ val string_of_no_real_wrap :
 
 val read_no_real_wrap :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> no_real_wrap
-  (** Input JSON data of type {!no_real_wrap}. *)
+  (** Input JSON data of type {!type:no_real_wrap}. *)
 
 val no_real_wrap_of_string :
   string -> no_real_wrap
-  (** Deserialize JSON data of type {!no_real_wrap}. *)
+  (** Deserialize JSON data of type {!type:no_real_wrap}. *)
 
 
 val write_natural :
   Bi_outbuf.t -> natural -> unit
-  (** Output a JSON value of type {!natural}. *)
+  (** Output a JSON value of type {!type:natural}. *)
 
 val string_of_natural :
   ?len:int -> natural -> string
-  (** Serialize a value of type {!natural}
+  (** Serialize a value of type {!type:natural}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -766,20 +766,20 @@ val string_of_natural :
 
 val read_natural :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> natural
-  (** Input JSON data of type {!natural}. *)
+  (** Input JSON data of type {!type:natural}. *)
 
 val natural_of_string :
   string -> natural
-  (** Deserialize JSON data of type {!natural}. *)
+  (** Deserialize JSON data of type {!type:natural}. *)
 
 
 val write_id :
   Bi_outbuf.t -> id -> unit
-  (** Output a JSON value of type {!id}. *)
+  (** Output a JSON value of type {!type:id}. *)
 
 val string_of_id :
   ?len:int -> id -> string
-  (** Serialize a value of type {!id}
+  (** Serialize a value of type {!type:id}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -787,20 +787,20 @@ val string_of_id :
 
 val read_id :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> id
-  (** Input JSON data of type {!id}. *)
+  (** Input JSON data of type {!type:id}. *)
 
 val id_of_string :
   string -> id
-  (** Deserialize JSON data of type {!id}. *)
+  (** Deserialize JSON data of type {!type:id}. *)
 
 
 val write_json_map :
   Bi_outbuf.t -> json_map -> unit
-  (** Output a JSON value of type {!json_map}. *)
+  (** Output a JSON value of type {!type:json_map}. *)
 
 val string_of_json_map :
   ?len:int -> json_map -> string
-  (** Serialize a value of type {!json_map}
+  (** Serialize a value of type {!type:json_map}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -808,20 +808,20 @@ val string_of_json_map :
 
 val read_json_map :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> json_map
-  (** Input JSON data of type {!json_map}. *)
+  (** Input JSON data of type {!type:json_map}. *)
 
 val json_map_of_string :
   string -> json_map
-  (** Deserialize JSON data of type {!json_map}. *)
+  (** Deserialize JSON data of type {!type:json_map}. *)
 
 
 val write_intopt :
   Bi_outbuf.t -> intopt -> unit
-  (** Output a JSON value of type {!intopt}. *)
+  (** Output a JSON value of type {!type:intopt}. *)
 
 val string_of_intopt :
   ?len:int -> intopt -> string
-  (** Serialize a value of type {!intopt}
+  (** Serialize a value of type {!type:intopt}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -829,20 +829,20 @@ val string_of_intopt :
 
 val read_intopt :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> intopt
-  (** Input JSON data of type {!intopt}. *)
+  (** Input JSON data of type {!type:intopt}. *)
 
 val intopt_of_string :
   string -> intopt
-  (** Deserialize JSON data of type {!intopt}. *)
+  (** Deserialize JSON data of type {!type:intopt}. *)
 
 
 val write_int_assoc_list :
   Bi_outbuf.t -> int_assoc_list -> unit
-  (** Output a JSON value of type {!int_assoc_list}. *)
+  (** Output a JSON value of type {!type:int_assoc_list}. *)
 
 val string_of_int_assoc_list :
   ?len:int -> int_assoc_list -> string
-  (** Serialize a value of type {!int_assoc_list}
+  (** Serialize a value of type {!type:int_assoc_list}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -850,20 +850,20 @@ val string_of_int_assoc_list :
 
 val read_int_assoc_list :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int_assoc_list
-  (** Input JSON data of type {!int_assoc_list}. *)
+  (** Input JSON data of type {!type:int_assoc_list}. *)
 
 val int_assoc_list_of_string :
   string -> int_assoc_list
-  (** Deserialize JSON data of type {!int_assoc_list}. *)
+  (** Deserialize JSON data of type {!type:int_assoc_list}. *)
 
 
 val write_int_assoc_array :
   Bi_outbuf.t -> int_assoc_array -> unit
-  (** Output a JSON value of type {!int_assoc_array}. *)
+  (** Output a JSON value of type {!type:int_assoc_array}. *)
 
 val string_of_int_assoc_array :
   ?len:int -> int_assoc_array -> string
-  (** Serialize a value of type {!int_assoc_array}
+  (** Serialize a value of type {!type:int_assoc_array}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -871,20 +871,20 @@ val string_of_int_assoc_array :
 
 val read_int_assoc_array :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int_assoc_array
-  (** Input JSON data of type {!int_assoc_array}. *)
+  (** Input JSON data of type {!type:int_assoc_array}. *)
 
 val int_assoc_array_of_string :
   string -> int_assoc_array
-  (** Deserialize JSON data of type {!int_assoc_array}. *)
+  (** Deserialize JSON data of type {!type:int_assoc_array}. *)
 
 
 val write_int8 :
   Bi_outbuf.t -> int8 -> unit
-  (** Output a JSON value of type {!int8}. *)
+  (** Output a JSON value of type {!type:int8}. *)
 
 val string_of_int8 :
   ?len:int -> int8 -> string
-  (** Serialize a value of type {!int8}
+  (** Serialize a value of type {!type:int8}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -892,20 +892,20 @@ val string_of_int8 :
 
 val read_int8 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int8
-  (** Input JSON data of type {!int8}. *)
+  (** Input JSON data of type {!type:int8}. *)
 
 val int8_of_string :
   string -> int8
-  (** Deserialize JSON data of type {!int8}. *)
+  (** Deserialize JSON data of type {!type:int8}. *)
 
 
 val write_int64 :
   Bi_outbuf.t -> int64 -> unit
-  (** Output a JSON value of type {!int64}. *)
+  (** Output a JSON value of type {!type:int64}. *)
 
 val string_of_int64 :
   ?len:int -> int64 -> string
-  (** Serialize a value of type {!int64}
+  (** Serialize a value of type {!type:int64}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -913,20 +913,20 @@ val string_of_int64 :
 
 val read_int64 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int64
-  (** Input JSON data of type {!int64}. *)
+  (** Input JSON data of type {!type:int64}. *)
 
 val int64_of_string :
   string -> int64
-  (** Deserialize JSON data of type {!int64}. *)
+  (** Deserialize JSON data of type {!type:int64}. *)
 
 
 val write_int32 :
   Bi_outbuf.t -> int32 -> unit
-  (** Output a JSON value of type {!int32}. *)
+  (** Output a JSON value of type {!type:int32}. *)
 
 val string_of_int32 :
   ?len:int -> int32 -> string
-  (** Serialize a value of type {!int32}
+  (** Serialize a value of type {!type:int32}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -934,20 +934,20 @@ val string_of_int32 :
 
 val read_int32 :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> int32
-  (** Input JSON data of type {!int32}. *)
+  (** Input JSON data of type {!type:int32}. *)
 
 val int32_of_string :
   string -> int32
-  (** Deserialize JSON data of type {!int32}. *)
+  (** Deserialize JSON data of type {!type:int32}. *)
 
 
 val write_hello :
   Bi_outbuf.t -> hello -> unit
-  (** Output a JSON value of type {!hello}. *)
+  (** Output a JSON value of type {!type:hello}. *)
 
 val string_of_hello :
   ?len:int -> hello -> string
-  (** Serialize a value of type {!hello}
+  (** Serialize a value of type {!type:hello}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -955,20 +955,20 @@ val string_of_hello :
 
 val read_hello :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> hello
-  (** Input JSON data of type {!hello}. *)
+  (** Input JSON data of type {!type:hello}. *)
 
 val hello_of_string :
   string -> hello
-  (** Deserialize JSON data of type {!hello}. *)
+  (** Deserialize JSON data of type {!type:hello}. *)
 
 
 val write_floats :
   Bi_outbuf.t -> floats -> unit
-  (** Output a JSON value of type {!floats}. *)
+  (** Output a JSON value of type {!type:floats}. *)
 
 val string_of_floats :
   ?len:int -> floats -> string
-  (** Serialize a value of type {!floats}
+  (** Serialize a value of type {!type:floats}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -976,26 +976,26 @@ val string_of_floats :
 
 val read_floats :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> floats
-  (** Input JSON data of type {!floats}. *)
+  (** Input JSON data of type {!type:floats}. *)
 
 val floats_of_string :
   string -> floats
-  (** Deserialize JSON data of type {!floats}. *)
+  (** Deserialize JSON data of type {!type:floats}. *)
 
 val create_floats :
   f32: float ->
   f64: float ->
   unit -> floats
-  (** Create a record of type {!floats}. *)
+  (** Create a record of type {!type:floats}. *)
 
 
 val write_extended_tuple :
   Bi_outbuf.t -> extended_tuple -> unit
-  (** Output a JSON value of type {!extended_tuple}. *)
+  (** Output a JSON value of type {!type:extended_tuple}. *)
 
 val string_of_extended_tuple :
   ?len:int -> extended_tuple -> string
-  (** Serialize a value of type {!extended_tuple}
+  (** Serialize a value of type {!type:extended_tuple}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1003,20 +1003,20 @@ val string_of_extended_tuple :
 
 val read_extended_tuple :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> extended_tuple
-  (** Input JSON data of type {!extended_tuple}. *)
+  (** Input JSON data of type {!type:extended_tuple}. *)
 
 val extended_tuple_of_string :
   string -> extended_tuple
-  (** Deserialize JSON data of type {!extended_tuple}. *)
+  (** Deserialize JSON data of type {!type:extended_tuple}. *)
 
 
 val write_extended :
   Bi_outbuf.t -> extended -> unit
-  (** Output a JSON value of type {!extended}. *)
+  (** Output a JSON value of type {!type:extended}. *)
 
 val string_of_extended :
   ?len:int -> extended -> string
-  (** Serialize a value of type {!extended}
+  (** Serialize a value of type {!type:extended}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1024,11 +1024,11 @@ val string_of_extended :
 
 val read_extended :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> extended
-  (** Input JSON data of type {!extended}. *)
+  (** Input JSON data of type {!type:extended}. *)
 
 val extended_of_string :
   string -> extended
-  (** Deserialize JSON data of type {!extended}. *)
+  (** Deserialize JSON data of type {!type:extended}. *)
 
 val create_extended :
   b0x: int ->
@@ -1038,16 +1038,16 @@ val create_extended :
   b4x: string option ->
   ?b5x: float ->
   unit -> extended
-  (** Create a record of type {!extended}. *)
+  (** Create a record of type {!type:extended}. *)
 
 
 val write_even_natural :
   Bi_outbuf.t -> even_natural -> unit
-  (** Output a JSON value of type {!even_natural}. *)
+  (** Output a JSON value of type {!type:even_natural}. *)
 
 val string_of_even_natural :
   ?len:int -> even_natural -> string
-  (** Serialize a value of type {!even_natural}
+  (** Serialize a value of type {!type:even_natural}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1055,20 +1055,20 @@ val string_of_even_natural :
 
 val read_even_natural :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> even_natural
-  (** Input JSON data of type {!even_natural}. *)
+  (** Input JSON data of type {!type:even_natural}. *)
 
 val even_natural_of_string :
   string -> even_natural
-  (** Deserialize JSON data of type {!even_natural}. *)
+  (** Deserialize JSON data of type {!type:even_natural}. *)
 
 
 val write_def :
   Bi_outbuf.t -> def -> unit
-  (** Output a JSON value of type {!def}. *)
+  (** Output a JSON value of type {!type:def}. *)
 
 val string_of_def :
   ?len:int -> def -> string
-  (** Serialize a value of type {!def}
+  (** Serialize a value of type {!type:def}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1076,20 +1076,20 @@ val string_of_def :
 
 val read_def :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> def
-  (** Input JSON data of type {!def}. *)
+  (** Input JSON data of type {!type:def}. *)
 
 val def_of_string :
   string -> def
-  (** Deserialize JSON data of type {!def}. *)
+  (** Deserialize JSON data of type {!type:def}. *)
 
 
 val write_char :
   Bi_outbuf.t -> char -> unit
-  (** Output a JSON value of type {!char}. *)
+  (** Output a JSON value of type {!type:char}. *)
 
 val string_of_char :
   ?len:int -> char -> string
-  (** Serialize a value of type {!char}
+  (** Serialize a value of type {!type:char}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1097,20 +1097,20 @@ val string_of_char :
 
 val read_char :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> char
-  (** Input JSON data of type {!char}. *)
+  (** Input JSON data of type {!type:char}. *)
 
 val char_of_string :
   string -> char
-  (** Deserialize JSON data of type {!char}. *)
+  (** Deserialize JSON data of type {!type:char}. *)
 
 
 val write_base_tuple :
   Bi_outbuf.t -> base_tuple -> unit
-  (** Output a JSON value of type {!base_tuple}. *)
+  (** Output a JSON value of type {!type:base_tuple}. *)
 
 val string_of_base_tuple :
   ?len:int -> base_tuple -> string
-  (** Serialize a value of type {!base_tuple}
+  (** Serialize a value of type {!type:base_tuple}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1118,20 +1118,20 @@ val string_of_base_tuple :
 
 val read_base_tuple :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> base_tuple
-  (** Input JSON data of type {!base_tuple}. *)
+  (** Input JSON data of type {!type:base_tuple}. *)
 
 val base_tuple_of_string :
   string -> base_tuple
-  (** Deserialize JSON data of type {!base_tuple}. *)
+  (** Deserialize JSON data of type {!type:base_tuple}. *)
 
 
 val write_base :
   Bi_outbuf.t -> base -> unit
-  (** Output a JSON value of type {!base}. *)
+  (** Output a JSON value of type {!type:base}. *)
 
 val string_of_base :
   ?len:int -> base -> string
-  (** Serialize a value of type {!base}
+  (** Serialize a value of type {!type:base}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1139,28 +1139,28 @@ val string_of_base :
 
 val read_base :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> base
-  (** Input JSON data of type {!base}. *)
+  (** Input JSON data of type {!type:base}. *)
 
 val base_of_string :
   string -> base
-  (** Deserialize JSON data of type {!base}. *)
+  (** Deserialize JSON data of type {!type:base}. *)
 
 val create_base :
   b0: int ->
   b1: bool ->
   unit -> base
-  (** Create a record of type {!base}. *)
+  (** Create a record of type {!type:base}. *)
 
 
 val write_array :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a array -> unit
-  (** Output a JSON value of type {!array}. *)
+  (** Output a JSON value of type {!type:array}. *)
 
 val string_of_array :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a array -> string
-  (** Serialize a value of type {!array}
+  (** Serialize a value of type {!type:array}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1169,23 +1169,23 @@ val string_of_array :
 val read_array :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a array
-  (** Input JSON data of type {!array}. *)
+  (** Input JSON data of type {!type:array}. *)
 
 val array_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a array
-  (** Deserialize JSON data of type {!array}. *)
+  (** Deserialize JSON data of type {!type:array}. *)
 
 
 val write_abs3 :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs3 -> unit
-  (** Output a JSON value of type {!abs3}. *)
+  (** Output a JSON value of type {!type:abs3}. *)
 
 val string_of_abs3 :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs3 -> string
-  (** Serialize a value of type {!abs3}
+  (** Serialize a value of type {!type:abs3}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1194,23 +1194,23 @@ val string_of_abs3 :
 val read_abs3 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a abs3
-  (** Input JSON data of type {!abs3}. *)
+  (** Input JSON data of type {!type:abs3}. *)
 
 val abs3_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a abs3
-  (** Deserialize JSON data of type {!abs3}. *)
+  (** Deserialize JSON data of type {!type:abs3}. *)
 
 
 val write_abs2 :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs2 -> unit
-  (** Output a JSON value of type {!abs2}. *)
+  (** Output a JSON value of type {!type:abs2}. *)
 
 val string_of_abs2 :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs2 -> string
-  (** Serialize a value of type {!abs2}
+  (** Serialize a value of type {!type:abs2}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1219,23 +1219,23 @@ val string_of_abs2 :
 val read_abs2 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a abs2
-  (** Input JSON data of type {!abs2}. *)
+  (** Input JSON data of type {!type:abs2}. *)
 
 val abs2_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a abs2
-  (** Deserialize JSON data of type {!abs2}. *)
+  (** Deserialize JSON data of type {!type:abs2}. *)
 
 
 val write_abs1 :
   (Bi_outbuf.t -> 'a -> unit) ->
   Bi_outbuf.t -> 'a abs1 -> unit
-  (** Output a JSON value of type {!abs1}. *)
+  (** Output a JSON value of type {!type:abs1}. *)
 
 val string_of_abs1 :
   (Bi_outbuf.t -> 'a -> unit) ->
   ?len:int -> 'a abs1 -> string
-  (** Serialize a value of type {!abs1}
+  (** Serialize a value of type {!type:abs1}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1244,11 +1244,11 @@ val string_of_abs1 :
 val read_abs1 :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a abs1
-  (** Input JSON data of type {!abs1}. *)
+  (** Input JSON data of type {!type:abs1}. *)
 
 val abs1_of_string :
   (Yojson.Safe.lexer_state -> Lexing.lexbuf -> 'a) ->
   string -> 'a abs1
-  (** Deserialize JSON data of type {!abs1}. *)
+  (** Deserialize JSON data of type {!type:abs1}. *)
 
 

--- a/atdgen/test/testv.expected.mli
+++ b/atdgen/test/testv.expected.mli
@@ -159,74 +159,74 @@ type 'a abs1 = 'a Test.abs1
 
 val validate_test_variant :
   Atdgen_runtime.Util.Validation.path -> test_variant -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!test_variant}. *)
+  (** Validate a value of type {!type:test_variant}. *)
 
 val create_poly :
   fst: 'x list ->
   snd: ('x, 'y) poly option ->
   unit -> ('x, 'y) poly
-  (** Create a record of type {!poly}. *)
+  (** Create a record of type {!type:poly}. *)
 
 val validate_poly :
   (Atdgen_runtime.Util.Validation.path -> 'x -> Atdgen_runtime.Util.Validation.error option) ->
   (Atdgen_runtime.Util.Validation.path -> 'y -> Atdgen_runtime.Util.Validation.error option) ->
   Atdgen_runtime.Util.Validation.path -> ('x, 'y) poly -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!poly}. *)
+  (** Validate a value of type {!type:poly}. *)
 
 val validate_p' :
   (Atdgen_runtime.Util.Validation.path -> 'a -> Atdgen_runtime.Util.Validation.error option) ->
   Atdgen_runtime.Util.Validation.path -> 'a p' -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!p'}. *)
+  (** Validate a value of type {!type:p'}. *)
 
 val validate_p :
   Atdgen_runtime.Util.Validation.path -> p -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!p}. *)
+  (** Validate a value of type {!type:p}. *)
 
 val create_r :
   a: int ->
   b: bool ->
   c: p ->
   unit -> r
-  (** Create a record of type {!r}. *)
+  (** Create a record of type {!type:r}. *)
 
 val validate_r :
   Atdgen_runtime.Util.Validation.path -> r -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!r}. *)
+  (** Validate a value of type {!type:r}. *)
 
 val validate_validated_string_check :
   Atdgen_runtime.Util.Validation.path -> validated_string_check -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!validated_string_check}. *)
+  (** Validate a value of type {!type:validated_string_check}. *)
 
 val validate_validate_me :
   Atdgen_runtime.Util.Validation.path -> validate_me -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!validate_me}. *)
+  (** Validate a value of type {!type:validate_me}. *)
 
 val create_val1 :
   val1_x: int ->
   unit -> val1
-  (** Create a record of type {!val1}. *)
+  (** Create a record of type {!type:val1}. *)
 
 val validate_val1 :
   Atdgen_runtime.Util.Validation.path -> val1 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!val1}. *)
+  (** Validate a value of type {!type:val1}. *)
 
 val create_val2 :
   val2_x: val1 ->
   ?val2_y: val1 ->
   unit -> val2
-  (** Create a record of type {!val2}. *)
+  (** Create a record of type {!type:val2}. *)
 
 val validate_val2 :
   Atdgen_runtime.Util.Validation.path -> val2 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!val2}. *)
+  (** Validate a value of type {!type:val2}. *)
 
 val validate_unixtime_list :
   Atdgen_runtime.Util.Validation.path -> unixtime_list -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!unixtime_list}. *)
+  (** Validate a value of type {!type:unixtime_list}. *)
 
 val validate_date :
   Atdgen_runtime.Util.Validation.path -> date -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!date}. *)
+  (** Validate a value of type {!type:date}. *)
 
 val create_mixed_record :
   ?field0: int ->
@@ -245,15 +245,15 @@ val create_mixed_record :
   field13: string option list ->
   field14: date ->
   unit -> mixed_record
-  (** Create a record of type {!mixed_record}. *)
+  (** Create a record of type {!type:mixed_record}. *)
 
 val validate_mixed_record :
   Atdgen_runtime.Util.Validation.path -> mixed_record -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!mixed_record}. *)
+  (** Validate a value of type {!type:mixed_record}. *)
 
 val validate_mixed :
   Atdgen_runtime.Util.Validation.path -> mixed -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!mixed}. *)
+  (** Validate a value of type {!type:mixed}. *)
 
 val create_test :
   ?x0: int ->
@@ -262,129 +262,129 @@ val create_test :
   x3: mixed_record list ->
   x4: Int64.t ->
   unit -> test
-  (** Create a record of type {!test}. *)
+  (** Create a record of type {!type:test}. *)
 
 val validate_test :
   Atdgen_runtime.Util.Validation.path -> test -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!test}. *)
+  (** Validate a value of type {!type:test}. *)
 
 val validate_tup :
   Atdgen_runtime.Util.Validation.path -> tup -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!tup}. *)
+  (** Validate a value of type {!type:tup}. *)
 
 val create_test_field_prefix :
   theprefix_hello: bool ->
   theprefix_world: int ->
   unit -> test_field_prefix
-  (** Create a record of type {!test_field_prefix}. *)
+  (** Create a record of type {!type:test_field_prefix}. *)
 
 val validate_test_field_prefix :
   Atdgen_runtime.Util.Validation.path -> test_field_prefix -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!test_field_prefix}. *)
+  (** Validate a value of type {!type:test_field_prefix}. *)
 
 val validate_star_rating :
   Atdgen_runtime.Util.Validation.path -> star_rating -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!star_rating}. *)
+  (** Validate a value of type {!type:star_rating}. *)
 
 val create_generic :
   x294623: int ->
   unit -> 'a generic
-  (** Create a record of type {!generic}. *)
+  (** Create a record of type {!type:generic}. *)
 
 val validate_generic :
   (Atdgen_runtime.Util.Validation.path -> 'a -> Atdgen_runtime.Util.Validation.error option) ->
   Atdgen_runtime.Util.Validation.path -> 'a generic -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!generic}. *)
+  (** Validate a value of type {!type:generic}. *)
 
 val validate_specialized :
   Atdgen_runtime.Util.Validation.path -> specialized -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!specialized}. *)
+  (** Validate a value of type {!type:specialized}. *)
 
 val create_some_record :
   some_field: int ->
   unit -> some_record
-  (** Create a record of type {!some_record}. *)
+  (** Create a record of type {!type:some_record}. *)
 
 val validate_some_record :
   Atdgen_runtime.Util.Validation.path -> some_record -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!some_record}. *)
+  (** Validate a value of type {!type:some_record}. *)
 
 val create_precision :
   sqrt2_5: float ->
   small_2: float ->
   large_2: float ->
   unit -> precision
-  (** Create a record of type {!precision}. *)
+  (** Create a record of type {!type:precision}. *)
 
 val validate_precision :
   Atdgen_runtime.Util.Validation.path -> precision -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!precision}. *)
+  (** Validate a value of type {!type:precision}. *)
 
 val validate_p'' :
   Atdgen_runtime.Util.Validation.path -> p'' -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!p''}. *)
+  (** Validate a value of type {!type:p''}. *)
 
 val validate_option_validation :
   Atdgen_runtime.Util.Validation.path -> option_validation -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!option_validation}. *)
+  (** Validate a value of type {!type:option_validation}. *)
 
 val validate_no_real_wrap :
   Atdgen_runtime.Util.Validation.path -> no_real_wrap -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!no_real_wrap}. *)
+  (** Validate a value of type {!type:no_real_wrap}. *)
 
 val validate_natural :
   Atdgen_runtime.Util.Validation.path -> natural -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!natural}. *)
+  (** Validate a value of type {!type:natural}. *)
 
 val validate_id :
   Atdgen_runtime.Util.Validation.path -> id -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!id}. *)
+  (** Validate a value of type {!type:id}. *)
 
 val validate_json_map :
   Atdgen_runtime.Util.Validation.path -> json_map -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!json_map}. *)
+  (** Validate a value of type {!type:json_map}. *)
 
 val validate_intopt :
   Atdgen_runtime.Util.Validation.path -> intopt -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!intopt}. *)
+  (** Validate a value of type {!type:intopt}. *)
 
 val validate_int_assoc_list :
   Atdgen_runtime.Util.Validation.path -> int_assoc_list -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!int_assoc_list}. *)
+  (** Validate a value of type {!type:int_assoc_list}. *)
 
 val validate_int_assoc_array :
   Atdgen_runtime.Util.Validation.path -> int_assoc_array -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!int_assoc_array}. *)
+  (** Validate a value of type {!type:int_assoc_array}. *)
 
 val validate_int8 :
   Atdgen_runtime.Util.Validation.path -> int8 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!int8}. *)
+  (** Validate a value of type {!type:int8}. *)
 
 val validate_int64 :
   Atdgen_runtime.Util.Validation.path -> int64 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!int64}. *)
+  (** Validate a value of type {!type:int64}. *)
 
 val validate_int32 :
   Atdgen_runtime.Util.Validation.path -> int32 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!int32}. *)
+  (** Validate a value of type {!type:int32}. *)
 
 val validate_hello :
   Atdgen_runtime.Util.Validation.path -> hello -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!hello}. *)
+  (** Validate a value of type {!type:hello}. *)
 
 val create_floats :
   f32: float ->
   f64: float ->
   unit -> floats
-  (** Create a record of type {!floats}. *)
+  (** Create a record of type {!type:floats}. *)
 
 val validate_floats :
   Atdgen_runtime.Util.Validation.path -> floats -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!floats}. *)
+  (** Validate a value of type {!type:floats}. *)
 
 val validate_extended_tuple :
   Atdgen_runtime.Util.Validation.path -> extended_tuple -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!extended_tuple}. *)
+  (** Validate a value of type {!type:extended_tuple}. *)
 
 val create_extended :
   b0x: int ->
@@ -394,51 +394,51 @@ val create_extended :
   b4x: string option ->
   ?b5x: float ->
   unit -> extended
-  (** Create a record of type {!extended}. *)
+  (** Create a record of type {!type:extended}. *)
 
 val validate_extended :
   Atdgen_runtime.Util.Validation.path -> extended -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!extended}. *)
+  (** Validate a value of type {!type:extended}. *)
 
 val validate_even_natural :
   Atdgen_runtime.Util.Validation.path -> even_natural -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!even_natural}. *)
+  (** Validate a value of type {!type:even_natural}. *)
 
 val validate_char :
   Atdgen_runtime.Util.Validation.path -> char -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!char}. *)
+  (** Validate a value of type {!type:char}. *)
 
 val validate_base_tuple :
   Atdgen_runtime.Util.Validation.path -> base_tuple -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!base_tuple}. *)
+  (** Validate a value of type {!type:base_tuple}. *)
 
 val create_base :
   b0: int ->
   b1: bool ->
   unit -> base
-  (** Create a record of type {!base}. *)
+  (** Create a record of type {!type:base}. *)
 
 val validate_base :
   Atdgen_runtime.Util.Validation.path -> base -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!base}. *)
+  (** Validate a value of type {!type:base}. *)
 
 val validate_array :
   (Atdgen_runtime.Util.Validation.path -> 'a -> Atdgen_runtime.Util.Validation.error option) ->
   Atdgen_runtime.Util.Validation.path -> 'a array -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!array}. *)
+  (** Validate a value of type {!type:array}. *)
 
 val validate_abs3 :
   (Atdgen_runtime.Util.Validation.path -> 'a -> Atdgen_runtime.Util.Validation.error option) ->
   Atdgen_runtime.Util.Validation.path -> 'a abs3 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!abs3}. *)
+  (** Validate a value of type {!type:abs3}. *)
 
 val validate_abs2 :
   (Atdgen_runtime.Util.Validation.path -> 'a -> Atdgen_runtime.Util.Validation.error option) ->
   Atdgen_runtime.Util.Validation.path -> 'a abs2 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!abs2}. *)
+  (** Validate a value of type {!type:abs2}. *)
 
 val validate_abs1 :
   (Atdgen_runtime.Util.Validation.path -> 'a -> Atdgen_runtime.Util.Validation.error option) ->
   Atdgen_runtime.Util.Validation.path -> 'a abs1 -> Atdgen_runtime.Util.Validation.error option
-  (** Validate a value of type {!abs1}. *)
+  (** Validate a value of type {!type:abs1}. *)
 


### PR DESCRIPTION
It's possible that a type and a value share the same name in generated
code, and odoc can't know which of them the reference is pointing to.