### PR TITLE
Support option types in Python by treating them as nullables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 * atdpy: Support parametrized type definitions (#303)
+* atdpy: Support options approximately by treating them as nullables
 
 2.10.0 (2022-08-09)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 * atdpy: Support parametrized type definitions (#303)
-* atdpy: Support options approximately by treating them as nullables
+* atdpy: Support options approximately by treating them as nullables (#320)
 
 2.10.0 (2022-08-09)
 -------------------

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -490,10 +490,6 @@ let py_type_name env (name : string) =
   | "abstract" -> "Any"
   | user_defined -> class_name env user_defined
 
-let option_is_not_implemented loc =
-  not_implemented loc "true option type (did you forget a '?' \
-                       before the field name?)"
-
 let rec type_name_of_expr env (e : type_expr) : string =
   match e with
   | Sum (loc, _, _) -> not_implemented loc "inline sum types"
@@ -534,7 +530,7 @@ let rec get_default_default
   | List _ ->
       if mutable_ok then Some "[]"
       else None
-  | Option _ -> None
+  | Option _
   | Nullable _ -> Some "None"
   | Shared (loc, e, an) -> get_default_default ~mutable_ok e
   | Wrap (loc, e, an) -> get_default_default ~mutable_ok e
@@ -613,7 +609,7 @@ let rec json_writer env e =
            sprintf "_atd_write_assoc_list_to_object(%s)"
              (json_writer env value)
       )
-  | Option (loc, e, an) -> option_is_not_implemented loc
+  | Option (loc, e, an)
   | Nullable (loc, e, an) ->
       sprintf "_atd_write_nullable(%s)" (json_writer env e)
   | Shared (loc, e, an) -> not_implemented loc "shared"
@@ -694,7 +690,7 @@ let rec json_reader env (e : type_expr) =
            sprintf "_atd_read_assoc_object_into_list(%s)"
              (json_reader env value)
       )
-  | Option (loc, e, an) -> option_is_not_implemented loc
+  | Option (loc, e, an)
   | Nullable (loc, e, an) ->
       sprintf "_atd_read_nullable(%s)" (json_reader env e)
   | Shared (loc, e, an) -> not_implemented loc "shared"

--- a/atdpy/test/atd-input/everything.atd
+++ b/atdpy/test/atd-input/everything.atd
@@ -38,8 +38,8 @@ type root = {
   assoc3: (float * int) list <python repr="dict">;
   assoc4: (string * int) list <json repr="object"> <python repr="dict">;
   nullables: int nullable list;
+  options: int option list;
   untyped_things: abstract list;
-  (*options: int option list;*)
   parametrized_record: (int, float) parametrized_record;
   parametrized_tuple: kind parametrized_tuple;
 }

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -475,6 +475,7 @@ class Root:
     assoc3: Dict[float, int]
     assoc4: Dict[str, int]
     nullables: List[Optional[int]]
+    options: List[Optional[int]]
     untyped_things: List[Any]
     parametrized_record: X1
     parametrized_tuple: X2
@@ -498,6 +499,7 @@ class Root:
                 assoc3=_atd_read_assoc_array_into_dict(_atd_read_float, _atd_read_int)(x['assoc3']) if 'assoc3' in x else _atd_missing_json_field('Root', 'assoc3'),
                 assoc4=_atd_read_assoc_object_into_dict(_atd_read_int)(x['assoc4']) if 'assoc4' in x else _atd_missing_json_field('Root', 'assoc4'),
                 nullables=_atd_read_list(_atd_read_nullable(_atd_read_int))(x['nullables']) if 'nullables' in x else _atd_missing_json_field('Root', 'nullables'),
+                options=_atd_read_list(_atd_read_nullable(_atd_read_int))(x['options']) if 'options' in x else _atd_missing_json_field('Root', 'options'),
                 untyped_things=_atd_read_list((lambda x: x))(x['untyped_things']) if 'untyped_things' in x else _atd_missing_json_field('Root', 'untyped_things'),
                 parametrized_record=X1.from_json(x['parametrized_record']) if 'parametrized_record' in x else _atd_missing_json_field('Root', 'parametrized_record'),
                 parametrized_tuple=X2.from_json(x['parametrized_tuple']) if 'parametrized_tuple' in x else _atd_missing_json_field('Root', 'parametrized_tuple'),
@@ -522,6 +524,7 @@ class Root:
         res['assoc3'] = _atd_write_assoc_dict_to_array(_atd_write_float, _atd_write_int)(self.assoc3)
         res['assoc4'] = _atd_write_assoc_dict_to_object(_atd_write_int)(self.assoc4)
         res['nullables'] = _atd_write_list(_atd_write_nullable(_atd_write_int))(self.nullables)
+        res['options'] = _atd_write_list(_atd_write_nullable(_atd_write_int))(self.options)
         res['untyped_things'] = _atd_write_list((lambda x: x))(self.untyped_things)
         res['parametrized_record'] = (lambda x: x.to_json())(self.parametrized_record)
         res['parametrized_tuple'] = (lambda x: x.to_json())(self.parametrized_tuple)

--- a/atdpy/test/python-tests/test_atdpy.py
+++ b/atdpy/test/python-tests/test_atdpy.py
@@ -80,6 +80,7 @@ def test_everything_to_json() -> None:
             "h": 8,
         },
         nullables=[12, None, 34],
+        options=[56, None, 78],
         untyped_things=[[["hello"]], {}, None, 123],
         parametrized_record=e.X1(
             field_a=42,
@@ -165,6 +166,11 @@ def test_everything_to_json() -> None:
     12,
     null,
     34
+  ],
+  "options": [
+    56,
+    null,
+    78
   ],
   "untyped_things": [
     [


### PR DESCRIPTION
Note that 'Some None' of type 'int option option' can't be represented with nullables but the problem hopefully won't come up frequently.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
