### PR TITLE
atdpy: Propagate decorators on sum types to all constructor classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Next release
 ------------------
 
 * atdgen: use odoc syntax to disambiguate clashing names (#296).
+* atdpy: propagate decorators on sum types to all constructor classes
 
 2.7.0 (2022-05-17)
 ------------------

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -925,7 +925,6 @@ let case_class env ~class_decorators type_name
   | None ->
       [
         Inline class_decorators;
-        Line "@dataclass";
         Line (sprintf "class %s:" (trans env unique_name));
         Block [
           Line (sprintf {|"""Original type: %s = [ ... | %s | ... ]"""|}
@@ -954,7 +953,6 @@ let case_class env ~class_decorators type_name
   | Some e ->
       [
         Inline class_decorators;
-        Line "@dataclass";
         Line (sprintf "class %s:" (trans env unique_name));
         Block [
           Line (sprintf {|"""Original type: %s = [ ... | %s of ... | ... ]"""|}

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -918,12 +918,13 @@ let alias_wrapper env ~class_decorators name type_expr =
     ]
   ]
 
-let case_class env type_name
+let case_class env ~class_decorators type_name
     (loc, orig_name, unique_name, an, opt_e) =
   let json_name = Atd.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
       [
+        Inline class_decorators;
         Line "@dataclass";
         Line (sprintf "class %s:" (trans env unique_name));
         Block [
@@ -952,6 +953,7 @@ let case_class env type_name
       ]
   | Some e ->
       [
+        Inline class_decorators;
         Line "@dataclass";
         Line (sprintf "class %s:" (trans env unique_name));
         Block [
@@ -1116,7 +1118,7 @@ let sum env ~class_decorators loc name cases =
     ) cases
   in
   let case_classes =
-    List.map (fun x -> Inline (case_class env name x)) cases
+    List.map (fun x -> Inline (case_class env ~class_decorators name x)) cases
     |> double_spaced
   in
   let container_class = sum_container env ~class_decorators loc name cases in

--- a/atdpy/test/atd-input/everything.atd
+++ b/atdpy/test/atd-input/everything.atd
@@ -9,6 +9,12 @@ type kind = [
   | Amaze <json name="!!!"> of string list
 ]
 
+type frozen
+  <python decorator="dataclass(frozen=True)"> = [
+  | A
+  | B of int
+]
+
 type root = {
   id <json name="ID">: string;
   await: bool;

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -241,6 +241,7 @@ from dataclasses import dataclass
 
 
 @dataclass
+@dataclass
 class Root_:
     """Original type: kind = [ ... | Root | ... ]"""
 
@@ -257,6 +258,7 @@ class Root_:
         return json.dumps(self.to_json(), **kw)
 
 
+@dataclass
 @dataclass
 class Thing:
     """Original type: kind = [ ... | Thing of ... | ... ]"""
@@ -276,6 +278,7 @@ class Thing:
 
 
 @dataclass
+@dataclass
 class WOW:
     """Original type: kind = [ ... | WOW | ... ]"""
 
@@ -292,6 +295,7 @@ class WOW:
         return json.dumps(self.to_json(), **kw)
 
 
+@dataclass
 @dataclass
 class Amaze:
     """Original type: kind = [ ... | Amaze of ... | ... ]"""
@@ -489,6 +493,78 @@ class Pair:
 
     @classmethod
     def from_json_string(cls, x: str) -> 'Pair':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass(frozen=True)
+@dataclass
+class A:
+    """Original type: frozen = [ ... | A | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'A'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'A'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass(frozen=True)
+@dataclass
+class B:
+    """Original type: frozen = [ ... | B of ... | ... ]"""
+
+    value: int
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'B'
+
+    def to_json(self) -> Any:
+        return ['B', _atd_write_int(self.value)]
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass(frozen=True)
+class Frozen:
+    """Original type: frozen = [ ... ]"""
+
+    value: Union[A, B]
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return self.value.kind
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Frozen':
+        if isinstance(x, str):
+            if x == 'A':
+                return cls(A())
+            _atd_bad_json('Frozen', x)
+        if isinstance(x, List) and len(x) == 2:
+            cons = x[0]
+            if cons == 'B':
+                return cls(B(_atd_read_int(x[1])))
+            _atd_bad_json('Frozen', x)
+        _atd_bad_json('Frozen', x)
+
+    def to_json(self) -> Any:
+        return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Frozen':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -241,7 +241,6 @@ from dataclasses import dataclass
 
 
 @dataclass
-@dataclass
 class Root_:
     """Original type: kind = [ ... | Root | ... ]"""
 
@@ -258,7 +257,6 @@ class Root_:
         return json.dumps(self.to_json(), **kw)
 
 
-@dataclass
 @dataclass
 class Thing:
     """Original type: kind = [ ... | Thing of ... | ... ]"""
@@ -278,7 +276,6 @@ class Thing:
 
 
 @dataclass
-@dataclass
 class WOW:
     """Original type: kind = [ ... | WOW | ... ]"""
 
@@ -295,7 +292,6 @@ class WOW:
         return json.dumps(self.to_json(), **kw)
 
 
-@dataclass
 @dataclass
 class Amaze:
     """Original type: kind = [ ... | Amaze of ... | ... ]"""
@@ -500,7 +496,6 @@ class Pair:
 
 
 @dataclass(frozen=True)
-@dataclass
 class A:
     """Original type: frozen = [ ... | A | ... ]"""
 
@@ -518,7 +513,6 @@ class A:
 
 
 @dataclass(frozen=True)
-@dataclass
 class B:
     """Original type: frozen = [ ... | B of ... | ... ]"""
 

--- a/doc/atdpy.rst
+++ b/doc/atdpy.rst
@@ -398,3 +398,6 @@ The generated Python class will start like this:
    @dataclass
    class Thing:
        ...
+
+If extra class decorators are specifed on a sum type, the python classes generated
+for the constructors of the sum type will also have the extra class decorators.


### PR DESCRIPTION
Previously the following code would add `dataclass(frozen=True)` only to the class generated for `type t`, but _not_ the classes generated for its constructors. 
```
type t 
  <python decorator="dataclass(frozen=True)"> = [
  | A of int
  | B 
]
```

Now any decorators on the sum type class are propagated to the classes for its constructors.

This makes sense because any decorators applied to the sum type are meant to affect the inhabitants of the sum type, and in the generated python the inhabitants of a sum type are instances of the classes generated for its constructors.

### PR checklist

- [x] New code has tests to catch future regressions
- [ ] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
