### PR TITLE
[atdts] fix case reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+UNRELEASED
+------------------
+
+* atdts: fix reader for case type (#302)
+
 2.8.0 (2022-06-06)
 ------------------
 

--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -886,7 +886,7 @@ let read_case env loc orig_name an opt_e =
         Block [
           Line (sprintf "return { kind: '%s', value: %s(x[1], x) }"
                   (single_esc orig_name)
-                  (json_writer env e))
+                  (json_reader env e))
         ]
       ]
 

--- a/atdts/test/ts-expected/everything.ts
+++ b/atdts/test/ts-expected/everything.ts
@@ -68,9 +68,9 @@ export function readDifferentKindsOfThings(x: any, context: any = x): DifferentK
     _atd_check_json_tuple(2, x, context)
     switch (x[0]) {
       case 'Thing':
-        return { kind: 'Thing', value: _atd_write_int(x[1], x) }
+        return { kind: 'Thing', value: _atd_read_int(x[1], x) }
       case '!!!':
-        return { kind: 'Amaze', value: _atd_write_array(_atd_write_string)(x[1], x) }
+        return { kind: 'Amaze', value: _atd_read_array(_atd_read_string)(x[1], x) }
       default:
         _atd_bad_json('DifferentKindsOfThings', x, context)
         throw new Error('impossible')


### PR DESCRIPTION
We are using atdgen and atdts in LPCIC/elpi#146 and we found out that the ts reader is just broken, probably a copy/paste error.
Here the fix.

### PR checklist

- [ ] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
