### PR TITLE
Allow recursive references in atdpy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,6 @@ Master
 ------------------
 
 * atdpy: Support recursive definitions
-
-Master
-------------------
-
 * atdts: fix nullable object field writer (#312)
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Master
 ------------------
 
+* atdpy: Support recursive definitions
+
+Master
+------------------
+
 * atdts: fix nullable object field writer (#312)
 
 

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -195,6 +195,7 @@ methods and functions to convert data from/to JSON.
 # Disable flake8 entirely on this file:
 # flake8: noqa
 
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, Union
 
@@ -1168,19 +1169,8 @@ let module_body env x =
   |> List.rev
   |> spaced
 
-let extract_definition_names (items : A.module_body) =
-  List.map (fun (Type (loc, (name, param, an), e)) -> name) items
-
 let definition_group ~atd_filename env
     (is_recursive, (items: A.module_body)) : B.t =
-  if is_recursive then
-    A.error (
-      sprintf "recursive definitions are not supported by atdpy \
-               at this time: types %s in %S"
-        (extract_definition_names items
-         |> String.concat ", ")
-        atd_filename
-    );
   [
     Inline (module_body env items);
   ]

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -195,6 +195,7 @@ methods and functions to convert data from/to JSON.
 # Disable flake8 entirely on this file:
 # flake8: noqa
 
+# Import annotations to allow forward references
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, Union

--- a/atdpy/test/atd-input/everything.atd
+++ b/atdpy/test/atd-input/everything.atd
@@ -44,3 +44,9 @@ type require_field <python decorator="deco.deco1"
                            decorator="dataclass(order=True)"> = {
   req: string;
 }
+
+type recursive_class = {
+  id: int;
+  flag: bool;
+  children: recursive_class list;
+}

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -7,6 +7,7 @@ methods and functions to convert data from/to JSON.
 # Disable flake8 entirely on this file:
 # flake8: noqa
 
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, Union
 
@@ -238,6 +239,40 @@ def _atd_write_nullable(write_elt: Callable[[Any], Any]) \
 # This was inserted by the user.
 import deco
 from dataclasses import dataclass
+
+
+@dataclass
+class RecursiveClass:
+    """Original type: recursive_class = { ... }"""
+
+    id: int
+    flag: bool
+    children: List[RecursiveClass]
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'RecursiveClass':
+        if isinstance(x, dict):
+            return cls(
+                id=_atd_read_int(x['id']) if 'id' in x else _atd_missing_json_field('RecursiveClass', 'id'),
+                flag=_atd_read_bool(x['flag']) if 'flag' in x else _atd_missing_json_field('RecursiveClass', 'flag'),
+                children=_atd_read_list(RecursiveClass.from_json)(x['children']) if 'children' in x else _atd_missing_json_field('RecursiveClass', 'children'),
+            )
+        else:
+            _atd_bad_json('RecursiveClass', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['id'] = _atd_write_int(self.id)
+        res['flag'] = _atd_write_bool(self.flag)
+        res['children'] = _atd_write_list((lambda x: x.to_json()))(self.children)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'RecursiveClass':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
 
 
 @dataclass

--- a/atdpy/test/python-tests/test_atdpy.py
+++ b/atdpy/test/python-tests/test_atdpy.py
@@ -196,5 +196,34 @@ def test_pair() -> None:
             )
 
 
+def test_recursive_class() -> None:
+    child1 = e.RecursiveClass(id=1, flag=True, children=[])
+    child2 = e.RecursiveClass(id=2, flag=True, children=[])
+    a_obj = e.RecursiveClass(id=0, flag=False, children=[child1, child2])
+    a_str = a_obj.to_json_string(indent=2)
+
+    b_str = """{
+  "id": 0,
+  "flag": false,
+  "children": [
+    {
+      "id": 1,
+      "flag": true,
+      "children": []
+    },
+    {
+      "id": 2,
+      "flag": true,
+      "children": []
+    }
+  ]
+}"""
+    b_obj = e.RecursiveClass.from_json_string(a_str)
+    b_str2 = b_obj.to_json_string(indent=2)
+
+    assert b_str == b_str2
+    assert b_str2 == a_str
+
+
 # print updated json
 test_everything_to_json()


### PR DESCRIPTION
Use Python's future annotations to support forward declarations so that atdpy can generate classes with recursive references.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
