### PR TITLE
Add support for parametrized types to atdpy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+* atdcat: The -x option no longer expands the built-in parametrized types
+  such as 'int list'. We could have preserved the old behavior but the new 
+  behavior seems generally better. If this is breaks people's code, we could
+  add a command-line option to choose between the new or the old behavior. 
+  (#303)
+* atdpy: Support parametrized type definitions (#303)
+
 2.10.0 (2022-08-09)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,3 @@
-* atdcat: The -x option no longer expands the built-in parametrized types
-  such as 'int list'. We could have preserved the old behavior but the new 
-  behavior seems generally better. If this is breaks people's code, we could
-  add a command-line option to choose between the new or the old behavior. 
-  (#303)
 * atdpy: Support parametrized type definitions (#303)
 
 2.10.0 (2022-08-09)

--- a/atd/src/ast.mli
+++ b/atd/src/ast.mli
@@ -290,3 +290,31 @@ val is_parametrized : type_expr -> bool
   *)
 
 val is_required : field_kind -> bool
+
+(** Replace nodes by other nodes of the same type.
+    First the user-given mapper is applied to a node,
+    then the children nodes are mapped recursively.
+*)
+module Map : sig
+  type mappers = {
+    type_expr: type_expr -> type_expr;
+  }
+
+  val default_mappers : mappers
+
+  val type_expr : mappers -> type_expr -> type_expr
+  val variant : mappers -> variant -> variant
+  val field : mappers -> field -> field
+  val type_def : mappers -> type_def -> type_def
+  val module_item : mappers -> module_item -> module_item
+  val module_body : mappers -> module_body -> module_body
+  val full_module : mappers -> full_module -> full_module
+end
+
+val use_only_specific_variants : full_module -> full_module
+  (** Use the dedicated variants [Int], [List], etc. instead of the generic
+      variant [Name]. *)
+
+val use_only_name_variant : full_module -> full_module
+  (** Use the generic variant [Name] instead of the dedicated variants
+      [Int], [List], etc. *)

--- a/atd/src/expand.ml
+++ b/atd/src/expand.ml
@@ -59,8 +59,8 @@ open Import
 
 open Ast
 
-module S = Set.Make (String)
-module M = Map.Make (String)
+module S = Stdlib.Set.Make (String)
+module M = Stdlib.Map.Make (String)
 
 
 (*
@@ -246,7 +246,7 @@ let add_annot (x : type_expr) a : type_expr =
 
 
 let expand
-    ?(keep_builtins = true) ?(keep_poly = false) (l : type_def list)
+    ?(keep_builtins = false) ?(keep_poly = false) (l : type_def list)
   : type_def list * original_types =
 
   let seqnum, tbl = init_table () in
@@ -267,7 +267,7 @@ let expand
     | Name (loc, (loc2, "list", [t]), a) ->
         let t' = subst env t in
         if keep_builtins then
-          List (loc2, t', a)
+          Name (loc, (loc2, "list", [t']), a)
         else
           subst_type_name loc loc2 "list" [t'] a
 
@@ -275,7 +275,7 @@ let expand
     | Name (loc, (loc2, "option", [t]), a) ->
         let t' = subst env t in
         if keep_builtins then
-          Option (loc2, t', a)
+          Name (loc, (loc2, "option", [t']), a)
         else
           subst_type_name loc loc2 "option" [t'] a
 
@@ -283,7 +283,7 @@ let expand
     | Name (loc, (loc2, "nullable", [t]), a) ->
         let t' = subst env t in
         if keep_builtins then
-          Nullable (loc2, t', a)
+          Name (loc, (loc2, "nullable", [t']), a)
         else
           subst_type_name loc loc2 "nullable" [t'] a
 
@@ -291,7 +291,7 @@ let expand
     | Name (loc, (loc2, "shared", [t]), a) ->
         let t' = subst env t in
         if keep_builtins then
-          Shared (loc2, t', a)
+          Name (loc, (loc2, "shared", [t']), a)
         else
           subst_type_name loc loc2 "shared" [t'] a
 
@@ -299,7 +299,7 @@ let expand
     | Name (loc, (loc2, "wrap", [t]), a) ->
         let t' = subst env t in
         if keep_builtins then
-          Wrap (loc2, t', a)
+          Name (loc, (loc2, "wrap", [t']), a)
         else
           subst_type_name loc loc2 "wrap" [t'] a
 

--- a/atd/src/expand.mli
+++ b/atd/src/expand.mli
@@ -13,6 +13,7 @@ type original_types = (string, string * int) Hashtbl.t
 
 val expand_module_body :
   ?prefix:string ->
+  ?keep_builtins:bool ->
   ?keep_poly:bool ->
   ?debug:bool ->
   Ast.module_body -> Ast.module_body * original_types
@@ -20,6 +21,10 @@ val expand_module_body :
    Monomorphization of type expressions.
 
    @param prefix prefix to use for new type names. Default is ["_"].
+
+   @param keep_builtins preserve occurrences of the built-in parametrized
+   types such as [list] or [option].
+   Default is [false].
 
    @param keep_poly return definitions for the parametrized types.
    Default is [false].

--- a/atd/src/util.ml
+++ b/atd/src/util.ml
@@ -1,6 +1,9 @@
 let read_lexbuf
     ?annot_schema
-    ?(expand = false) ?keep_poly ?(xdebug = false)
+    ?(expand = false)
+    ?keep_builtins
+    ?keep_poly
+    ?(xdebug = false)
     ?(inherit_fields = false)
     ?(inherit_variants = false)
     ?(pos_fname = "")
@@ -17,7 +20,8 @@ let read_lexbuf
       body
   in
   let (body, original_types) =
-    if expand then Expand.expand_module_body ?keep_poly ~debug: xdebug body
+    if expand then
+      Expand.expand_module_body ?keep_builtins ?keep_poly ~debug: xdebug body
     else (body, Hashtbl.create 0)
   in
   let full_module = (head, body) in
@@ -29,7 +33,8 @@ let read_lexbuf
   (full_module, original_types)
 
 let read_channel
-    ?annot_schema ?expand ?keep_poly ?xdebug ?inherit_fields ?inherit_variants
+    ?annot_schema ?expand ?keep_builtins ?keep_poly ?xdebug
+    ?inherit_fields ?inherit_variants
     ?pos_fname ?pos_lnum
     ic =
   let lexbuf = Lexing.from_channel ic in
@@ -39,11 +44,12 @@ let read_channel
     else
       pos_fname
   in
-  read_lexbuf ?annot_schema ?expand ?keep_poly ?xdebug
+  read_lexbuf ?annot_schema ?expand ?keep_builtins ?keep_poly ?xdebug
     ?inherit_fields ?inherit_variants ?pos_fname ?pos_lnum lexbuf
 
 let load_file
-    ?annot_schema ?expand ?keep_poly ?xdebug ?inherit_fields ?inherit_variants
+    ?annot_schema ?expand ?keep_builtins ?keep_poly ?xdebug
+    ?inherit_fields ?inherit_variants
     ?pos_fname ?pos_lnum
     file =
   let ic = open_in file in
@@ -56,8 +62,8 @@ let load_file
     in
     let ast =
       read_channel
-        ?annot_schema ?expand ?keep_poly ?xdebug ?inherit_fields
-        ?inherit_variants ?pos_fname ?pos_lnum ic
+        ?annot_schema ?expand ?keep_builtins ?keep_poly ?xdebug
+        ?inherit_fields ?inherit_variants ?pos_fname ?pos_lnum ic
     in
     finally ();
     ast
@@ -66,11 +72,12 @@ let load_file
     raise e
 
 let load_string
-    ?annot_schema ?expand ?keep_poly ?xdebug ?inherit_fields ?inherit_variants
+    ?annot_schema ?expand ?keep_builtins ?keep_poly ?xdebug
+    ?inherit_fields ?inherit_variants
     ?pos_fname ?pos_lnum
     s =
   let lexbuf = Lexing.from_string s in
-  read_lexbuf ?annot_schema ?expand ?keep_poly ?xdebug
+  read_lexbuf ?annot_schema ?expand ?keep_builtins ?keep_poly ?xdebug
     ?inherit_fields ?inherit_variants ?pos_fname ?pos_lnum lexbuf
 
 module Tsort = Sort.Make (

--- a/atd/src/util.mli
+++ b/atd/src/util.mli
@@ -3,6 +3,7 @@
 val read_lexbuf :
   ?annot_schema:Annot.schema ->
   ?expand:bool ->
+  ?keep_builtins:bool ->
   ?keep_poly:bool ->
   ?xdebug:bool ->
   ?inherit_fields:bool ->
@@ -58,6 +59,7 @@ val read_lexbuf :
 val read_channel :
   ?annot_schema:Annot.schema ->
   ?expand:bool ->
+  ?keep_builtins:bool ->
   ?keep_poly:bool ->
   ?xdebug:bool ->
   ?inherit_fields:bool ->
@@ -71,6 +73,7 @@ val read_channel :
 val load_file :
   ?annot_schema:Annot.schema ->
   ?expand:bool ->
+  ?keep_builtins:bool ->
   ?keep_poly:bool ->
   ?xdebug:bool ->
   ?inherit_fields:bool ->
@@ -84,6 +87,7 @@ val load_file :
 val load_string :
   ?annot_schema:Annot.schema ->
   ?expand:bool ->
+  ?keep_builtins:bool ->
   ?keep_poly:bool ->
   ?xdebug:bool ->
   ?inherit_fields:bool ->

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -394,7 +394,9 @@ let rec get_writer_name
       if paren && l <> [] then "(" ^ s ^ ")"
       else s
 
-  | _ -> assert false
+  | Unit _ | Bool _ | Int _ | Float _ | String _ | Abstract _
+  | Sum _ | Record _ | Tuple _ | List _ | Option _ | Nullable _
+  | Wrap _ | Name _ | External _ -> assert false
 
 let write_with_adapter adapter writer =
   match adapter.Json.ocaml_adapter with

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -1355,7 +1355,7 @@ let make_ocaml_files
   let m1 = tsort m0 in
   let defs1 = Oj_mapping.defs_of_atd_modules m1 ~target in
   let (m1', original_types) =
-    Atd.Expand.expand_module_body ~keep_poly:true m0
+    Atd.Expand.expand_module_body ~keep_builtins:false ~keep_poly:true m0
   in
   let m2 = tsort m1' in
   (* m0 = original type definitions

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -505,7 +505,7 @@ let rec type_name_of_expr env (e : type_expr) : string =
       in
       sprintf "Tuple[%s]" (String.concat ", " type_names)
   | List (loc, e, an) ->
-      (match assoc_kind loc e an with
+     (match assoc_kind loc e an with
        | Array_list
        | Object_list _ ->
            sprintf "List[%s]"
@@ -522,7 +522,7 @@ let rec type_name_of_expr env (e : type_expr) : string =
   | Shared (loc, e, an) -> not_implemented loc "shared"
   | Wrap (loc, e, an) -> todo "wrap"
   | Name (loc, (loc2, name, []), an) -> py_type_name env name
-  | Name (loc, _, _) -> not_implemented loc "parametrized types"
+  | Name (loc, (_, name, _::_), _) -> assert false
   | Tvar (loc, _) -> not_implemented loc "type variables"
 
 let rec get_default_default
@@ -1219,13 +1219,16 @@ let run_file src_path =
     |> String.lowercase_ascii
   in
   let dst_path = dst_name in
-  let (atd_head, atd_module), _original_types =
+  let full_module, _original_types =
     Atd.Util.load_file
       ~annot_schema
       ~expand:true (* monomorphization = eliminate parametrized type defs *)
+      ~keep_builtins:true
       ~inherit_fields:true
       ~inherit_variants:true
       src_path
   in
+  let full_module = Atd.Ast.use_only_specific_variants full_module in
+  let (atd_head, atd_module) = full_module in
   let head = Python_annot.get_python_json_text (snd atd_head) in
   to_file ~atd_filename:src_name ~head atd_module dst_path

--- a/atdpy/test/atd-input/everything.atd
+++ b/atdpy/test/atd-input/everything.atd
@@ -15,6 +15,13 @@ type frozen
   | B of int
 ]
 
+type ('a, 'b) parametrized_record = {
+  field_a: 'a;
+  ~field_b: 'b list;
+}
+
+type 'a parametrized_tuple = ('a * 'a * int)
+
 type root = {
   id <json name="ID">: string;
   await: bool;
@@ -33,6 +40,8 @@ type root = {
   nullables: int nullable list;
   untyped_things: abstract list;
   (*options: int option list;*)
+  parametrized_record: (int, float) parametrized_record;
+  parametrized_tuple: kind parametrized_tuple;
 }
 
 type alias = int list

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -407,6 +407,58 @@ class Alias:
 
 
 @dataclass
+class X2:
+    """Original type: _2"""
+
+    value: Tuple[Kind, Kind, int]
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'X2':
+        return cls((lambda x: (Kind.from_json(x[0]), Kind.from_json(x[1]), _atd_read_int(x[2])) if isinstance(x, list) and len(x) == 3 else _atd_bad_json('array of length 3', x))(x))
+
+    def to_json(self) -> Any:
+        return (lambda x: [(lambda x: x.to_json())(x[0]), (lambda x: x.to_json())(x[1]), _atd_write_int(x[2])] if isinstance(x, tuple) and len(x) == 3 else _atd_bad_python('tuple of length 3', x))(self.value)
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'X2':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class X1:
+    """Original type: _1 = { ... }"""
+
+    field_a: int
+    field_b: List[float]
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'X1':
+        if isinstance(x, dict):
+            return cls(
+                field_a=_atd_read_int(x['field_a']) if 'field_a' in x else _atd_missing_json_field('X1', 'field_a'),
+                field_b=_atd_read_list(_atd_read_float)(x['field_b']) if 'field_b' in x else [],
+            )
+        else:
+            _atd_bad_json('X1', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['field_a'] = _atd_write_int(self.field_a)
+        res['field_b'] = _atd_write_list(_atd_write_float)(self.field_b)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'X1':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class Root:
     """Original type: root = { ... }"""
 
@@ -424,6 +476,8 @@ class Root:
     assoc4: Dict[str, int]
     nullables: List[Optional[int]]
     untyped_things: List[Any]
+    parametrized_record: X1
+    parametrized_tuple: X2
     maybe: Optional[int] = None
     answer: int = 42
 
@@ -445,6 +499,8 @@ class Root:
                 assoc4=_atd_read_assoc_object_into_dict(_atd_read_int)(x['assoc4']) if 'assoc4' in x else _atd_missing_json_field('Root', 'assoc4'),
                 nullables=_atd_read_list(_atd_read_nullable(_atd_read_int))(x['nullables']) if 'nullables' in x else _atd_missing_json_field('Root', 'nullables'),
                 untyped_things=_atd_read_list((lambda x: x))(x['untyped_things']) if 'untyped_things' in x else _atd_missing_json_field('Root', 'untyped_things'),
+                parametrized_record=X1.from_json(x['parametrized_record']) if 'parametrized_record' in x else _atd_missing_json_field('Root', 'parametrized_record'),
+                parametrized_tuple=X2.from_json(x['parametrized_tuple']) if 'parametrized_tuple' in x else _atd_missing_json_field('Root', 'parametrized_tuple'),
                 maybe=_atd_read_int(x['maybe']) if 'maybe' in x else None,
                 answer=_atd_read_int(x['answer']) if 'answer' in x else 42,
             )
@@ -467,6 +523,8 @@ class Root:
         res['assoc4'] = _atd_write_assoc_dict_to_object(_atd_write_int)(self.assoc4)
         res['nullables'] = _atd_write_list(_atd_write_nullable(_atd_write_int))(self.nullables)
         res['untyped_things'] = _atd_write_list((lambda x: x))(self.untyped_things)
+        res['parametrized_record'] = (lambda x: x.to_json())(self.parametrized_record)
+        res['parametrized_tuple'] = (lambda x: x.to_json())(self.parametrized_tuple)
         if self.maybe is not None:
             res['maybe'] = _atd_write_int(self.maybe)
         res['answer'] = _atd_write_int(self.answer)

--- a/atdpy/test/python-tests/test_atdpy.py
+++ b/atdpy/test/python-tests/test_atdpy.py
@@ -81,6 +81,13 @@ def test_everything_to_json() -> None:
         },
         nullables=[12, None, 34],
         untyped_things=[[["hello"]], {}, None, 123],
+        parametrized_record=e.X1(
+            field_a=42,
+            field_b=[9.9, 8.8],
+        ),
+        parametrized_tuple=e.X2(
+            (e.Kind(e.WOW()), e.Kind(e.WOW()), 100)
+        )
     )
     a_str = a_obj.to_json_string(indent=2)
     print(a_str)
@@ -168,6 +175,18 @@ def test_everything_to_json() -> None:
     {},
     null,
     123
+  ],
+  "parametrized_record": {
+    "field_a": 42,
+    "field_b": [
+      9.9,
+      8.8
+    ]
+  },
+  "parametrized_tuple": [
+    "wow",
+    "wow",
+    100
   ],
   "answer": 42
 }"""


### PR DESCRIPTION
Implements the atdpy part of https://github.com/ahrefs/atd/issues/303

There were annoyances due to the representation of lists, options and other parametrized built-ins which sometimes use the dedicated `List`, `Option` etc. constructors and other times use the generic `Name` constructor. I solved it by providing functions to convert between the two forms.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
