### PR TITLE
Assign stable and human-friendly names to generated type names

### DIFF
--- a/atd/src/expand.ml
+++ b/atd/src/expand.ml
@@ -212,7 +212,9 @@ let make_type_name loc orig_name args an =
   in
   let normalized_args = List.map (mapvar_expr assign_name) args in
   let new_name =
-    "@(" ^ Print.string_of_type_name orig_name normalized_args an ^ ")" in
+    sprintf "@(%s)"
+      (Print.string_of_type_name orig_name normalized_args an)
+  in
   let mapping = List.rev !mapping in
   let new_args =
     List.map (fun (old_s, _) -> Tvar (loc, old_s)) mapping in
@@ -551,35 +553,101 @@ let replace_type_names (subst : string -> string) (t : type_expr) : type_expr =
   in
   replace t
 
+(* Prefer MD5 over Hashtbl.hash because it won't change. *)
+let hex_hash_string s =
+  Digest.string s
+  |> Digest.to_hex
+  |> fun s -> String.sub s 0 7
+
+(*
+   Remove punctuation and non-ascii symbols from a name and replace them
+   with underscores. The original case is preserved.
+   The result is of the form [A-Za-z][A-Za-z0-9_]+.
+
+   Example:
+
+     "@((@(bool wrap_) * type_) option)" -> "bool_wrap_type_option"
+
+   The original name can contain ATD annotations. It would be nice to
+   ignore them but it's not clear how. Ideally we want this:
+
+        "@(string list <ocaml valid='fun l -> true'>)"
+     -> "string_list"
+
+   But we get this:
+
+     "true_6a9832c"
+
+   Since it's misleading, when we see a suspected annotation, we
+   use just "x" followed by a hash of the original contents.
+   The hash has the property of making the name stable i.e. it is unlikely
+   to change when unrelated type definitions change.
+
+     "x_6a9832c"
+*)
+let suggest_good_name =
+  let rex = Re.Pcre.regexp "([^a-zA-Z0-9])+" in
+  fun name_with_punct ->
+    let components =
+      Re.Pcre.split ~rex name_with_punct
+      |> List.filter ((<>) "")
+    in
+    let full_name = String.concat "_" components in
+    let hash = hex_hash_string full_name in
+    let name =
+      if String.contains name_with_punct '<' then
+        (* Avoid misleading names to due ATD annotations embedded in the
+           type name. See earlier comments. *)
+        "x_" ^ hash
+      else if List.length components > 5 then
+        (* Avoid insanely long type names *)
+        match List.rev components with
+        | [] -> assert false
+        | [_] -> assert false
+        | main :: rev_details ->
+            (* Place the hash after the main name rather than before because
+               it often starts with a digit which would have to be prefixed
+               by an extra letter so it can be a valid name. *)
+            main ^ "_" ^ hash
+      else
+        (* A full name that's not too long and makes sense such as
+           'int_bracket' for the type 'int bracket'. *)
+        String.concat "_" components
+    in
+    (* Ensure the name starts with a letter. *)
+    if name = "" then "x"
+    else
+      match name.[0] with
+      | 'a'..'z' | 'A'..'Z' -> name
+      | _ (* digit *) -> "x" ^ name
 
 let standardize_type_names
-    ~prefix ~original_types (l : type_def list) : type_def list =
-
-  let new_id =
-    let n = ref 0 in
-    let rec f tbl =
-      incr n;
-      let id = prefix ^ string_of_int !n in
-      if Hashtbl.mem tbl id then f tbl
-      else id
-    in
-    f
+    ~prefix ~original_types (defs : type_def list) : type_def list =
+  let reserved_identifiers =
+    List.map (fun (k, _, _) -> k) Predef.list
+    @ List.filter_map (fun (_, (k, _, _), _) ->
+      if is_special k then None
+      else Some k
+    ) defs
   in
-
-  let tbl = Hashtbl.create 50 in
-  List.iter (fun (k, _, _) -> Hashtbl.add tbl k k) Predef.list;
-  List.iter (
-    fun (_, (k, _, _), _) ->
-      if not (is_special k) then (
-        Hashtbl.add tbl k k
-      )
-  ) l;
+  let name_registry =
+    Unique_name.init
+      ~reserved_identifiers
+      ~reserved_prefixes:[]
+      ~safe_prefix:""
+  in
+  (* The value v of the type is for extracting a good, short fallback name *)
+  let new_id id =
+    (* The leading underscore is used to identify generated type names
+       in other places. *)
+    Unique_name.translate
+      name_registry
+      ~preferred_translation:(prefix ^ suggest_good_name id)
+      id
+  in
   let replace_name k =
-    try Hashtbl.find tbl k
-    with Not_found ->
-      assert (is_special k);
-      let k' = new_id tbl in
-      Hashtbl.add tbl k k';
+    if is_special k then
+      let k' = new_id k in
       begin try
           let orig_info = Hashtbl.find original_types k in
           Hashtbl.remove original_types k;
@@ -588,21 +656,24 @@ let standardize_type_names
           assert false (* Must have been added during expand *)
       end;
       k'
+    else
+      k
   in
-  let l =
+  let defs =
     List.map (
       fun (loc, (k, pl, a), t) ->
         let k' = replace_name k in
         (loc, (k', pl, a), t)
-    ) l
+    ) defs
   in
-  let subst s =
-    try Hashtbl.find tbl s
-    with Not_found ->
-      (* must have been defined as abstract *)
-      s
+  let subst id =
+    match Unique_name.translate_only name_registry id with
+    | Some x -> x
+    | None ->
+        (* must have been defined as abstract *)
+        id
   in
-  List.map (fun (loc, x, t) -> (loc, x, replace_type_names subst t)) l
+  List.map (fun (loc, x, t) -> (loc, x, replace_type_names subst t)) defs
 
 
 let expand_module_body

--- a/atd/src/print.ml
+++ b/atd/src/print.ml
@@ -257,7 +257,6 @@ let _default_format, default_format_type_name, default_format_type_expr =
 
 let string_of_type_name name args an =
   let x = default_format_type_name name args an in
-
   Easy_format.Pretty.to_string x
 
 let string_of_type_expr expr =

--- a/atd/src/unique_name.ml
+++ b/atd/src/unique_name.ml
@@ -77,11 +77,16 @@ let enumerate_suffixes () =
   in
   get_suffix
 
-let register env src =
+let register ?preferred_translation env src =
+  let pref_dst =
+    match preferred_translation with
+    | None -> src
+    | Some x -> x
+  in
   let get_suffix = enumerate_suffixes () in
   let rec find_available_suffix () =
     let suffix = get_suffix () in
-    let dst = src ^ suffix in
+    let dst = pref_dst ^ suffix in
     let dst =
       (* assume that safe_prefix is not a prefix of a reserved prefix *)
       if has_reserved_prefix env dst then
@@ -102,10 +107,10 @@ let register env src =
 let translate_only env src =
   Hashtbl.find_opt env.translations src
 
-let translate env src =
+let translate ?preferred_translation env src =
   match translate_only env src with
   | Some dst -> dst
-  | None -> register env src
+  | None -> register ?preferred_translation env src
 
 let reverse_translate env dst =
   Hashtbl.find_opt env.reverse_translations dst

--- a/atd/src/unique_name.mli
+++ b/atd/src/unique_name.mli
@@ -59,7 +59,9 @@ val create : t -> string -> string
     Repeated calls of this function on the same input will produce
     the same output as the previous times.
 *)
-val translate : t -> string -> string
+val translate :
+  ?preferred_translation:string ->
+  t -> string -> string
 
 (** Return whether a name exists in the source space. If it exists, return
     its translation to the destination space. *)

--- a/atdgen/test/bucklescript/bucklespec_bs.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_bs.expected.ml
@@ -118,7 +118,7 @@ and read_mutual_recurse2 js = (
     )
   )
 ) js
-let rec write__5 js = (
+let rec write__recurse_list js = (
   Atdgen_codec_runtime.Encode.list (
     write_recurse
   )
@@ -130,7 +130,7 @@ and write_recurse js = (
       [
           Atdgen_codec_runtime.Encode.field
             (
-            write__5
+            write__recurse_list
             )
           ~name:"recurse_items"
           t.recurse_items
@@ -138,7 +138,7 @@ and write_recurse js = (
     )
   )
 ) js
-let rec read__5 js = (
+let rec read__recurse_list js = (
   Atdgen_codec_runtime.Decode.list (
     read_recurse
   )
@@ -150,7 +150,7 @@ and read_recurse js = (
           recurse_items =
             Atdgen_codec_runtime.Decode.decode
             (
-              read__5
+              read__recurse_list
               |> Atdgen_codec_runtime.Decode.field "recurse_items"
             ) json;
       } : recurse)
@@ -284,7 +284,7 @@ let read_v1 = (
       )
   ]
 )
-let write__6 = (
+let write__x_547263f = (
   Atdgen_codec_runtime.Encode.make (fun (t : _) ->
     t |>
     List.map (
@@ -299,7 +299,7 @@ let write__6 = (
     Atdgen_codec_runtime.Encode.obj
   )
 )
-let read__6 = (
+let read__x_547263f = (
   Atdgen_codec_runtime.Decode.obj_list (
     Atdgen_codec_runtime.Decode.int
   )
@@ -311,7 +311,7 @@ let write_using_object = (
       [
           Atdgen_codec_runtime.Encode.field
             (
-            write__6
+            write__x_547263f
             )
           ~name:"f"
           t.f
@@ -326,7 +326,7 @@ let read_using_object = (
           f =
             Atdgen_codec_runtime.Decode.decode
             (
-              read__6
+              read__x_547263f
               |> Atdgen_codec_runtime.Decode.field "f"
             ) json;
       } : using_object)
@@ -360,22 +360,22 @@ let read_single_tuple = (
       )
   ]
 )
-let write__2 = (
+let write__x_2596d76 = (
     Atdgen_codec_runtime.Encode.string
   |> Atdgen_codec_runtime.Encode.contramap (function `Id s -> s)
 )
-let read__2 = (
+let read__x_2596d76 = (
   (
     Atdgen_codec_runtime.Decode.string
   ) |> (Atdgen_codec_runtime.Decode.map (fun s -> `Id s))
 )
 let write_id = (
-  write__2
+  write__x_2596d76
 )
 let read_id = (
-  read__2
+  read__x_2596d76
 )
-let write__3 = (
+let write__unit_simple_var = (
   Atdgen_codec_runtime.Encode.make (fun (x : _) -> match x with
     | `Foo x ->
     Atdgen_codec_runtime.Encode.constr1 "Foo" (
@@ -399,7 +399,7 @@ let write__3 = (
     ) x
   )
 )
-let read__3 = (
+let read__unit_simple_var = (
   Atdgen_codec_runtime.Decode.enum
   [
       (
@@ -442,21 +442,21 @@ let read__3 = (
       )
   ]
 )
-let write__4 = (
+let write__unit_simple_var_list = (
   Atdgen_codec_runtime.Encode.list (
-    write__3
+    write__unit_simple_var
   )
 )
-let read__4 = (
+let read__unit_simple_var_list = (
   Atdgen_codec_runtime.Decode.list (
-    read__3
+    read__unit_simple_var
   )
 )
 let write_simple_vars = (
-  write__4
+  write__unit_simple_var_list
 )
 let read_simple_vars = (
-  read__4
+  read__unit_simple_var_list
 )
 let write_simple_var write__a = (
   Atdgen_codec_runtime.Encode.make (fun (x : _) -> match x with
@@ -728,21 +728,21 @@ let read_pair read__a read__b = (
     )
   )
 )
-let write__1 write__a write__b = (
+let write__a_b_pair_list write__a write__b = (
   Atdgen_codec_runtime.Encode.list (
     write_pair write__a write__a
   )
 )
-let read__1 read__a read__b = (
+let read__a_b_pair_list read__a read__b = (
   Atdgen_codec_runtime.Decode.list (
     read_pair read__a read__a
   )
 )
 let write_pairs write__a = (
-  write__1 write__a write__a
+  write__a_b_pair_list write__a write__a
 )
 let read_pairs read__a = (
-  read__1 read__a read__a
+  read__a_b_pair_list read__a read__a
 )
 let write_label = (
   Atdgen_codec_runtime.Encode.string

--- a/atdgen/test/bucklescript/bucklespec_j.expected.ml
+++ b/atdgen/test/bucklescript/bucklespec_j.expected.ml
@@ -256,14 +256,14 @@ and read_mutual_recurse2 = (
 )
 and mutual_recurse2_of_string s =
   read_mutual_recurse2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let rec write__5 ob x = (
+let rec write__recurse_list ob x = (
   Atdgen_runtime.Oj_run.write_list (
     write_recurse
   )
 ) ob x
-and string_of__5 ?(len = 1024) x =
+and string_of__recurse_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__5 ob x;
+  write__recurse_list ob x;
   Buffer.contents ob
 and write_recurse : _ -> recurse -> _ = (
   fun ob (x : recurse) ->
@@ -275,7 +275,7 @@ and write_recurse : _ -> recurse -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"recurse_items\":";
     (
-      write__5
+      write__recurse_list
     )
       ob x.recurse_items;
     Buffer.add_char ob '}';
@@ -284,13 +284,13 @@ and string_of_recurse ?(len = 1024) x =
   let ob = Buffer.create len in
   write_recurse ob x;
   Buffer.contents ob
-let rec read__5 p lb = (
+let rec read__recurse_list p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_recurse
   )
 ) p lb
-and _5_of_string s =
-  read__5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and _recurse_list_of_string s =
+  read__recurse_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read_recurse = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
@@ -319,7 +319,7 @@ and read_recurse = (
             field_recurse_items := (
               Some (
                 (
-                  read__5
+                  read__recurse_list
                 ) p lb
               )
             );
@@ -350,7 +350,7 @@ and read_recurse = (
               field_recurse_items := (
                 Some (
                   (
-                    read__5
+                    read__recurse_list
                   ) p lb
                 )
               );
@@ -653,26 +653,26 @@ let read_v1 = (
 )
 let v1_of_string s =
   read_v1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__6 = (
+let write__x_547263f = (
   Atdgen_runtime.Oj_run.write_assoc_list (
     Yojson.Safe.write_string
   ) (
     Yojson.Safe.write_int
   )
 )
-let string_of__6 ?(len = 1024) x =
+let string_of__x_547263f ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__6 ob x;
+  write__x_547263f ob x;
   Buffer.contents ob
-let read__6 = (
+let read__x_547263f = (
   Atdgen_runtime.Oj_run.read_assoc_list (
     Atdgen_runtime.Oj_run.read_string
   ) (
     Atdgen_runtime.Oj_run.read_int
   )
 )
-let _6_of_string s =
-  read__6 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_547263f_of_string s =
+  read__x_547263f (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_using_object : _ -> using_object -> _ = (
   fun ob (x : using_object) ->
     Buffer.add_char ob '{';
@@ -683,7 +683,7 @@ let write_using_object : _ -> using_object -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"f\":";
     (
-      write__6
+      write__x_547263f
     )
       ob x.f;
     Buffer.add_char ob '}';
@@ -720,7 +720,7 @@ let read_using_object = (
             field_f := (
               Some (
                 (
-                  read__6
+                  read__x_547263f
                 ) p lb
               )
             );
@@ -751,7 +751,7 @@ let read_using_object = (
               field_f := (
                 Some (
                   (
-                    read__6
+                    read__x_547263f
                   ) p lb
                 )
               );
@@ -894,38 +894,38 @@ let read_single_tuple = (
 )
 let single_tuple_of_string s =
   read_single_tuple (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__2 = (
+let write__x_2596d76 = (
   fun ob x -> (
     let x = ( function `Id s -> s ) x in (
       Yojson.Safe.write_string
     ) ob x)
 )
-let string_of__2 ?(len = 1024) x =
+let string_of__x_2596d76 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__2 ob x;
+  write__x_2596d76 ob x;
   Buffer.contents ob
-let read__2 = (
+let read__x_2596d76 = (
   fun p lb ->
     let x = (
       Atdgen_runtime.Oj_run.read_string
     ) p lb in
     ( fun s -> `Id s ) x
 )
-let _2_of_string s =
-  read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_2596d76_of_string s =
+  read__x_2596d76 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_id = (
-  write__2
+  write__x_2596d76
 )
 let string_of_id ?(len = 1024) x =
   let ob = Buffer.create len in
   write_id ob x;
   Buffer.contents ob
 let read_id = (
-  read__2
+  read__x_2596d76
 )
 let id_of_string s =
   read_id (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__3 = (
+let write__unit_simple_var = (
   fun ob x ->
     match x with
       | `Foo x ->
@@ -961,11 +961,11 @@ let write__3 = (
         ) ob x;
         Buffer.add_char ob ']'
 )
-let string_of__3 ?(len = 1024) x =
+let string_of__unit_simple_var ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__3 ob x;
+  write__unit_simple_var ob x;
   Buffer.contents ob
-let read__3 = (
+let read__unit_simple_var = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -1133,33 +1133,33 @@ let read__3 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _3_of_string s =
-  read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__4 = (
+let _unit_simple_var_of_string s =
+  read__unit_simple_var (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__unit_simple_var_list = (
   Atdgen_runtime.Oj_run.write_list (
-    write__3
+    write__unit_simple_var
   )
 )
-let string_of__4 ?(len = 1024) x =
+let string_of__unit_simple_var_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__4 ob x;
+  write__unit_simple_var_list ob x;
   Buffer.contents ob
-let read__4 = (
+let read__unit_simple_var_list = (
   Atdgen_runtime.Oj_run.read_list (
-    read__3
+    read__unit_simple_var
   )
 )
-let _4_of_string s =
-  read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _unit_simple_var_list_of_string s =
+  read__unit_simple_var_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_simple_vars = (
-  write__4
+  write__unit_simple_var_list
 )
 let string_of_simple_vars ?(len = 1024) x =
   let ob = Buffer.create len in
   write_simple_vars ob x;
   Buffer.contents ob
 let read_simple_vars = (
-  read__4
+  read__unit_simple_var_list
 )
 let simple_vars_of_string s =
   read_simple_vars (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -2096,31 +2096,31 @@ let read_pair read__a read__b = (
 )
 let pair_of_string read__a read__b s =
   read_pair read__a read__b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__1 write__a write__b = (
+let write__a_b_pair_list write__a write__b = (
   Atdgen_runtime.Oj_run.write_list (
     write_pair write__a write__a
   )
 )
-let string_of__1 write__a write__b ?(len = 1024) x =
+let string_of__a_b_pair_list write__a write__b ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__1 write__a write__b ob x;
+  write__a_b_pair_list write__a write__b ob x;
   Buffer.contents ob
-let read__1 read__a read__b = (
+let read__a_b_pair_list read__a read__b = (
   Atdgen_runtime.Oj_run.read_list (
     read_pair read__a read__a
   )
 )
-let _1_of_string read__a read__b s =
-  read__1 read__a read__b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _a_b_pair_list_of_string read__a read__b s =
+  read__a_b_pair_list read__a read__b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_pairs write__a = (
-  write__1 write__a write__a
+  write__a_b_pair_list write__a write__a
 )
 let string_of_pairs write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_pairs write__a ob x;
   Buffer.contents ob
 let read_pairs read__a = (
-  read__1 read__a read__a
+  read__a_b_pair_list read__a read__a
 )
 let pairs_of_string read__a s =
   read_pairs read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/test.expected.ml
+++ b/atdgen/test/test.expected.ml
@@ -166,33 +166,33 @@ type 'a abs2 = 'a list
 
 type 'a abs1 = 'a list
 
-let _19_tag = Bi_io.array_tag
-let write_untagged__19 _a_tag write_untagged__a write__a = (
+let _a_list_tag = Bi_io.array_tag
+let write_untagged__a_list _a_tag write_untagged__a write__a = (
   Atdgen_runtime.Ob_run.write_untagged_list
     _a_tag
     (
       write_untagged__a
     )
 )
-let write__19 _a_tag write_untagged__a write__a ob x =
+let write__a_list _a_tag write_untagged__a write__a ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__19 _a_tag write_untagged__a write__a ob x
-let string_of__19 _a_tag write_untagged__a write__a ?(len = 1024) x =
+  write_untagged__a_list _a_tag write_untagged__a write__a ob x
+let string_of__a_list _a_tag write_untagged__a write__a ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__19 _a_tag write_untagged__a write__a ob x;
+  write__a_list _a_tag write_untagged__a write__a ob x;
   Bi_outbuf.contents ob
-let get__19_reader get__a_reader read__a = (
+let get__a_list_reader get__a_reader read__a = (
   Atdgen_runtime.Ob_run.get_list_reader (
     get__a_reader
   )
 )
-let read__19 get__a_reader read__a = (
+let read__a_list get__a_reader read__a = (
   Atdgen_runtime.Ob_run.read_list (
     get__a_reader
   )
 )
-let _19_of_string get__a_reader read__a ?pos s =
-  read__19 get__a_reader read__a (Bi_inbuf.from_string ?pos s)
+let _a_list_of_string get__a_reader read__a ?pos s =
+  read__a_list get__a_reader read__a (Bi_inbuf.from_string ?pos s)
 let rec p'_tag = Bi_io.variant_tag
 and write_untagged_p' _a_tag write_untagged__a write__a : Bi_outbuf.t -> 'a p' -> unit = (
   fun ob x ->
@@ -420,18 +420,188 @@ and read_r = (
 )
 and r_of_string ?pos s =
   read_r (Bi_inbuf.from_string ?pos s)
-let rec _20_tag = Bi_io.num_variant_tag
-and write_untagged__20 _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x = (
+let rec _test_variant_list_tag = Bi_io.array_tag
+and write_untagged__test_variant_list ob x = (
+  Atdgen_runtime.Ob_run.write_untagged_list
+    test_variant_tag
+    (
+      write_untagged_test_variant
+    )
+) ob x
+and write__test_variant_list ob x =
+  Bi_io.write_tag ob Bi_io.array_tag;
+  write_untagged__test_variant_list ob x
+and string_of__test_variant_list ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__test_variant_list ob x;
+  Bi_outbuf.contents ob
+and test_variant_tag = Bi_io.variant_tag
+and write_untagged_test_variant = (
+  fun ob x ->
+    match x with
+      | `Case1 -> Bi_outbuf.add_char4 ob 'T' 'N' '+' 'a'
+      | `Case2 x ->
+        Bi_outbuf.add_char4 ob '\212' 'N' '+' 'b';
+        (
+          Bi_io.write_svint
+        ) ob x
+      | `Case3 x ->
+        Bi_outbuf.add_char4 ob '\212' 'N' '+' 'c';
+        (
+          Bi_io.write_string
+        ) ob x
+      | `Case4 x ->
+        Bi_outbuf.add_char4 ob '\212' 'N' '+' 'd';
+        (
+          write__test_variant_list
+        ) ob x
+)
+and write_test_variant ob x =
+  Bi_io.write_tag ob Bi_io.variant_tag;
+  write_untagged_test_variant ob x
+and string_of_test_variant ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_test_variant ob x;
+  Bi_outbuf.contents ob
+let rec get__test_variant_list_reader tag = (
+  Atdgen_runtime.Ob_run.get_list_reader (
+    get_test_variant_reader
+  )
+) tag
+and read__test_variant_list ib = (
+  Atdgen_runtime.Ob_run.read_list (
+    get_test_variant_reader
+  )
+) ib
+and _test_variant_list_of_string ?pos s =
+  read__test_variant_list (Bi_inbuf.from_string ?pos s)
+and get_test_variant_reader = (
+  fun tag ->
+    if tag <> 23 then Atdgen_runtime.Ob_run.read_error () else
+      fun ib ->
+        Bi_io.read_hashtag ib (fun ib h has_arg ->
+          match h, has_arg with
+            | -733074591, false -> `Case1
+            | -733074590, true -> (`Case2 (
+                (
+                  Atdgen_runtime.Ob_run.read_int
+                ) ib
+              ))
+            | -733074589, true -> (`Case3 (
+                (
+                  Atdgen_runtime.Ob_run.read_string
+                ) ib
+              ))
+            | -733074588, true -> (`Case4 (
+                (
+                  read__test_variant_list
+                ) ib
+              ))
+            | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
+        )
+)
+and read_test_variant = (
+  fun ib ->
+    if Bi_io.read_tag ib <> 23 then Atdgen_runtime.Ob_run.read_error_at ib;
+    Bi_io.read_hashtag ib (fun ib h has_arg ->
+      match h, has_arg with
+        | -733074591, false -> `Case1
+        | -733074590, true -> (`Case2 (
+            (
+              Atdgen_runtime.Ob_run.read_int
+            ) ib
+          ))
+        | -733074589, true -> (`Case3 (
+            (
+              Atdgen_runtime.Ob_run.read_string
+            ) ib
+          ))
+        | -733074588, true -> (`Case4 (
+            (
+              read__test_variant_list
+            ) ib
+          ))
+        | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
+    )
+)
+and test_variant_of_string ?pos s =
+  read_test_variant (Bi_inbuf.from_string ?pos s)
+let rec _int_p_tag = Bi_io.variant_tag
+and write_untagged__int_p : Bi_outbuf.t -> _ p' -> unit = (
+  fun ob x ->
+    match x with
+      | A -> Bi_outbuf.add_char4 ob '\000' '\000' '\000' 'A'
+      | Bb x ->
+        Bi_outbuf.add_char4 ob '\128' '\000' '9' '\224';
+        (
+          write__int_p
+        ) ob x
+      | Ccccc x ->
+        Bi_outbuf.add_char4 ob '\213' '\148' 's' '\003';
+        (
+          Bi_io.write_svint
+        ) ob x
+)
+and write__int_p ob x =
+  Bi_io.write_tag ob Bi_io.variant_tag;
+  write_untagged__int_p ob x
+and string_of__int_p ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__int_p ob x;
+  Bi_outbuf.contents ob
+let rec get__int_p_reader = (
+  fun tag ->
+    if tag <> 23 then Atdgen_runtime.Ob_run.read_error () else
+      fun ib ->
+        Bi_io.read_hashtag ib (fun ib h has_arg ->
+          match h, has_arg with
+            | 65, false -> (A : _ p')
+            | 14816, true -> (Bb (
+                (
+                  read__int_p
+                ) ib
+              ) : _ p')
+            | -711691517, true -> (Ccccc (
+                (
+                  Atdgen_runtime.Ob_run.read_int
+                ) ib
+              ) : _ p')
+            | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
+        )
+)
+and read__int_p = (
+  fun ib ->
+    if Bi_io.read_tag ib <> 23 then Atdgen_runtime.Ob_run.read_error_at ib;
+    Bi_io.read_hashtag ib (fun ib h has_arg ->
+      match h, has_arg with
+        | 65, false -> (A : _ p')
+        | 14816, true -> (Bb (
+            (
+              read__int_p
+            ) ib
+          ) : _ p')
+        | -711691517, true -> (Ccccc (
+            (
+              Atdgen_runtime.Ob_run.read_int
+            ) ib
+          ) : _ p')
+        | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
+    )
+)
+and _int_p_of_string ?pos s =
+  read__int_p (Bi_inbuf.from_string ?pos s)
+let rec _a_b_poly_option_tag = Bi_io.num_variant_tag
+and write_untagged__a_b_poly_option _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x = (
   Atdgen_runtime.Ob_run.write_untagged_option (
     write_poly _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b
   )
 ) ob x
-and write__20 _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x =
+and write__a_b_poly_option _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__20 _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x
-and string_of__20 _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ?(len = 1024) x =
+  write_untagged__a_b_poly_option _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x
+and string_of__a_b_poly_option _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__20 _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x;
+  write__a_b_poly_option _a_tag write_untagged__a write__a _b_tag write_untagged__b write__b ob x;
   Bi_outbuf.contents ob
 and poly_tag = Bi_io.record_tag
 and write_untagged_poly _x_tag write_untagged__x write__x _y_tag write_untagged__y write__y : Bi_outbuf.t -> ('x, 'y) poly -> unit = (
@@ -439,11 +609,11 @@ and write_untagged_poly _x_tag write_untagged__x write__x _y_tag write_untagged_
     Bi_vint.write_uvint ob 2;
     Bi_outbuf.add_char4 ob '\128' 'M' '\202' '\135';
     (
-      write__19 _x_tag write_untagged__x write__x
+      write__a_list _x_tag write_untagged__x write__x
     ) ob x.fst;
     Bi_outbuf.add_char4 ob '\128' 'W' '\163' 'i';
     (
-      write__20 _x_tag write_untagged__x write__x _y_tag write_untagged__y write__y
+      write__a_b_poly_option _x_tag write_untagged__x write__x _y_tag write_untagged__y write__y
     ) ob x.snd;
 )
 and write_poly _x_tag write_untagged__x write__x _y_tag write_untagged__y write__y ob x =
@@ -453,7 +623,7 @@ and string_of_poly _x_tag write_untagged__x write__x _y_tag write_untagged__y wr
   let ob = Bi_outbuf.create len in
   write_poly _x_tag write_untagged__x write__x _y_tag write_untagged__y write__y ob x;
   Bi_outbuf.contents ob
-let rec get__20_reader get__a_reader read__a get__b_reader read__b = (
+let rec get__a_b_poly_option_reader get__a_reader read__a get__b_reader read__b = (
   fun tag ->
     if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -468,7 +638,7 @@ let rec get__20_reader get__a_reader read__a get__b_reader read__b = (
             )
           | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-and read__20 get__a_reader read__a get__b_reader read__b = (
+and read__a_b_poly_option get__a_reader read__a get__b_reader read__b = (
   fun ib ->
     if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
     match Char.code (Bi_inbuf.read_char ib) with
@@ -482,8 +652,8 @@ and read__20 get__a_reader read__a get__b_reader read__b = (
         )
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-and _20_of_string get__a_reader read__a get__b_reader read__b ?pos s =
-  read__20 get__a_reader read__a get__b_reader read__b (Bi_inbuf.from_string ?pos s)
+and _a_b_poly_option_of_string get__a_reader read__a get__b_reader read__b ?pos s =
+  read__a_b_poly_option get__a_reader read__a get__b_reader read__b (Bi_inbuf.from_string ?pos s)
 and get_poly_reader get__x_reader read__x get__y_reader read__y = (
   fun tag ->
     if tag <> 21 then Atdgen_runtime.Ob_run.read_error () else
@@ -497,14 +667,14 @@ and get_poly_reader get__x_reader read__x get__y_reader read__y = (
             | 5098119 ->
               field_fst := (
                 (
-                  read__19 get__x_reader read__x
+                  read__a_list get__x_reader read__x
                 ) ib
               );
               bits0 := !bits0 lor 0x1;
             | 5743465 ->
               field_snd := (
                 (
-                  read__20 get__x_reader read__x get__y_reader read__y
+                  read__a_b_poly_option get__x_reader read__x get__y_reader read__y
                 ) ib
               );
               bits0 := !bits0 lor 0x2;
@@ -530,14 +700,14 @@ and read_poly get__x_reader read__x get__y_reader read__y = (
         | 5098119 ->
           field_fst := (
             (
-              read__19 get__x_reader read__x
+              read__a_list get__x_reader read__x
             ) ib
           );
           bits0 := !bits0 lor 0x1;
         | 5743465 ->
           field_snd := (
             (
-              read__20 get__x_reader read__x get__y_reader read__y
+              read__a_b_poly_option get__x_reader read__x get__y_reader read__y
             ) ib
           );
           bits0 := !bits0 lor 0x2;
@@ -553,176 +723,6 @@ and read_poly get__x_reader read__x get__y_reader read__y = (
 )
 and poly_of_string get__x_reader read__x get__y_reader read__y ?pos s =
   read_poly get__x_reader read__x get__y_reader read__y (Bi_inbuf.from_string ?pos s)
-let rec _2_tag = Bi_io.array_tag
-and write_untagged__2 ob x = (
-  Atdgen_runtime.Ob_run.write_untagged_list
-    test_variant_tag
-    (
-      write_untagged_test_variant
-    )
-) ob x
-and write__2 ob x =
-  Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__2 ob x
-and string_of__2 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__2 ob x;
-  Bi_outbuf.contents ob
-and test_variant_tag = Bi_io.variant_tag
-and write_untagged_test_variant = (
-  fun ob x ->
-    match x with
-      | `Case1 -> Bi_outbuf.add_char4 ob 'T' 'N' '+' 'a'
-      | `Case2 x ->
-        Bi_outbuf.add_char4 ob '\212' 'N' '+' 'b';
-        (
-          Bi_io.write_svint
-        ) ob x
-      | `Case3 x ->
-        Bi_outbuf.add_char4 ob '\212' 'N' '+' 'c';
-        (
-          Bi_io.write_string
-        ) ob x
-      | `Case4 x ->
-        Bi_outbuf.add_char4 ob '\212' 'N' '+' 'd';
-        (
-          write__2
-        ) ob x
-)
-and write_test_variant ob x =
-  Bi_io.write_tag ob Bi_io.variant_tag;
-  write_untagged_test_variant ob x
-and string_of_test_variant ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write_test_variant ob x;
-  Bi_outbuf.contents ob
-let rec get__2_reader tag = (
-  Atdgen_runtime.Ob_run.get_list_reader (
-    get_test_variant_reader
-  )
-) tag
-and read__2 ib = (
-  Atdgen_runtime.Ob_run.read_list (
-    get_test_variant_reader
-  )
-) ib
-and _2_of_string ?pos s =
-  read__2 (Bi_inbuf.from_string ?pos s)
-and get_test_variant_reader = (
-  fun tag ->
-    if tag <> 23 then Atdgen_runtime.Ob_run.read_error () else
-      fun ib ->
-        Bi_io.read_hashtag ib (fun ib h has_arg ->
-          match h, has_arg with
-            | -733074591, false -> `Case1
-            | -733074590, true -> (`Case2 (
-                (
-                  Atdgen_runtime.Ob_run.read_int
-                ) ib
-              ))
-            | -733074589, true -> (`Case3 (
-                (
-                  Atdgen_runtime.Ob_run.read_string
-                ) ib
-              ))
-            | -733074588, true -> (`Case4 (
-                (
-                  read__2
-                ) ib
-              ))
-            | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
-        )
-)
-and read_test_variant = (
-  fun ib ->
-    if Bi_io.read_tag ib <> 23 then Atdgen_runtime.Ob_run.read_error_at ib;
-    Bi_io.read_hashtag ib (fun ib h has_arg ->
-      match h, has_arg with
-        | -733074591, false -> `Case1
-        | -733074590, true -> (`Case2 (
-            (
-              Atdgen_runtime.Ob_run.read_int
-            ) ib
-          ))
-        | -733074589, true -> (`Case3 (
-            (
-              Atdgen_runtime.Ob_run.read_string
-            ) ib
-          ))
-        | -733074588, true -> (`Case4 (
-            (
-              read__2
-            ) ib
-          ))
-        | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
-    )
-)
-and test_variant_of_string ?pos s =
-  read_test_variant (Bi_inbuf.from_string ?pos s)
-let rec _1_tag = Bi_io.variant_tag
-and write_untagged__1 : Bi_outbuf.t -> _ p' -> unit = (
-  fun ob x ->
-    match x with
-      | A -> Bi_outbuf.add_char4 ob '\000' '\000' '\000' 'A'
-      | Bb x ->
-        Bi_outbuf.add_char4 ob '\128' '\000' '9' '\224';
-        (
-          write__1
-        ) ob x
-      | Ccccc x ->
-        Bi_outbuf.add_char4 ob '\213' '\148' 's' '\003';
-        (
-          Bi_io.write_svint
-        ) ob x
-)
-and write__1 ob x =
-  Bi_io.write_tag ob Bi_io.variant_tag;
-  write_untagged__1 ob x
-and string_of__1 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__1 ob x;
-  Bi_outbuf.contents ob
-let rec get__1_reader = (
-  fun tag ->
-    if tag <> 23 then Atdgen_runtime.Ob_run.read_error () else
-      fun ib ->
-        Bi_io.read_hashtag ib (fun ib h has_arg ->
-          match h, has_arg with
-            | 65, false -> (A : _ p')
-            | 14816, true -> (Bb (
-                (
-                  read__1
-                ) ib
-              ) : _ p')
-            | -711691517, true -> (Ccccc (
-                (
-                  Atdgen_runtime.Ob_run.read_int
-                ) ib
-              ) : _ p')
-            | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
-        )
-)
-and read__1 = (
-  fun ib ->
-    if Bi_io.read_tag ib <> 23 then Atdgen_runtime.Ob_run.read_error_at ib;
-    Bi_io.read_hashtag ib (fun ib h has_arg ->
-      match h, has_arg with
-        | 65, false -> (A : _ p')
-        | 14816, true -> (Bb (
-            (
-              read__1
-            ) ib
-          ) : _ p')
-        | -711691517, true -> (Ccccc (
-            (
-              Atdgen_runtime.Ob_run.read_int
-            ) ib
-          ) : _ p')
-        | _ -> Atdgen_runtime.Ob_run.unsupported_variant h has_arg
-    )
-)
-and _1_of_string ?pos s =
-  read__1 (Bi_inbuf.from_string ?pos s)
 let validated_string_check_tag = Bi_io.string_tag
 let write_untagged_validated_string_check = (
   Bi_io.write_untagged_string
@@ -742,36 +742,36 @@ let read_validated_string_check = (
 )
 let validated_string_check_of_string ?pos s =
   read_validated_string_check (Bi_inbuf.from_string ?pos s)
-let _31_tag = Bi_io.array_tag
-let write_untagged__31 = (
+let _x_5640b64_tag = Bi_io.array_tag
+let write_untagged__x_5640b64 = (
   Atdgen_runtime.Ob_run.write_untagged_list
     Bi_io.string_tag
     (
       Bi_io.write_untagged_string
     )
 )
-let write__31 ob x =
+let write__x_5640b64 ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__31 ob x
-let string_of__31 ?(len = 1024) x =
+  write_untagged__x_5640b64 ob x
+let string_of__x_5640b64 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__31 ob x;
+  write__x_5640b64 ob x;
   Bi_outbuf.contents ob
-let get__31_reader = (
+let get__x_5640b64_reader = (
   Atdgen_runtime.Ob_run.get_list_reader (
     Atdgen_runtime.Ob_run.get_string_reader
   )
 )
-let read__31 = (
+let read__x_5640b64 = (
   Atdgen_runtime.Ob_run.read_list (
     Atdgen_runtime.Ob_run.get_string_reader
   )
 )
-let _31_of_string ?pos s =
-  read__31 (Bi_inbuf.from_string ?pos s)
+let _x_5640b64_of_string ?pos s =
+  read__x_5640b64 (Bi_inbuf.from_string ?pos s)
 let validate_me_tag = Bi_io.array_tag
 let write_untagged_validate_me = (
-  write_untagged__31
+  write_untagged__x_5640b64
 )
 let write_validate_me ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -781,10 +781,10 @@ let string_of_validate_me ?(len = 1024) x =
   write_validate_me ob x;
   Bi_outbuf.contents ob
 let get_validate_me_reader = (
-  get__31_reader
+  get__x_5640b64_reader
 )
 let read_validate_me = (
-  read__31
+  read__x_5640b64
 )
 let validate_me_of_string ?pos s =
   read_validate_me (Bi_inbuf.from_string ?pos s)
@@ -855,20 +855,20 @@ let read_val1 = (
 )
 let val1_of_string ?pos s =
   read_val1 (Bi_inbuf.from_string ?pos s)
-let _16_tag = Bi_io.num_variant_tag
-let write_untagged__16 = (
+let _val1_option_tag = Bi_io.num_variant_tag
+let write_untagged__val1_option = (
   Atdgen_runtime.Ob_run.write_untagged_option (
     write_val1
   )
 )
-let write__16 ob x =
+let write__val1_option ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__16 ob x
-let string_of__16 ?(len = 1024) x =
+  write_untagged__val1_option ob x
+let string_of__val1_option ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__16 ob x;
+  write__val1_option ob x;
   Bi_outbuf.contents ob
-let get__16_reader = (
+let get__val1_option_reader = (
   fun tag ->
     if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -883,7 +883,7 @@ let get__16_reader = (
             )
           | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let read__16 = (
+let read__val1_option = (
   fun ib ->
     if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
     match Char.code (Bi_inbuf.read_char ib) with
@@ -897,8 +897,8 @@ let read__16 = (
         )
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _16_of_string ?pos s =
-  read__16 (Bi_inbuf.from_string ?pos s)
+let _val1_option_of_string ?pos s =
+  read__val1_option (Bi_inbuf.from_string ?pos s)
 let val2_tag = Bi_io.record_tag
 let write_untagged_val2 : Bi_outbuf.t -> val2 -> unit = (
   fun ob x ->
@@ -995,36 +995,36 @@ let read_val2 = (
 )
 let val2_of_string ?pos s =
   read_val2 (Bi_inbuf.from_string ?pos s)
-let _29_tag = Bi_io.array_tag
-let write_untagged__29 = (
+let _x_6089809_tag = Bi_io.array_tag
+let write_untagged__x_6089809 = (
   Atdgen_runtime.Ob_run.write_untagged_list
     Bi_io.float64_tag
     (
       Bi_io.write_untagged_float64
     )
 )
-let write__29 ob x =
+let write__x_6089809 ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__29 ob x
-let string_of__29 ?(len = 1024) x =
+  write_untagged__x_6089809 ob x
+let string_of__x_6089809 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__29 ob x;
+  write__x_6089809 ob x;
   Bi_outbuf.contents ob
-let get__29_reader = (
+let get__x_6089809_reader = (
   Atdgen_runtime.Ob_run.get_list_reader (
     Atdgen_runtime.Ob_run.get_float64_reader
   )
 )
-let read__29 = (
+let read__x_6089809 = (
   Atdgen_runtime.Ob_run.read_list (
     Atdgen_runtime.Ob_run.get_float64_reader
   )
 )
-let _29_of_string ?pos s =
-  read__29 (Bi_inbuf.from_string ?pos s)
+let _x_6089809_of_string ?pos s =
+  read__x_6089809 (Bi_inbuf.from_string ?pos s)
 let unixtime_list_tag = Bi_io.array_tag
 let write_untagged_unixtime_list = (
-  write_untagged__29
+  write_untagged__x_6089809
 )
 let write_unixtime_list ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -1034,27 +1034,27 @@ let string_of_unixtime_list ?(len = 1024) x =
   write_unixtime_list ob x;
   Bi_outbuf.contents ob
 let get_unixtime_list_reader = (
-  get__29_reader
+  get__x_6089809_reader
 )
 let read_unixtime_list = (
-  read__29
+  read__x_6089809
 )
 let unixtime_list_of_string ?pos s =
   read_unixtime_list (Bi_inbuf.from_string ?pos s)
-let _3_tag = Bi_io.num_variant_tag
-let write_untagged__3 = (
+let _int_nullable_tag = Bi_io.num_variant_tag
+let write_untagged__int_nullable = (
   Atdgen_runtime.Ob_run.write_untagged_option (
     Bi_io.write_svint
   )
 )
-let write__3 ob x =
+let write__int_nullable ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__3 ob x
-let string_of__3 ?(len = 1024) x =
+  write_untagged__int_nullable ob x
+let string_of__int_nullable ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__3 ob x;
+  write__int_nullable ob x;
   Bi_outbuf.contents ob
-let get__3_reader = (
+let get__int_nullable_reader = (
   fun tag ->
     if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -1069,7 +1069,7 @@ let get__3_reader = (
             )
           | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let read__3 = (
+let read__int_nullable = (
   fun ib ->
     if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
     match Char.code (Bi_inbuf.read_char ib) with
@@ -1083,8 +1083,8 @@ let read__3 = (
         )
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _3_of_string ?pos s =
-  read__3 (Bi_inbuf.from_string ?pos s)
+let _int_nullable_of_string ?pos s =
+  read__int_nullable (Bi_inbuf.from_string ?pos s)
 let date_tag = Bi_io.tuple_tag
 let write_untagged_date = (
   fun ob x ->
@@ -1096,12 +1096,12 @@ let write_untagged_date = (
     );
     (
       let _, x, _ = x in (
-        write__3
+        write__int_nullable
       ) ob x
     );
     (
       let _, _, x = x in (
-        write__3
+        write__int_nullable
       ) ob x
     );
 )
@@ -1125,12 +1125,12 @@ let get_date_reader = (
         in
         let x1 =
           (
-            read__3
+            read__int_nullable
           ) ib
         in
         let x2 =
           (
-            read__3
+            read__int_nullable
           ) ib
         in
         for i = 3 to len - 1 do Bi_io.skip ib done;
@@ -1148,12 +1148,12 @@ let read_date = (
     in
     let x1 =
       (
-        read__3
+        read__int_nullable
       ) ib
     in
     let x2 =
       (
-        read__3
+        read__int_nullable
       ) ib
     in
     for i = 3 to len - 1 do Bi_io.skip ib done;
@@ -1161,118 +1161,101 @@ let read_date = (
 )
 let date_of_string ?pos s =
   read_date (Bi_inbuf.from_string ?pos s)
-let _9_tag = Bi_io.array_tag
-let write_untagged__9 = (
-  Atdgen_runtime.Ob_run.write_untagged_array
-    Bi_io.string_tag
-    (
-      Bi_io.write_untagged_string
-    )
-)
-let write__9 ob x =
-  Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__9 ob x
-let string_of__9 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__9 ob x;
-  Bi_outbuf.contents ob
-let get__9_reader = (
-  Atdgen_runtime.Ob_run.get_array_reader (
-    Atdgen_runtime.Ob_run.get_string_reader
-  )
-)
-let read__9 = (
-  Atdgen_runtime.Ob_run.read_array (
-    Atdgen_runtime.Ob_run.get_string_reader
-  )
-)
-let _9_of_string ?pos s =
-  read__9 (Bi_inbuf.from_string ?pos s)
-let _8_tag = Bi_io.num_variant_tag
-let write_untagged__8 = (
-  Atdgen_runtime.Ob_run.write_untagged_option (
-    Bi_io.write_bool
-  )
-)
-let write__8 ob x =
-  Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__8 ob x
-let string_of__8 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__8 ob x;
-  Bi_outbuf.contents ob
-let get__8_reader = (
-  fun tag ->
-    if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
-      fun ib ->
-        match Char.code (Bi_inbuf.read_char ib) with
-          | 0 -> None
-          | 0x80 ->
-            Some (
-              (
-                Atdgen_runtime.Ob_run.read_bool
-              )
-                ib
-            )
-          | _ -> Atdgen_runtime.Ob_run.read_error_at ib
-)
-let read__8 = (
-  fun ib ->
-    if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
-    match Char.code (Bi_inbuf.read_char ib) with
-      | 0 -> None
-      | 0x80 ->
-        Some (
-          (
-            Atdgen_runtime.Ob_run.read_bool
-          )
-            ib
-        )
-      | _ -> Atdgen_runtime.Ob_run.read_error_at ib
-)
-let _8_of_string ?pos s =
-  read__8 (Bi_inbuf.from_string ?pos s)
-let _7_tag = Bi_io.array_tag
-let write_untagged__7 = (
+let _x_adbef7e_tag = Bi_io.array_tag
+let write_untagged__x_adbef7e = (
   Atdgen_runtime.Ob_run.write_untagged_array
     Bi_io.float64_tag
     (
       Bi_io.write_untagged_float64
     )
 )
-let write__7 ob x =
+let write__x_adbef7e ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__7 ob x
-let string_of__7 ?(len = 1024) x =
+  write_untagged__x_adbef7e ob x
+let string_of__x_adbef7e ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__7 ob x;
+  write__x_adbef7e ob x;
   Bi_outbuf.contents ob
-let get__7_reader = (
+let get__x_adbef7e_reader = (
   Atdgen_runtime.Ob_run.get_array_reader (
     Atdgen_runtime.Ob_run.get_float64_reader
   )
 )
-let read__7 = (
+let read__x_adbef7e = (
   Atdgen_runtime.Ob_run.read_array (
     Atdgen_runtime.Ob_run.get_float64_reader
   )
 )
-let _7_of_string ?pos s =
-  read__7 (Bi_inbuf.from_string ?pos s)
-let _6_tag = Bi_io.num_variant_tag
-let write_untagged__6 = (
+let _x_adbef7e_of_string ?pos s =
+  read__x_adbef7e (Bi_inbuf.from_string ?pos s)
+let _x_20d39e2_tag = Bi_io.array_tag
+let write_untagged__x_20d39e2 = (
+  Atdgen_runtime.Ob_run.write_untagged_array
+    Bi_io.string_tag
+    (
+      Bi_io.write_untagged_string
+    )
+)
+let write__x_20d39e2 ob x =
+  Bi_io.write_tag ob Bi_io.array_tag;
+  write_untagged__x_20d39e2 ob x
+let string_of__x_20d39e2 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__x_20d39e2 ob x;
+  Bi_outbuf.contents ob
+let get__x_20d39e2_reader = (
+  Atdgen_runtime.Ob_run.get_array_reader (
+    Atdgen_runtime.Ob_run.get_string_reader
+  )
+)
+let read__x_20d39e2 = (
+  Atdgen_runtime.Ob_run.read_array (
+    Atdgen_runtime.Ob_run.get_string_reader
+  )
+)
+let _x_20d39e2_of_string ?pos s =
+  read__x_20d39e2 (Bi_inbuf.from_string ?pos s)
+let _unit_list_tag = Bi_io.array_tag
+let write_untagged__unit_list = (
+  Atdgen_runtime.Ob_run.write_untagged_list
+    Bi_io.unit_tag
+    (
+      Bi_io.write_untagged_unit
+    )
+)
+let write__unit_list ob x =
+  Bi_io.write_tag ob Bi_io.array_tag;
+  write_untagged__unit_list ob x
+let string_of__unit_list ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__unit_list ob x;
+  Bi_outbuf.contents ob
+let get__unit_list_reader = (
+  Atdgen_runtime.Ob_run.get_list_reader (
+    Atdgen_runtime.Ob_run.get_unit_reader
+  )
+)
+let read__unit_list = (
+  Atdgen_runtime.Ob_run.read_list (
+    Atdgen_runtime.Ob_run.get_unit_reader
+  )
+)
+let _unit_list_of_string ?pos s =
+  read__unit_list (Bi_inbuf.from_string ?pos s)
+let _string_option_tag = Bi_io.num_variant_tag
+let write_untagged__string_option = (
   Atdgen_runtime.Ob_run.write_untagged_option (
     Bi_io.write_string
   )
 )
-let write__6 ob x =
+let write__string_option ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__6 ob x
-let string_of__6 ?(len = 1024) x =
+  write_untagged__string_option ob x
+let string_of__string_option ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__6 ob x;
+  write__string_option ob x;
   Bi_outbuf.contents ob
-let get__6_reader = (
+let get__string_option_reader = (
   fun tag ->
     if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -1287,7 +1270,7 @@ let get__6_reader = (
             )
           | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let read__6 = (
+let read__string_option = (
   fun ib ->
     if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
     match Char.code (Bi_inbuf.read_char ib) with
@@ -1301,66 +1284,49 @@ let read__6 = (
         )
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _6_of_string ?pos s =
-  read__6 (Bi_inbuf.from_string ?pos s)
-let _5_tag = Bi_io.num_variant_tag
-let write_untagged__5 = (
-  Atdgen_runtime.Ob_run.write_untagged_option (
-    Bi_io.write_float64
+let _string_option_of_string ?pos s =
+  read__string_option (Bi_inbuf.from_string ?pos s)
+let _string_option_list_tag = Bi_io.array_tag
+let write_untagged__string_option_list = (
+  Atdgen_runtime.Ob_run.write_untagged_list
+    _string_option_tag
+    (
+      write_untagged__string_option
+    )
+)
+let write__string_option_list ob x =
+  Bi_io.write_tag ob Bi_io.array_tag;
+  write_untagged__string_option_list ob x
+let string_of__string_option_list ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__string_option_list ob x;
+  Bi_outbuf.contents ob
+let get__string_option_list_reader = (
+  Atdgen_runtime.Ob_run.get_list_reader (
+    get__string_option_reader
   )
 )
-let write__5 ob x =
-  Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__5 ob x
-let string_of__5 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__5 ob x;
-  Bi_outbuf.contents ob
-let get__5_reader = (
-  fun tag ->
-    if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
-      fun ib ->
-        match Char.code (Bi_inbuf.read_char ib) with
-          | 0 -> None
-          | 0x80 ->
-            Some (
-              (
-                Atdgen_runtime.Ob_run.read_float64
-              )
-                ib
-            )
-          | _ -> Atdgen_runtime.Ob_run.read_error_at ib
+let read__string_option_list = (
+  Atdgen_runtime.Ob_run.read_list (
+    get__string_option_reader
+  )
 )
-let read__5 = (
-  fun ib ->
-    if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
-    match Char.code (Bi_inbuf.read_char ib) with
-      | 0 -> None
-      | 0x80 ->
-        Some (
-          (
-            Atdgen_runtime.Ob_run.read_float64
-          )
-            ib
-        )
-      | _ -> Atdgen_runtime.Ob_run.read_error_at ib
-)
-let _5_of_string ?pos s =
-  read__5 (Bi_inbuf.from_string ?pos s)
-let _4_tag = Bi_io.num_variant_tag
-let write_untagged__4 = (
+let _string_option_list_of_string ?pos s =
+  read__string_option_list (Bi_inbuf.from_string ?pos s)
+let _int_option_tag = Bi_io.num_variant_tag
+let write_untagged__int_option = (
   Atdgen_runtime.Ob_run.write_untagged_option (
     Bi_io.write_svint
   )
 )
-let write__4 ob x =
+let write__int_option ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__4 ob x
-let string_of__4 ?(len = 1024) x =
+  write_untagged__int_option ob x
+let string_of__int_option ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__4 ob x;
+  write__int_option ob x;
   Bi_outbuf.contents ob
-let get__4_reader = (
+let get__int_option_reader = (
   fun tag ->
     if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -1375,7 +1341,7 @@ let get__4_reader = (
             )
           | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let read__4 = (
+let read__int_option = (
   fun ib ->
     if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
     match Char.code (Bi_inbuf.read_char ib) with
@@ -1389,62 +1355,96 @@ let read__4 = (
         )
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _4_of_string ?pos s =
-  read__4 (Bi_inbuf.from_string ?pos s)
-let _11_tag = Bi_io.array_tag
-let write_untagged__11 = (
-  Atdgen_runtime.Ob_run.write_untagged_list
-    _6_tag
-    (
-      write_untagged__6
-    )
+let _int_option_of_string ?pos s =
+  read__int_option (Bi_inbuf.from_string ?pos s)
+let _float_option_tag = Bi_io.num_variant_tag
+let write_untagged__float_option = (
+  Atdgen_runtime.Ob_run.write_untagged_option (
+    Bi_io.write_float64
+  )
 )
-let write__11 ob x =
-  Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__11 ob x
-let string_of__11 ?(len = 1024) x =
+let write__float_option ob x =
+  Bi_io.write_tag ob Bi_io.num_variant_tag;
+  write_untagged__float_option ob x
+let string_of__float_option ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__11 ob x;
+  write__float_option ob x;
   Bi_outbuf.contents ob
-let get__11_reader = (
-  Atdgen_runtime.Ob_run.get_list_reader (
-    get__6_reader
+let get__float_option_reader = (
+  fun tag ->
+    if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
+      fun ib ->
+        match Char.code (Bi_inbuf.read_char ib) with
+          | 0 -> None
+          | 0x80 ->
+            Some (
+              (
+                Atdgen_runtime.Ob_run.read_float64
+              )
+                ib
+            )
+          | _ -> Atdgen_runtime.Ob_run.read_error_at ib
+)
+let read__float_option = (
+  fun ib ->
+    if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
+    match Char.code (Bi_inbuf.read_char ib) with
+      | 0 -> None
+      | 0x80 ->
+        Some (
+          (
+            Atdgen_runtime.Ob_run.read_float64
+          )
+            ib
+        )
+      | _ -> Atdgen_runtime.Ob_run.read_error_at ib
+)
+let _float_option_of_string ?pos s =
+  read__float_option (Bi_inbuf.from_string ?pos s)
+let _bool_option_tag = Bi_io.num_variant_tag
+let write_untagged__bool_option = (
+  Atdgen_runtime.Ob_run.write_untagged_option (
+    Bi_io.write_bool
   )
 )
-let read__11 = (
-  Atdgen_runtime.Ob_run.read_list (
-    get__6_reader
-  )
-)
-let _11_of_string ?pos s =
-  read__11 (Bi_inbuf.from_string ?pos s)
-let _10_tag = Bi_io.array_tag
-let write_untagged__10 = (
-  Atdgen_runtime.Ob_run.write_untagged_list
-    Bi_io.unit_tag
-    (
-      Bi_io.write_untagged_unit
-    )
-)
-let write__10 ob x =
-  Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__10 ob x
-let string_of__10 ?(len = 1024) x =
+let write__bool_option ob x =
+  Bi_io.write_tag ob Bi_io.num_variant_tag;
+  write_untagged__bool_option ob x
+let string_of__bool_option ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__10 ob x;
+  write__bool_option ob x;
   Bi_outbuf.contents ob
-let get__10_reader = (
-  Atdgen_runtime.Ob_run.get_list_reader (
-    Atdgen_runtime.Ob_run.get_unit_reader
-  )
+let get__bool_option_reader = (
+  fun tag ->
+    if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
+      fun ib ->
+        match Char.code (Bi_inbuf.read_char ib) with
+          | 0 -> None
+          | 0x80 ->
+            Some (
+              (
+                Atdgen_runtime.Ob_run.read_bool
+              )
+                ib
+            )
+          | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let read__10 = (
-  Atdgen_runtime.Ob_run.read_list (
-    Atdgen_runtime.Ob_run.get_unit_reader
-  )
+let read__bool_option = (
+  fun ib ->
+    if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
+    match Char.code (Bi_inbuf.read_char ib) with
+      | 0 -> None
+      | 0x80 ->
+        Some (
+          (
+            Atdgen_runtime.Ob_run.read_bool
+          )
+            ib
+        )
+      | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _10_of_string ?pos s =
-  read__10 (Bi_inbuf.from_string ?pos s)
+let _bool_option_of_string ?pos s =
+  read__bool_option (Bi_inbuf.from_string ?pos s)
 let mixed_record_tag = Bi_io.record_tag
 let write_untagged_mixed_record : Bi_outbuf.t -> mixed_record -> unit = (
   fun ob x ->
@@ -1474,7 +1474,7 @@ let write_untagged_mixed_record : Bi_outbuf.t -> mixed_record -> unit = (
     );
     Bi_outbuf.add_char4 ob '\128' '\142' '\142' '8';
     (
-      write__6
+      write__string_option
     ) ob x.field2;
     Bi_outbuf.add_char4 ob '\128' '\142' '\142' '9';
     (
@@ -1482,7 +1482,7 @@ let write_untagged_mixed_record : Bi_outbuf.t -> mixed_record -> unit = (
     ) ob x.field3;
     Bi_outbuf.add_char4 ob '\128' '\142' '\142' ':';
     (
-      write__7
+      write__x_adbef7e
     ) ob x.field4;
     (match x_field5 with None -> () | Some x ->
       Bi_outbuf.add_char4 ob '\128' '\142' '\142' ';';
@@ -1502,7 +1502,7 @@ let write_untagged_mixed_record : Bi_outbuf.t -> mixed_record -> unit = (
     ) ob x.field7;
     Bi_outbuf.add_char4 ob '\128' '\142' '\142' '>';
     (
-      write__9
+      write__x_20d39e2
     ) ob x.field8;
     Bi_outbuf.add_char4 ob '\128' '\142' '\142' '?';
     (
@@ -1552,11 +1552,11 @@ let write_untagged_mixed_record : Bi_outbuf.t -> mixed_record -> unit = (
     );
     Bi_outbuf.add_char4 ob '\252' '-' '\226' '\027';
     (
-      write__10
+      write__unit_list
     ) ob x.field12;
     Bi_outbuf.add_char4 ob '\252' '-' '\226' '\028';
     (
-      write__11
+      write__string_option_list
     ) ob x.field13;
     Bi_outbuf.add_char4 ob '\252' '-' '\226' '\029';
     (
@@ -1612,7 +1612,7 @@ let get_mixed_record_reader = (
             | 9342520 ->
               field_field2 := (
                 (
-                  read__6
+                  read__string_option
                 ) ib
               );
               bits0 := !bits0 lor 0x1;
@@ -1626,7 +1626,7 @@ let get_mixed_record_reader = (
             | 9342522 ->
               field_field4 := (
                 (
-                  read__7
+                  read__x_adbef7e
                 ) ib
               );
               bits0 := !bits0 lor 0x4;
@@ -1656,7 +1656,7 @@ let get_mixed_record_reader = (
             | 9342526 ->
               field_field8 := (
                 (
-                  read__9
+                  read__x_20d39e2
                 ) ib
               );
               bits0 := !bits0 lor 0x10;
@@ -1718,14 +1718,14 @@ let get_mixed_record_reader = (
             | -64101861 ->
               field_field12 := (
                 (
-                  read__10
+                  read__unit_list
                 ) ib
               );
               bits0 := !bits0 lor 0x80;
             | -64101860 ->
               field_field13 := (
                 (
-                  read__11
+                  read__string_option_list
                 ) ib
               );
               bits0 := !bits0 lor 0x100;
@@ -1800,7 +1800,7 @@ let read_mixed_record = (
         | 9342520 ->
           field_field2 := (
             (
-              read__6
+              read__string_option
             ) ib
           );
           bits0 := !bits0 lor 0x1;
@@ -1814,7 +1814,7 @@ let read_mixed_record = (
         | 9342522 ->
           field_field4 := (
             (
-              read__7
+              read__x_adbef7e
             ) ib
           );
           bits0 := !bits0 lor 0x4;
@@ -1844,7 +1844,7 @@ let read_mixed_record = (
         | 9342526 ->
           field_field8 := (
             (
-              read__9
+              read__x_20d39e2
             ) ib
           );
           bits0 := !bits0 lor 0x10;
@@ -1906,14 +1906,14 @@ let read_mixed_record = (
         | -64101861 ->
           field_field12 := (
             (
-              read__10
+              read__unit_list
             ) ib
           );
           bits0 := !bits0 lor 0x80;
         | -64101860 ->
           field_field13 := (
             (
-              read__11
+              read__string_option_list
             ) ib
           );
           bits0 := !bits0 lor 0x100;
@@ -1949,58 +1949,31 @@ let read_mixed_record = (
 )
 let mixed_record_of_string ?pos s =
   read_mixed_record (Bi_inbuf.from_string ?pos s)
-let _13_tag = Bi_io.array_tag
-let write_untagged__13 = (
-  Atdgen_runtime.Ob_run.write_untagged_array
-    mixed_record_tag
-    (
-      write_untagged_mixed_record
-    )
-)
-let write__13 ob x =
-  Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__13 ob x
-let string_of__13 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__13 ob x;
-  Bi_outbuf.contents ob
-let get__13_reader = (
-  Atdgen_runtime.Ob_run.get_array_reader (
-    get_mixed_record_reader
-  )
-)
-let read__13 = (
-  Atdgen_runtime.Ob_run.read_array (
-    get_mixed_record_reader
-  )
-)
-let _13_of_string ?pos s =
-  read__13 (Bi_inbuf.from_string ?pos s)
-let _12_tag = Bi_io.table_tag
-let write_untagged__12 = (
+let _x_d88f1c8_tag = Bi_io.table_tag
+let write_untagged__x_d88f1c8 = (
   fun ob x ->
     let len = Array.length x in
     Bi_vint.write_uvint ob len;
     if len > 0 then (
       Bi_vint.write_uvint ob 15;
       Bi_io.write_hashtag ob (9342518) true;
-      Bi_io.write_tag ob _4_tag;
+      Bi_io.write_tag ob _int_option_tag;
       Bi_io.write_hashtag ob (9342519) true;
-      Bi_io.write_tag ob _5_tag;
+      Bi_io.write_tag ob _float_option_tag;
       Bi_io.write_hashtag ob (9342520) true;
-      Bi_io.write_tag ob _6_tag;
+      Bi_io.write_tag ob _string_option_tag;
       Bi_io.write_hashtag ob (9342521) true;
       Bi_io.write_tag ob Bi_io.int64_tag;
       Bi_io.write_hashtag ob (9342522) true;
-      Bi_io.write_tag ob _7_tag;
+      Bi_io.write_tag ob _x_adbef7e_tag;
       Bi_io.write_hashtag ob (9342523) true;
-      Bi_io.write_tag ob _8_tag;
+      Bi_io.write_tag ob _bool_option_tag;
       Bi_io.write_hashtag ob (9342524) true;
-      Bi_io.write_tag ob _6_tag;
+      Bi_io.write_tag ob _string_option_tag;
       Bi_io.write_hashtag ob (9342525) true;
       Bi_io.write_tag ob test_variant_tag;
       Bi_io.write_hashtag ob (9342526) true;
-      Bi_io.write_tag ob _9_tag;
+      Bi_io.write_tag ob _x_20d39e2_tag;
       Bi_io.write_hashtag ob (9342527) true;
       Bi_io.write_tag ob Bi_io.tuple_tag;
       Bi_io.write_hashtag ob (-64101863) true;
@@ -2008,22 +1981,22 @@ let write_untagged__12 = (
       Bi_io.write_hashtag ob (-64101862) true;
       Bi_io.write_tag ob Bi_io.bool_tag;
       Bi_io.write_hashtag ob (-64101861) true;
-      Bi_io.write_tag ob _10_tag;
+      Bi_io.write_tag ob _unit_list_tag;
       Bi_io.write_hashtag ob (-64101860) true;
-      Bi_io.write_tag ob _11_tag;
+      Bi_io.write_tag ob _string_option_list_tag;
       Bi_io.write_hashtag ob (-64101859) true;
       Bi_io.write_tag ob date_tag;
       Atdgen_runtime.Ob_run.array_iter2 (fun ob x ->
         (
-          write_untagged__4
+          write_untagged__int_option
         )
           ob x.field0;
         (
-          write_untagged__5
+          write_untagged__float_option
         )
           ob x.field1;
         (
-          write_untagged__6
+          write_untagged__string_option
         )
           ob x.field2;
         (
@@ -2031,15 +2004,15 @@ let write_untagged__12 = (
         )
           ob x.field3;
         (
-          write_untagged__7
+          write_untagged__x_adbef7e
         )
           ob x.field4;
         (
-          write_untagged__8
+          write_untagged__bool_option
         )
           ob x.field5;
         (
-          write_untagged__6
+          write_untagged__string_option
         )
           ob x.field6;
         (
@@ -2047,7 +2020,7 @@ let write_untagged__12 = (
         )
           ob x.field7;
         (
-          write_untagged__9
+          write_untagged__x_20d39e2
         )
           ob x.field8;
         (
@@ -2094,11 +2067,11 @@ let write_untagged__12 = (
         )
           ob x.field11;
         (
-          write_untagged__10
+          write_untagged__unit_list
         )
           ob x.field12;
         (
-          write_untagged__11
+          write_untagged__string_option_list
         )
           ob x.field13;
         (
@@ -2108,14 +2081,14 @@ let write_untagged__12 = (
       ) ob x;
     );
 )
-let write__12 ob x =
+let write__x_d88f1c8 ob x =
   Bi_io.write_tag ob Bi_io.table_tag;
-  write_untagged__12 ob x
-let string_of__12 ?(len = 1024) x =
+  write_untagged__x_d88f1c8 ob x
+let string_of__x_d88f1c8 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__12 ob x;
+  write__x_d88f1c8 ob x;
   Bi_outbuf.contents ob
-let get__12_reader = (
+let get__x_d88f1c8_reader = (
   function
     | 25 -> 
       (fun ib ->
@@ -2148,7 +2121,7 @@ let get__12_reader = (
                   | 9342518 ->
                     let read =
                       (
-                        get__4_reader
+                        get__int_option_reader
                       )
                         tag
                     in
@@ -2156,7 +2129,7 @@ let get__12_reader = (
                   | 9342519 ->
                     let read =
                       (
-                        get__5_reader
+                        get__float_option_reader
                       )
                         tag
                     in
@@ -2165,7 +2138,7 @@ let get__12_reader = (
                     bits0 := !bits0 lor 0x1;
                     let read =
                       (
-                        get__6_reader
+                        get__string_option_reader
                       )
                         tag
                     in
@@ -2183,7 +2156,7 @@ let get__12_reader = (
                     bits0 := !bits0 lor 0x4;
                     let read =
                       (
-                        get__7_reader
+                        get__x_adbef7e_reader
                       )
                         tag
                     in
@@ -2191,7 +2164,7 @@ let get__12_reader = (
                   | 9342523 ->
                     let read =
                       (
-                        get__8_reader
+                        get__bool_option_reader
                       )
                         tag
                     in
@@ -2199,7 +2172,7 @@ let get__12_reader = (
                   | 9342524 ->
                     let read =
                       (
-                        get__6_reader
+                        get__string_option_reader
                       )
                         tag
                     in
@@ -2217,7 +2190,7 @@ let get__12_reader = (
                     bits0 := !bits0 lor 0x10;
                     let read =
                       (
-                        get__9_reader
+                        get__x_20d39e2_reader
                       )
                         tag
                     in
@@ -2288,7 +2261,7 @@ let get__12_reader = (
                     bits0 := !bits0 lor 0x80;
                     let read =
                       (
-                        get__10_reader
+                        get__unit_list_reader
                       )
                         tag
                     in
@@ -2297,7 +2270,7 @@ let get__12_reader = (
                     bits0 := !bits0 lor 0x100;
                     let read =
                       (
-                        get__11_reader
+                        get__string_option_list_reader
                       )
                         tag
                     in
@@ -2349,7 +2322,7 @@ let get__12_reader = (
       )
     | _ -> Atdgen_runtime.Ob_run.read_error ()
 )
-let read__12 = (
+let read__x_d88f1c8 = (
   fun ib ->
     match Bi_io.read_tag ib with
       | 25 -> 
@@ -2382,7 +2355,7 @@ let read__12 = (
                   | 9342518 ->
                     let read =
                       (
-                        get__4_reader
+                        get__int_option_reader
                       )
                         tag
                     in
@@ -2390,7 +2363,7 @@ let read__12 = (
                   | 9342519 ->
                     let read =
                       (
-                        get__5_reader
+                        get__float_option_reader
                       )
                         tag
                     in
@@ -2399,7 +2372,7 @@ let read__12 = (
                     bits0 := !bits0 lor 0x1;
                     let read =
                       (
-                        get__6_reader
+                        get__string_option_reader
                       )
                         tag
                     in
@@ -2417,7 +2390,7 @@ let read__12 = (
                     bits0 := !bits0 lor 0x4;
                     let read =
                       (
-                        get__7_reader
+                        get__x_adbef7e_reader
                       )
                         tag
                     in
@@ -2425,7 +2398,7 @@ let read__12 = (
                   | 9342523 ->
                     let read =
                       (
-                        get__8_reader
+                        get__bool_option_reader
                       )
                         tag
                     in
@@ -2433,7 +2406,7 @@ let read__12 = (
                   | 9342524 ->
                     let read =
                       (
-                        get__6_reader
+                        get__string_option_reader
                       )
                         tag
                     in
@@ -2451,7 +2424,7 @@ let read__12 = (
                     bits0 := !bits0 lor 0x10;
                     let read =
                       (
-                        get__9_reader
+                        get__x_20d39e2_reader
                       )
                         tag
                     in
@@ -2522,7 +2495,7 @@ let read__12 = (
                     bits0 := !bits0 lor 0x80;
                     let read =
                       (
-                        get__10_reader
+                        get__unit_list_reader
                       )
                         tag
                     in
@@ -2531,7 +2504,7 @@ let read__12 = (
                     bits0 := !bits0 lor 0x100;
                     let read =
                       (
-                        get__11_reader
+                        get__string_option_list_reader
                       )
                         tag
                     in
@@ -2580,10 +2553,37 @@ let read__12 = (
         ) ib
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _12_of_string ?pos s =
-  read__12 (Bi_inbuf.from_string ?pos s)
-let _14_tag = Bi_io.array_tag
-let write_untagged__14 = (
+let _x_d88f1c8_of_string ?pos s =
+  read__x_d88f1c8 (Bi_inbuf.from_string ?pos s)
+let _x_7de077c_tag = Bi_io.array_tag
+let write_untagged__x_7de077c = (
+  Atdgen_runtime.Ob_run.write_untagged_array
+    mixed_record_tag
+    (
+      write_untagged_mixed_record
+    )
+)
+let write__x_7de077c ob x =
+  Bi_io.write_tag ob Bi_io.array_tag;
+  write_untagged__x_7de077c ob x
+let string_of__x_7de077c ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__x_7de077c ob x;
+  Bi_outbuf.contents ob
+let get__x_7de077c_reader = (
+  Atdgen_runtime.Ob_run.get_array_reader (
+    get_mixed_record_reader
+  )
+)
+let read__x_7de077c = (
+  Atdgen_runtime.Ob_run.read_array (
+    get_mixed_record_reader
+  )
+)
+let _x_7de077c_of_string ?pos s =
+  read__x_7de077c (Bi_inbuf.from_string ?pos s)
+let _x_c393fa9_tag = Bi_io.array_tag
+let write_untagged__x_c393fa9 = (
   Atdgen_runtime.Ob_run.write_untagged_list
     Bi_io.tuple_tag
     (
@@ -2591,24 +2591,24 @@ let write_untagged__14 = (
         Bi_vint.write_uvint ob 2;
         (
           let x, _ = x in (
-            write__12
+            write__x_d88f1c8
           ) ob x
         );
         (
           let _, x = x in (
-            write__13
+            write__x_7de077c
           ) ob x
         );
     )
 )
-let write__14 ob x =
+let write__x_c393fa9 ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__14 ob x
-let string_of__14 ?(len = 1024) x =
+  write_untagged__x_c393fa9 ob x
+let string_of__x_c393fa9 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__14 ob x;
+  write__x_c393fa9 ob x;
   Bi_outbuf.contents ob
-let get__14_reader = (
+let get__x_c393fa9_reader = (
   Atdgen_runtime.Ob_run.get_list_reader (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -2617,19 +2617,19 @@ let get__14_reader = (
           if len < 2 then Atdgen_runtime.Ob_run.missing_tuple_fields len [ 0; 1 ];
           let x0 =
             (
-              read__12
+              read__x_d88f1c8
             ) ib
           in
           let x1 =
             (
-              read__13
+              read__x_7de077c
             ) ib
           in
           for i = 2 to len - 1 do Bi_io.skip ib done;
           (x0, x1)
   )
 )
-let read__14 = (
+let read__x_c393fa9 = (
   Atdgen_runtime.Ob_run.read_list (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -2638,23 +2638,23 @@ let read__14 = (
           if len < 2 then Atdgen_runtime.Ob_run.missing_tuple_fields len [ 0; 1 ];
           let x0 =
             (
-              read__12
+              read__x_d88f1c8
             ) ib
           in
           let x1 =
             (
-              read__13
+              read__x_7de077c
             ) ib
           in
           for i = 2 to len - 1 do Bi_io.skip ib done;
           (x0, x1)
   )
 )
-let _14_of_string ?pos s =
-  read__14 (Bi_inbuf.from_string ?pos s)
+let _x_c393fa9_of_string ?pos s =
+  read__x_c393fa9 (Bi_inbuf.from_string ?pos s)
 let mixed_tag = Bi_io.array_tag
 let write_untagged_mixed = (
-  write_untagged__14
+  write_untagged__x_c393fa9
 )
 let write_mixed ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -2664,40 +2664,40 @@ let string_of_mixed ?(len = 1024) x =
   write_mixed ob x;
   Bi_outbuf.contents ob
 let get_mixed_reader = (
-  get__14_reader
+  get__x_c393fa9_reader
 )
 let read_mixed = (
-  read__14
+  read__x_c393fa9
 )
 let mixed_of_string ?pos s =
   read_mixed (Bi_inbuf.from_string ?pos s)
-let _15_tag = Bi_io.array_tag
-let write_untagged__15 = (
+let _mixed_record_list_tag = Bi_io.array_tag
+let write_untagged__mixed_record_list = (
   Atdgen_runtime.Ob_run.write_untagged_list
     mixed_record_tag
     (
       write_untagged_mixed_record
     )
 )
-let write__15 ob x =
+let write__mixed_record_list ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__15 ob x
-let string_of__15 ?(len = 1024) x =
+  write_untagged__mixed_record_list ob x
+let string_of__mixed_record_list ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__15 ob x;
+  write__mixed_record_list ob x;
   Bi_outbuf.contents ob
-let get__15_reader = (
+let get__mixed_record_list_reader = (
   Atdgen_runtime.Ob_run.get_list_reader (
     get_mixed_record_reader
   )
 )
-let read__15 = (
+let read__mixed_record_list = (
   Atdgen_runtime.Ob_run.read_list (
     get_mixed_record_reader
   )
 )
-let _15_of_string ?pos s =
-  read__15 (Bi_inbuf.from_string ?pos s)
+let _mixed_record_list_of_string ?pos s =
+  read__mixed_record_list (Bi_inbuf.from_string ?pos s)
 let test_tag = Bi_io.record_tag
 let write_untagged_test : Bi_outbuf.t -> test -> unit = (
   fun ob x ->
@@ -2725,7 +2725,7 @@ let write_untagged_test : Bi_outbuf.t -> test -> unit = (
     ) ob x.x2;
     Bi_outbuf.add_char4 ob '\128' '\000' 'h' '\187';
     (
-      write__15
+      write__mixed_record_list
     ) ob x.x3;
     Bi_outbuf.add_char4 ob '\128' '\000' 'h' '\188';
     (
@@ -2778,7 +2778,7 @@ let get_test_reader = (
             | 26811 ->
               field_x3 := (
                 (
-                  read__15
+                  read__mixed_record_list
                 ) ib
               );
               bits0 := !bits0 lor 0x2;
@@ -2840,7 +2840,7 @@ let read_test = (
         | 26811 ->
           field_x3 := (
             (
-              read__15
+              read__mixed_record_list
             ) ib
           );
           bits0 := !bits0 lor 0x2;
@@ -3035,8 +3035,8 @@ let read_star_rating = (
 )
 let star_rating_of_string ?pos s =
   read_star_rating (Bi_inbuf.from_string ?pos s)
-let _30_tag = Bi_io.record_tag
-let write_untagged__30 : Bi_outbuf.t -> _ generic -> unit = (
+let _string_generic_tag = Bi_io.record_tag
+let write_untagged__string_generic : Bi_outbuf.t -> _ generic -> unit = (
   fun ob x ->
     Bi_vint.write_uvint ob 1;
     Bi_outbuf.add_char4 ob '\240' 'G' '\003' '\130';
@@ -3044,14 +3044,14 @@ let write_untagged__30 : Bi_outbuf.t -> _ generic -> unit = (
       Bi_io.write_svint
     ) ob x.x294623;
 )
-let write__30 ob x =
+let write__string_generic ob x =
   Bi_io.write_tag ob Bi_io.record_tag;
-  write_untagged__30 ob x
-let string_of__30 ?(len = 1024) x =
+  write_untagged__string_generic ob x
+let string_of__string_generic ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__30 ob x;
+  write__string_generic ob x;
   Bi_outbuf.contents ob
-let get__30_reader = (
+let get__string_generic_reader = (
   fun tag ->
     if tag <> 21 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -3076,7 +3076,7 @@ let get__30_reader = (
           }
          : _ generic)
 )
-let read__30 = (
+let read__string_generic = (
   fun ib ->
     if Bi_io.read_tag ib <> 21 then Atdgen_runtime.Ob_run.read_error_at ib;
     let field_x294623 = ref (Obj.magic (Sys.opaque_identity 0.0)) in
@@ -3100,11 +3100,11 @@ let read__30 = (
       }
      : _ generic)
 )
-let _30_of_string ?pos s =
-  read__30 (Bi_inbuf.from_string ?pos s)
+let _string_generic_of_string ?pos s =
+  read__string_generic (Bi_inbuf.from_string ?pos s)
 let specialized_tag = Bi_io.record_tag
 let write_untagged_specialized = (
-  write_untagged__30
+  write_untagged__string_generic
 )
 let write_specialized ob x =
   Bi_io.write_tag ob Bi_io.record_tag;
@@ -3114,10 +3114,10 @@ let string_of_specialized ?(len = 1024) x =
   write_specialized ob x;
   Bi_outbuf.contents ob
 let get_specialized_reader = (
-  get__30_reader
+  get__string_generic_reader
 )
 let read_specialized = (
-  read__30
+  read__string_generic
 )
 let specialized_of_string ?pos s =
   read_specialized (Bi_inbuf.from_string ?pos s)
@@ -3301,7 +3301,7 @@ let precision_of_string ?pos s =
   read_precision (Bi_inbuf.from_string ?pos s)
 let p''_tag = Bi_io.variant_tag
 let write_untagged_p'' = (
-  write_untagged__1
+  write_untagged__int_p
 )
 let write_p'' ob x =
   Bi_io.write_tag ob Bi_io.variant_tag;
@@ -3311,27 +3311,27 @@ let string_of_p'' ?(len = 1024) x =
   write_p'' ob x;
   Bi_outbuf.contents ob
 let get_p''_reader = (
-  get__1_reader
+  get__int_p_reader
 )
 let read_p'' = (
-  read__1
+  read__int_p
 )
 let p''_of_string ?pos s =
   read_p'' (Bi_inbuf.from_string ?pos s)
-let _18_tag = Bi_io.num_variant_tag
-let write_untagged__18 = (
+let _x_bee1b88_tag = Bi_io.num_variant_tag
+let write_untagged__x_bee1b88 = (
   Atdgen_runtime.Ob_run.write_untagged_option (
     Bi_io.write_svint
   )
 )
-let write__18 ob x =
+let write__x_bee1b88 ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__18 ob x
-let string_of__18 ?(len = 1024) x =
+  write_untagged__x_bee1b88 ob x
+let string_of__x_bee1b88 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__18 ob x;
+  write__x_bee1b88 ob x;
   Bi_outbuf.contents ob
-let get__18_reader = (
+let get__x_bee1b88_reader = (
   fun tag ->
     if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -3346,7 +3346,7 @@ let get__18_reader = (
             )
           | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let read__18 = (
+let read__x_bee1b88 = (
   fun ib ->
     if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
     match Char.code (Bi_inbuf.read_char ib) with
@@ -3360,11 +3360,11 @@ let read__18 = (
         )
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _18_of_string ?pos s =
-  read__18 (Bi_inbuf.from_string ?pos s)
+let _x_bee1b88_of_string ?pos s =
+  read__x_bee1b88 (Bi_inbuf.from_string ?pos s)
 let option_validation_tag = Bi_io.num_variant_tag
 let write_untagged_option_validation = (
-  write_untagged__18
+  write_untagged__x_bee1b88
 )
 let write_option_validation ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
@@ -3374,35 +3374,35 @@ let string_of_option_validation ?(len = 1024) x =
   write_option_validation ob x;
   Bi_outbuf.contents ob
 let get_option_validation_reader = (
-  get__18_reader
+  get__x_bee1b88_reader
 )
 let read_option_validation = (
-  read__18
+  read__x_bee1b88
 )
 let option_validation_of_string ?pos s =
   read_option_validation (Bi_inbuf.from_string ?pos s)
-let _28_tag = some_record_tag
-let write_untagged__28 = (
+let _some_record_wrap_tag = some_record_tag
+let write_untagged__some_record_wrap = (
   write_untagged_some_record
 )
-let write__28 ob x =
+let write__some_record_wrap ob x =
   Bi_io.write_tag ob some_record_tag;
-  write_untagged__28 ob x
-let string_of__28 ?(len = 1024) x =
+  write_untagged__some_record_wrap ob x
+let string_of__some_record_wrap ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__28 ob x;
+  write__some_record_wrap ob x;
   Bi_outbuf.contents ob
-let get__28_reader = (
+let get__some_record_wrap_reader = (
   get_some_record_reader
 )
-let read__28 = (
+let read__some_record_wrap = (
   read_some_record
 )
-let _28_of_string ?pos s =
-  read__28 (Bi_inbuf.from_string ?pos s)
+let _some_record_wrap_of_string ?pos s =
+  read__some_record_wrap (Bi_inbuf.from_string ?pos s)
 let no_real_wrap_tag = some_record_tag
 let write_untagged_no_real_wrap = (
-  write_untagged__28
+  write_untagged__some_record_wrap
 )
 let write_no_real_wrap ob x =
   Bi_io.write_tag ob some_record_tag;
@@ -3412,44 +3412,44 @@ let string_of_no_real_wrap ?(len = 1024) x =
   write_no_real_wrap ob x;
   Bi_outbuf.contents ob
 let get_no_real_wrap_reader = (
-  get__28_reader
+  get__some_record_wrap_reader
 )
 let read_no_real_wrap = (
-  read__28
+  read__some_record_wrap
 )
 let no_real_wrap_of_string ?pos s =
   read_no_real_wrap (Bi_inbuf.from_string ?pos s)
-let _26_tag = Bi_io.svint_tag
-let write_untagged__26 = (
+let _x_e48509c_tag = Bi_io.svint_tag
+let write_untagged__x_e48509c = (
   fun ob x -> (
     let x = ( Test_lib.Natural.unwrap ) x in (
       Bi_io.write_untagged_svint
     ) ob x)
 )
-let write__26 ob x =
+let write__x_e48509c ob x =
   Bi_io.write_tag ob Bi_io.svint_tag;
-  write_untagged__26 ob x
-let string_of__26 ?(len = 1024) x =
+  write_untagged__x_e48509c ob x
+let string_of__x_e48509c ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__26 ob x;
+  write__x_e48509c ob x;
   Bi_outbuf.contents ob
-let get__26_reader = (
+let get__x_e48509c_reader = (
   fun tag ib ->
     ( Test_lib.Natural.wrap ) ((
       Atdgen_runtime.Ob_run.get_int_reader
     ) tag ib)
 )
-let read__26 = (
+let read__x_e48509c = (
   fun ib ->
     ( Test_lib.Natural.wrap ) ((
       Atdgen_runtime.Ob_run.read_int
     ) ib)
 )
-let _26_of_string ?pos s =
-  read__26 (Bi_inbuf.from_string ?pos s)
+let _x_e48509c_of_string ?pos s =
+  read__x_e48509c (Bi_inbuf.from_string ?pos s)
 let natural_tag = Bi_io.svint_tag
 let write_untagged_natural = (
-  write_untagged__26
+  write_untagged__x_e48509c
 )
 let write_natural ob x =
   Bi_io.write_tag ob Bi_io.svint_tag;
@@ -3459,44 +3459,44 @@ let string_of_natural ?(len = 1024) x =
   write_natural ob x;
   Bi_outbuf.contents ob
 let get_natural_reader = (
-  get__26_reader
+  get__x_e48509c_reader
 )
 let read_natural = (
-  read__26
+  read__x_e48509c
 )
 let natural_of_string ?pos s =
   read_natural (Bi_inbuf.from_string ?pos s)
-let _24_tag = Bi_io.string_tag
-let write_untagged__24 = (
+let _x_2596d76_tag = Bi_io.string_tag
+let write_untagged__x_2596d76 = (
   fun ob x -> (
     let x = ( function `Id s -> s ) x in (
       Bi_io.write_untagged_string
     ) ob x)
 )
-let write__24 ob x =
+let write__x_2596d76 ob x =
   Bi_io.write_tag ob Bi_io.string_tag;
-  write_untagged__24 ob x
-let string_of__24 ?(len = 1024) x =
+  write_untagged__x_2596d76 ob x
+let string_of__x_2596d76 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__24 ob x;
+  write__x_2596d76 ob x;
   Bi_outbuf.contents ob
-let get__24_reader = (
+let get__x_2596d76_reader = (
   fun tag ib ->
     ( fun s -> `Id s ) ((
       Atdgen_runtime.Ob_run.get_string_reader
     ) tag ib)
 )
-let read__24 = (
+let read__x_2596d76 = (
   fun ib ->
     ( fun s -> `Id s ) ((
       Atdgen_runtime.Ob_run.read_string
     ) ib)
 )
-let _24_of_string ?pos s =
-  read__24 (Bi_inbuf.from_string ?pos s)
+let _x_2596d76_of_string ?pos s =
+  read__x_2596d76 (Bi_inbuf.from_string ?pos s)
 let id_tag = Bi_io.string_tag
 let write_untagged_id = (
-  write_untagged__24
+  write_untagged__x_2596d76
 )
 let write_id ob x =
   Bi_io.write_tag ob Bi_io.string_tag;
@@ -3506,15 +3506,15 @@ let string_of_id ?(len = 1024) x =
   write_id ob x;
   Bi_outbuf.contents ob
 let get_id_reader = (
-  get__24_reader
+  get__x_2596d76_reader
 )
 let read_id = (
-  read__24
+  read__x_2596d76
 )
 let id_of_string ?pos s =
   read_id (Bi_inbuf.from_string ?pos s)
-let _25_tag = Bi_io.array_tag
-let write_untagged__25 = (
+let _x_b6e4b4c_tag = Bi_io.array_tag
+let write_untagged__x_b6e4b4c = (
   Atdgen_runtime.Ob_run.write_untagged_list
     Bi_io.tuple_tag
     (
@@ -3532,14 +3532,14 @@ let write_untagged__25 = (
         );
     )
 )
-let write__25 ob x =
+let write__x_b6e4b4c ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__25 ob x
-let string_of__25 ?(len = 1024) x =
+  write_untagged__x_b6e4b4c ob x
+let string_of__x_b6e4b4c ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__25 ob x;
+  write__x_b6e4b4c ob x;
   Bi_outbuf.contents ob
-let get__25_reader = (
+let get__x_b6e4b4c_reader = (
   Atdgen_runtime.Ob_run.get_list_reader (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -3560,7 +3560,7 @@ let get__25_reader = (
           (x0, x1)
   )
 )
-let read__25 = (
+let read__x_b6e4b4c = (
   Atdgen_runtime.Ob_run.read_list (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -3581,11 +3581,11 @@ let read__25 = (
           (x0, x1)
   )
 )
-let _25_of_string ?pos s =
-  read__25 (Bi_inbuf.from_string ?pos s)
+let _x_b6e4b4c_of_string ?pos s =
+  read__x_b6e4b4c (Bi_inbuf.from_string ?pos s)
 let json_map_tag = Bi_io.array_tag
 let write_untagged_json_map = (
-  write_untagged__25
+  write_untagged__x_b6e4b4c
 )
 let write_json_map ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -3595,16 +3595,16 @@ let string_of_json_map ?(len = 1024) x =
   write_json_map ob x;
   Bi_outbuf.contents ob
 let get_json_map_reader = (
-  get__25_reader
+  get__x_b6e4b4c_reader
 )
 let read_json_map = (
-  read__25
+  read__x_b6e4b4c
 )
 let json_map_of_string ?pos s =
   read_json_map (Bi_inbuf.from_string ?pos s)
 let intopt_tag = Bi_io.num_variant_tag
 let write_untagged_intopt = (
-  write_untagged__4
+  write_untagged__int_option
 )
 let write_intopt ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
@@ -3614,15 +3614,15 @@ let string_of_intopt ?(len = 1024) x =
   write_intopt ob x;
   Bi_outbuf.contents ob
 let get_intopt_reader = (
-  get__4_reader
+  get__int_option_reader
 )
 let read_intopt = (
-  read__4
+  read__int_option
 )
 let intopt_of_string ?pos s =
   read_intopt (Bi_inbuf.from_string ?pos s)
-let _21_tag = Bi_io.array_tag
-let write_untagged__21 = (
+let _x_547263f_tag = Bi_io.array_tag
+let write_untagged__x_547263f = (
   Atdgen_runtime.Ob_run.write_untagged_list
     Bi_io.tuple_tag
     (
@@ -3640,14 +3640,14 @@ let write_untagged__21 = (
         );
     )
 )
-let write__21 ob x =
+let write__x_547263f ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__21 ob x
-let string_of__21 ?(len = 1024) x =
+  write_untagged__x_547263f ob x
+let string_of__x_547263f ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__21 ob x;
+  write__x_547263f ob x;
   Bi_outbuf.contents ob
-let get__21_reader = (
+let get__x_547263f_reader = (
   Atdgen_runtime.Ob_run.get_list_reader (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -3668,7 +3668,7 @@ let get__21_reader = (
           (x0, x1)
   )
 )
-let read__21 = (
+let read__x_547263f = (
   Atdgen_runtime.Ob_run.read_list (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -3689,11 +3689,11 @@ let read__21 = (
           (x0, x1)
   )
 )
-let _21_of_string ?pos s =
-  read__21 (Bi_inbuf.from_string ?pos s)
+let _x_547263f_of_string ?pos s =
+  read__x_547263f (Bi_inbuf.from_string ?pos s)
 let int_assoc_list_tag = Bi_io.array_tag
 let write_untagged_int_assoc_list = (
-  write_untagged__21
+  write_untagged__x_547263f
 )
 let write_int_assoc_list ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -3703,15 +3703,15 @@ let string_of_int_assoc_list ?(len = 1024) x =
   write_int_assoc_list ob x;
   Bi_outbuf.contents ob
 let get_int_assoc_list_reader = (
-  get__21_reader
+  get__x_547263f_reader
 )
 let read_int_assoc_list = (
-  read__21
+  read__x_547263f
 )
 let int_assoc_list_of_string ?pos s =
   read_int_assoc_list (Bi_inbuf.from_string ?pos s)
-let _22_tag = Bi_io.array_tag
-let write_untagged__22 = (
+let _x_0a94e5e_tag = Bi_io.array_tag
+let write_untagged__x_0a94e5e = (
   Atdgen_runtime.Ob_run.write_untagged_array
     Bi_io.tuple_tag
     (
@@ -3729,14 +3729,14 @@ let write_untagged__22 = (
         );
     )
 )
-let write__22 ob x =
+let write__x_0a94e5e ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__22 ob x
-let string_of__22 ?(len = 1024) x =
+  write_untagged__x_0a94e5e ob x
+let string_of__x_0a94e5e ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__22 ob x;
+  write__x_0a94e5e ob x;
   Bi_outbuf.contents ob
-let get__22_reader = (
+let get__x_0a94e5e_reader = (
   Atdgen_runtime.Ob_run.get_array_reader (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -3757,7 +3757,7 @@ let get__22_reader = (
           (x0, x1)
   )
 )
-let read__22 = (
+let read__x_0a94e5e = (
   Atdgen_runtime.Ob_run.read_array (
     fun tag ->
       if tag <> 20 then Atdgen_runtime.Ob_run.read_error () else
@@ -3778,11 +3778,11 @@ let read__22 = (
           (x0, x1)
   )
 )
-let _22_of_string ?pos s =
-  read__22 (Bi_inbuf.from_string ?pos s)
+let _x_0a94e5e_of_string ?pos s =
+  read__x_0a94e5e (Bi_inbuf.from_string ?pos s)
 let int_assoc_array_tag = Bi_io.array_tag
 let write_untagged_int_assoc_array = (
-  write_untagged__22
+  write_untagged__x_0a94e5e
 )
 let write_int_assoc_array ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -3792,10 +3792,10 @@ let string_of_int_assoc_array ?(len = 1024) x =
   write_int_assoc_array ob x;
   Bi_outbuf.contents ob
 let get_int_assoc_array_reader = (
-  get__22_reader
+  get__x_0a94e5e_reader
 )
 let read_int_assoc_array = (
-  read__22
+  read__x_0a94e5e
 )
 let int_assoc_array_of_string ?pos s =
   read_int_assoc_array (Bi_inbuf.from_string ?pos s)
@@ -4061,33 +4061,33 @@ let read_floats = (
 )
 let floats_of_string ?pos s =
   read_floats (Bi_inbuf.from_string ?pos s)
-let _17_tag = Bi_io.array_tag
-let write_untagged__17 = (
+let _string_list_tag = Bi_io.array_tag
+let write_untagged__string_list = (
   Atdgen_runtime.Ob_run.write_untagged_list
     Bi_io.string_tag
     (
       Bi_io.write_untagged_string
     )
 )
-let write__17 ob x =
+let write__string_list ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__17 ob x
-let string_of__17 ?(len = 1024) x =
+  write_untagged__string_list ob x
+let string_of__string_list ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__17 ob x;
+  write__string_list ob x;
   Bi_outbuf.contents ob
-let get__17_reader = (
+let get__string_list_reader = (
   Atdgen_runtime.Ob_run.get_list_reader (
     Atdgen_runtime.Ob_run.get_string_reader
   )
 )
-let read__17 = (
+let read__string_list = (
   Atdgen_runtime.Ob_run.read_list (
     Atdgen_runtime.Ob_run.get_string_reader
   )
 )
-let _17_of_string ?pos s =
-  read__17 (Bi_inbuf.from_string ?pos s)
+let _string_list_of_string ?pos s =
+  read__string_list (Bi_inbuf.from_string ?pos s)
 let extended_tuple_tag = Bi_io.tuple_tag
 let write_untagged_extended_tuple = (
   fun ob x ->
@@ -4109,7 +4109,7 @@ let write_untagged_extended_tuple = (
     );
     (
       let _, _, _, x, _, _ = x in (
-        write__4
+        write__int_option
       ) ob x
     );
     (
@@ -4119,7 +4119,7 @@ let write_untagged_extended_tuple = (
     );
     (
       let _, _, _, _, _, x = x in (
-        write__17
+        write__string_list
       ) ob x
     );
 )
@@ -4153,7 +4153,7 @@ let get_extended_tuple_reader = (
         in
         let x3 =
           (
-            read__4
+            read__int_option
           ) ib
         in
         let x4 =
@@ -4163,7 +4163,7 @@ let get_extended_tuple_reader = (
         in
         let x5 =
           if len >= 6 then (
-            read__17
+            read__string_list
           ) ib
           else
             []
@@ -4193,7 +4193,7 @@ let read_extended_tuple = (
     in
     let x3 =
       (
-        read__4
+        read__int_option
       ) ib
     in
     let x4 =
@@ -4203,7 +4203,7 @@ let read_extended_tuple = (
     in
     let x5 =
       if len >= 6 then (
-        read__17
+        read__string_list
       ) ib
       else
         []
@@ -4242,7 +4242,7 @@ let write_untagged_extended : Bi_outbuf.t -> extended -> unit = (
     );
     Bi_outbuf.add_char4 ob '\128' '\000' 'U' '\146';
     (
-      write__6
+      write__string_option
     ) ob x.b4x;
     if x_b5x != 0.5 then (
       Bi_outbuf.add_char4 ob '\128' '\000' 'U' '\147';
@@ -4304,7 +4304,7 @@ let get_extended_reader = (
             | 21906 ->
               field_b4x := (
                 (
-                  read__6
+                  read__string_option
                 ) ib
               );
               bits0 := !bits0 lor 0x8;
@@ -4373,7 +4373,7 @@ let read_extended = (
         | 21906 ->
           field_b4x := (
             (
-              read__6
+              read__string_option
             ) ib
           );
           bits0 := !bits0 lor 0x8;
@@ -4399,37 +4399,37 @@ let read_extended = (
 )
 let extended_of_string ?pos s =
   read_extended (Bi_inbuf.from_string ?pos s)
-let _27_tag = natural_tag
-let write_untagged__27 = (
+let _x_a08e9e5_tag = natural_tag
+let write_untagged__x_a08e9e5 = (
   fun ob x -> (
     let x = ( Test_lib.Even_natural.unwrap ) x in (
       write_untagged_natural
     ) ob x)
 )
-let write__27 ob x =
+let write__x_a08e9e5 ob x =
   Bi_io.write_tag ob natural_tag;
-  write_untagged__27 ob x
-let string_of__27 ?(len = 1024) x =
+  write_untagged__x_a08e9e5 ob x
+let string_of__x_a08e9e5 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__27 ob x;
+  write__x_a08e9e5 ob x;
   Bi_outbuf.contents ob
-let get__27_reader = (
+let get__x_a08e9e5_reader = (
   fun tag ib ->
     ( Test_lib.Even_natural.wrap ) ((
       get_natural_reader
     ) tag ib)
 )
-let read__27 = (
+let read__x_a08e9e5 = (
   fun ib ->
     ( Test_lib.Even_natural.wrap ) ((
       read_natural
     ) ib)
 )
-let _27_of_string ?pos s =
-  read__27 (Bi_inbuf.from_string ?pos s)
+let _x_a08e9e5_of_string ?pos s =
+  read__x_a08e9e5 (Bi_inbuf.from_string ?pos s)
 let even_natural_tag = natural_tag
 let write_untagged_even_natural = (
-  write_untagged__27
+  write_untagged__x_a08e9e5
 )
 let write_even_natural ob x =
   Bi_io.write_tag ob natural_tag;
@@ -4439,10 +4439,10 @@ let string_of_even_natural ?(len = 1024) x =
   write_even_natural ob x;
   Bi_outbuf.contents ob
 let get_even_natural_reader = (
-  get__27_reader
+  get__x_a08e9e5_reader
 )
 let read_even_natural = (
-  read__27
+  read__x_a08e9e5
 )
 let even_natural_of_string ?pos s =
   read_even_natural (Bi_inbuf.from_string ?pos s)
@@ -4634,36 +4634,36 @@ let read_base = (
 )
 let base_of_string ?pos s =
   read_base (Bi_inbuf.from_string ?pos s)
-let _23_tag = Bi_io.array_tag
-let write_untagged__23 _a_tag write_untagged__a write__a = (
+let _x_f9e3589_tag = Bi_io.array_tag
+let write_untagged__x_f9e3589 _a_tag write_untagged__a write__a = (
   Atdgen_runtime.Ob_run.write_untagged_array
     _a_tag
     (
       write_untagged__a
     )
 )
-let write__23 _a_tag write_untagged__a write__a ob x =
+let write__x_f9e3589 _a_tag write_untagged__a write__a ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
-  write_untagged__23 _a_tag write_untagged__a write__a ob x
-let string_of__23 _a_tag write_untagged__a write__a ?(len = 1024) x =
+  write_untagged__x_f9e3589 _a_tag write_untagged__a write__a ob x
+let string_of__x_f9e3589 _a_tag write_untagged__a write__a ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__23 _a_tag write_untagged__a write__a ob x;
+  write__x_f9e3589 _a_tag write_untagged__a write__a ob x;
   Bi_outbuf.contents ob
-let get__23_reader get__a_reader read__a = (
+let get__x_f9e3589_reader get__a_reader read__a = (
   Atdgen_runtime.Ob_run.get_array_reader (
     get__a_reader
   )
 )
-let read__23 get__a_reader read__a = (
+let read__x_f9e3589 get__a_reader read__a = (
   Atdgen_runtime.Ob_run.read_array (
     get__a_reader
   )
 )
-let _23_of_string get__a_reader read__a ?pos s =
-  read__23 get__a_reader read__a (Bi_inbuf.from_string ?pos s)
+let _x_f9e3589_of_string get__a_reader read__a ?pos s =
+  read__x_f9e3589 get__a_reader read__a (Bi_inbuf.from_string ?pos s)
 let array_tag = Bi_io.array_tag
 let write_untagged_array _a_tag write_untagged__a write__a = (
-  write_untagged__23 _a_tag write_untagged__a write__a
+  write_untagged__x_f9e3589 _a_tag write_untagged__a write__a
 )
 let write_array _a_tag write_untagged__a write__a ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -4673,16 +4673,16 @@ let string_of_array _a_tag write_untagged__a write__a ?(len = 1024) x =
   write_array _a_tag write_untagged__a write__a ob x;
   Bi_outbuf.contents ob
 let get_array_reader get__a_reader read__a = (
-  get__23_reader get__a_reader read__a
+  get__x_f9e3589_reader get__a_reader read__a
 )
 let read_array get__a_reader read__a = (
-  read__23 get__a_reader read__a
+  read__x_f9e3589 get__a_reader read__a
 )
 let array_of_string get__a_reader read__a ?pos s =
   read_array get__a_reader read__a (Bi_inbuf.from_string ?pos s)
 let abs3_tag = Bi_io.array_tag
 let write_untagged_abs3 _a_tag write_untagged__a write__a = (
-  write_untagged__19 _a_tag write_untagged__a write__a
+  write_untagged__a_list _a_tag write_untagged__a write__a
 )
 let write_abs3 _a_tag write_untagged__a write__a ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -4692,16 +4692,16 @@ let string_of_abs3 _a_tag write_untagged__a write__a ?(len = 1024) x =
   write_abs3 _a_tag write_untagged__a write__a ob x;
   Bi_outbuf.contents ob
 let get_abs3_reader get__a_reader read__a = (
-  get__19_reader get__a_reader read__a
+  get__a_list_reader get__a_reader read__a
 )
 let read_abs3 get__a_reader read__a = (
-  read__19 get__a_reader read__a
+  read__a_list get__a_reader read__a
 )
 let abs3_of_string get__a_reader read__a ?pos s =
   read_abs3 get__a_reader read__a (Bi_inbuf.from_string ?pos s)
 let abs2_tag = Bi_io.array_tag
 let write_untagged_abs2 _a_tag write_untagged__a write__a = (
-  write_untagged__19 _a_tag write_untagged__a write__a
+  write_untagged__a_list _a_tag write_untagged__a write__a
 )
 let write_abs2 _a_tag write_untagged__a write__a ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -4711,16 +4711,16 @@ let string_of_abs2 _a_tag write_untagged__a write__a ?(len = 1024) x =
   write_abs2 _a_tag write_untagged__a write__a ob x;
   Bi_outbuf.contents ob
 let get_abs2_reader get__a_reader read__a = (
-  get__19_reader get__a_reader read__a
+  get__a_list_reader get__a_reader read__a
 )
 let read_abs2 get__a_reader read__a = (
-  read__19 get__a_reader read__a
+  read__a_list get__a_reader read__a
 )
 let abs2_of_string get__a_reader read__a ?pos s =
   read_abs2 get__a_reader read__a (Bi_inbuf.from_string ?pos s)
 let abs1_tag = Bi_io.array_tag
 let write_untagged_abs1 _a_tag write_untagged__a write__a = (
-  write_untagged__19 _a_tag write_untagged__a write__a
+  write_untagged__a_list _a_tag write_untagged__a write__a
 )
 let write_abs1 _a_tag write_untagged__a write__a ob x =
   Bi_io.write_tag ob Bi_io.array_tag;
@@ -4730,10 +4730,10 @@ let string_of_abs1 _a_tag write_untagged__a write__a ?(len = 1024) x =
   write_abs1 _a_tag write_untagged__a write__a ob x;
   Bi_outbuf.contents ob
 let get_abs1_reader get__a_reader read__a = (
-  get__19_reader get__a_reader read__a
+  get__a_list_reader get__a_reader read__a
 )
 let read_abs1 get__a_reader read__a = (
-  read__19 get__a_reader read__a
+  read__a_list get__a_reader read__a
 )
 let abs1_of_string get__a_reader read__a ?pos s =
   read_abs1 get__a_reader read__a (Bi_inbuf.from_string ?pos s)

--- a/atdgen/test/test2.expected.ml
+++ b/atdgen/test/test2.expected.ml
@@ -29,28 +29,28 @@ let read_poly get__aa_reader read__aa get__bb_reader read__bb = (
 )
 let poly_of_string get__aa_reader read__aa get__bb_reader read__bb ?pos s =
   read_poly get__aa_reader read__aa get__bb_reader read__bb (Bi_inbuf.from_string ?pos s)
-let _1_tag = Test.poly_tag
-let write_untagged__1 = (
+let _int_int_poly_tag = Test.poly_tag
+let write_untagged__int_int_poly = (
   write_untagged_poly Bi_io.svint_tag Bi_io.write_untagged_svint Bi_io.write_svint Bi_io.svint_tag Bi_io.write_untagged_svint Bi_io.write_svint
 )
-let write__1 ob x =
+let write__int_int_poly ob x =
   Bi_io.write_tag ob Test.poly_tag;
-  write_untagged__1 ob x
-let string_of__1 ?(len = 1024) x =
+  write_untagged__int_int_poly ob x
+let string_of__int_int_poly ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__1 ob x;
+  write__int_int_poly ob x;
   Bi_outbuf.contents ob
-let get__1_reader = (
+let get__int_int_poly_reader = (
   get_poly_reader Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int
 )
-let read__1 = (
+let read__int_int_poly = (
   read_poly Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int
 )
-let _1_of_string ?pos s =
-  read__1 (Bi_inbuf.from_string ?pos s)
+let _int_int_poly_of_string ?pos s =
+  read__int_int_poly (Bi_inbuf.from_string ?pos s)
 let poly_int2_tag = Test.poly_tag
 let write_untagged_poly_int2 = (
-  write_untagged__1
+  write_untagged__int_int_poly
 )
 let write_poly_int2 ob x =
   Bi_io.write_tag ob Test.poly_tag;
@@ -60,27 +60,27 @@ let string_of_poly_int2 ?(len = 1024) x =
   write_poly_int2 ob x;
   Bi_outbuf.contents ob
 let get_poly_int2_reader = (
-  get__1_reader
+  get__int_int_poly_reader
 )
 let read_poly_int2 = (
-  read__1
+  read__int_int_poly
 )
 let poly_int2_of_string ?pos s =
   read_poly_int2 (Bi_inbuf.from_string ?pos s)
-let _3_tag = Bi_io.num_variant_tag
-let write_untagged__3 = (
+let _string_option_tag = Bi_io.num_variant_tag
+let write_untagged__string_option = (
   Atdgen_runtime.Ob_run.write_untagged_option (
     Bi_io.write_string
   )
 )
-let write__3 ob x =
+let write__string_option ob x =
   Bi_io.write_tag ob Bi_io.num_variant_tag;
-  write_untagged__3 ob x
-let string_of__3 ?(len = 1024) x =
+  write_untagged__string_option ob x
+let string_of__string_option ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__3 ob x;
+  write__string_option ob x;
   Bi_outbuf.contents ob
-let get__3_reader = (
+let get__string_option_reader = (
   fun tag ->
     if tag <> 22 then Atdgen_runtime.Ob_run.read_error () else
       fun ib ->
@@ -95,7 +95,7 @@ let get__3_reader = (
             )
           | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let read__3 = (
+let read__string_option = (
   fun ib ->
     if Bi_io.read_tag ib <> 22 then Atdgen_runtime.Ob_run.read_error_at ib;
     match Char.code (Bi_inbuf.read_char ib) with
@@ -109,27 +109,27 @@ let read__3 = (
         )
       | _ -> Atdgen_runtime.Ob_run.read_error_at ib
 )
-let _3_of_string ?pos s =
-  read__3 (Bi_inbuf.from_string ?pos s)
-let _4_tag = Test.poly_tag
-let write_untagged__4 = (
-  write_untagged_poly Bi_io.svint_tag Bi_io.write_untagged_svint Bi_io.write_svint _3_tag write_untagged__3 write__3
+let _string_option_of_string ?pos s =
+  read__string_option (Bi_inbuf.from_string ?pos s)
+let _int_string_option_poly_tag = Test.poly_tag
+let write_untagged__int_string_option_poly = (
+  write_untagged_poly Bi_io.svint_tag Bi_io.write_untagged_svint Bi_io.write_svint _string_option_tag write_untagged__string_option write__string_option
 )
-let write__4 ob x =
+let write__int_string_option_poly ob x =
   Bi_io.write_tag ob Test.poly_tag;
-  write_untagged__4 ob x
-let string_of__4 ?(len = 1024) x =
+  write_untagged__int_string_option_poly ob x
+let string_of__int_string_option_poly ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__4 ob x;
+  write__int_string_option_poly ob x;
   Bi_outbuf.contents ob
-let get__4_reader = (
-  get_poly_reader Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int get__3_reader read__3
+let get__int_string_option_poly_reader = (
+  get_poly_reader Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int get__string_option_reader read__string_option
 )
-let read__4 = (
-  read_poly Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int get__3_reader read__3
+let read__int_string_option_poly = (
+  read_poly Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int get__string_option_reader read__string_option
 )
-let _4_of_string ?pos s =
-  read__4 (Bi_inbuf.from_string ?pos s)
+let _int_string_option_poly_of_string ?pos s =
+  read__int_string_option_poly (Bi_inbuf.from_string ?pos s)
 let test2_tag = Bi_io.record_tag
 let write_untagged_test2 : Bi_outbuf.t -> test2 -> unit = (
   fun ob x ->
@@ -140,7 +140,7 @@ let write_untagged_test2 : Bi_outbuf.t -> test2 -> unit = (
     ) ob x.test0;
     Bi_outbuf.add_char4 ob '\141' '\149' '\127' '\159';
     (
-      write__4
+      write__int_string_option_poly
     ) ob x.test1;
 )
 let write_test2 ob x =
@@ -170,7 +170,7 @@ let get_test2_reader = (
             | 227901343 ->
               field_test1 := (
                 (
-                  read__4
+                  read__int_string_option_poly
                 ) ib
               );
               bits0 := !bits0 lor 0x2;
@@ -203,7 +203,7 @@ let read_test2 = (
         | 227901343 ->
           field_test1 := (
             (
-              read__4
+              read__int_string_option_poly
             ) ib
           );
           bits0 := !bits0 lor 0x2;
@@ -219,28 +219,28 @@ let read_test2 = (
 )
 let test2_of_string ?pos s =
   read_test2 (Bi_inbuf.from_string ?pos s)
-let _2_tag = Test.poly_tag
-let write_untagged__2 = (
+let _int_string_poly_tag = Test.poly_tag
+let write_untagged__int_string_poly = (
   write_untagged_poly Bi_io.svint_tag Bi_io.write_untagged_svint Bi_io.write_svint Bi_io.string_tag Bi_io.write_untagged_string Bi_io.write_string
 )
-let write__2 ob x =
+let write__int_string_poly ob x =
   Bi_io.write_tag ob Test.poly_tag;
-  write_untagged__2 ob x
-let string_of__2 ?(len = 1024) x =
+  write_untagged__int_string_poly ob x
+let string_of__int_string_poly ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__2 ob x;
+  write__int_string_poly ob x;
   Bi_outbuf.contents ob
-let get__2_reader = (
+let get__int_string_poly_reader = (
   get_poly_reader Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int Atdgen_runtime.Ob_run.get_string_reader Atdgen_runtime.Ob_run.read_string
 )
-let read__2 = (
+let read__int_string_poly = (
   read_poly Atdgen_runtime.Ob_run.get_int_reader Atdgen_runtime.Ob_run.read_int Atdgen_runtime.Ob_run.get_string_reader Atdgen_runtime.Ob_run.read_string
 )
-let _2_of_string ?pos s =
-  read__2 (Bi_inbuf.from_string ?pos s)
+let _int_string_poly_of_string ?pos s =
+  read__int_string_poly (Bi_inbuf.from_string ?pos s)
 let poly_int_string_tag = Test.poly_tag
 let write_untagged_poly_int_string = (
-  write_untagged__2
+  write_untagged__int_string_poly
 )
 let write_poly_int_string ob x =
   Bi_io.write_tag ob Test.poly_tag;
@@ -250,10 +250,10 @@ let string_of_poly_int_string ?(len = 1024) x =
   write_poly_int_string ob x;
   Bi_outbuf.contents ob
 let get_poly_int_string_reader = (
-  get__2_reader
+  get__int_string_poly_reader
 )
 let read_poly_int_string = (
-  read__2
+  read__int_string_poly
 )
 let poly_int_string_of_string ?pos s =
   read_poly_int_string (Bi_inbuf.from_string ?pos s)

--- a/atdgen/test/test2j.expected.ml
+++ b/atdgen/test/test2j.expected.ml
@@ -16,40 +16,40 @@ let read_poly read__aa read__bb = (
 )
 let poly_of_string read__aa read__bb s =
   read_poly read__aa read__bb (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__1 = (
+let write__int_int_poly = (
   write_poly Yojson.Safe.write_int Yojson.Safe.write_int
 )
-let string_of__1 ?(len = 1024) x =
+let string_of__int_int_poly ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__1 ob x;
+  write__int_int_poly ob x;
   Buffer.contents ob
-let read__1 = (
+let read__int_int_poly = (
   read_poly Atdgen_runtime.Oj_run.read_int Atdgen_runtime.Oj_run.read_int
 )
-let _1_of_string s =
-  read__1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _int_int_poly_of_string s =
+  read__int_int_poly (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_poly_int2 = (
-  write__1
+  write__int_int_poly
 )
 let string_of_poly_int2 ?(len = 1024) x =
   let ob = Buffer.create len in
   write_poly_int2 ob x;
   Buffer.contents ob
 let read_poly_int2 = (
-  read__1
+  read__int_int_poly
 )
 let poly_int2_of_string s =
   read_poly_int2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__3 = (
+let write__string_option = (
   Atdgen_runtime.Oj_run.write_std_option (
     Yojson.Safe.write_string
   )
 )
-let string_of__3 ?(len = 1024) x =
+let string_of__string_option ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__3 ob x;
+  write__string_option ob x;
   Buffer.contents ob
-let read__3 = (
+let read__string_option = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -95,20 +95,20 @@ let read__3 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _3_of_string s =
-  read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__4 = (
-  write_poly Yojson.Safe.write_int write__3
+let _string_option_of_string s =
+  read__string_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__int_string_option_poly = (
+  write_poly Yojson.Safe.write_int write__string_option
 )
-let string_of__4 ?(len = 1024) x =
+let string_of__int_string_option_poly ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__4 ob x;
+  write__int_string_option_poly ob x;
   Buffer.contents ob
-let read__4 = (
-  read_poly Atdgen_runtime.Oj_run.read_int read__3
+let read__int_string_option_poly = (
+  read_poly Atdgen_runtime.Oj_run.read_int read__string_option
 )
-let _4_of_string s =
-  read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _int_string_option_poly_of_string s =
+  read__int_string_option_poly (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_test2 : _ -> test2 -> _ = (
   fun ob (x : test2) ->
     Buffer.add_char ob '{';
@@ -128,7 +128,7 @@ let write_test2 : _ -> test2 -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"test1\":";
     (
-      write__4
+      write__int_string_option_poly
     )
       ob x.test1;
     Buffer.add_char ob '}';
@@ -183,7 +183,7 @@ let read_test2 = (
             field_test1 := (
               Some (
                 (
-                  read__4
+                  read__int_string_option_poly
                 ) p lb
               )
             );
@@ -231,7 +231,7 @@ let read_test2 = (
               field_test1 := (
                 Some (
                   (
-                    read__4
+                    read__int_string_option_poly
                   ) p lb
                 )
               );
@@ -252,27 +252,27 @@ let read_test2 = (
 )
 let test2_of_string s =
   read_test2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__2 = (
+let write__int_string_poly = (
   write_poly Yojson.Safe.write_int Yojson.Safe.write_string
 )
-let string_of__2 ?(len = 1024) x =
+let string_of__int_string_poly ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__2 ob x;
+  write__int_string_poly ob x;
   Buffer.contents ob
-let read__2 = (
+let read__int_string_poly = (
   read_poly Atdgen_runtime.Oj_run.read_int Atdgen_runtime.Oj_run.read_string
 )
-let _2_of_string s =
-  read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _int_string_poly_of_string s =
+  read__int_string_poly (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_poly_int_string = (
-  write__2
+  write__int_string_poly
 )
 let string_of_poly_int_string ?(len = 1024) x =
   let ob = Buffer.create len in
   write_poly_int_string ob x;
   Buffer.contents ob
 let read_poly_int_string = (
-  read__2
+  read__int_string_poly
 )
 let poly_int_string_of_string s =
   read_poly_int_string (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/test3j_j.expected.ml
+++ b/atdgen/test/test3j_j.expected.ml
@@ -42,14 +42,14 @@ type adapted_f = Test3j_t.adapted_f
 
 type adapted = Test3j_t.adapted
 
-let rec write__4 ob x = (
+let rec write__rec_type_list ob x = (
   Atdgen_runtime.Oj_run.write_list (
     write_rec_type
   )
 ) ob x
-and string_of__4 ?(len = 1024) x =
+and string_of__rec_type_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__4 ob x;
+  write__rec_type_list ob x;
   Buffer.contents ob
 and write_rec_type ob (x : rec_type) = (
   Atdgen_runtime.Oj_run.write_with_adapter Json_adapters.Identity.restore (
@@ -62,7 +62,7 @@ and write_rec_type ob (x : rec_type) = (
         Buffer.add_char ob ',';
         Buffer.add_string ob "\"more\":";
       (
-        write__4
+        write__rec_type_list
       )
         ob x.more;
       Buffer.add_char ob '}';
@@ -72,13 +72,13 @@ and string_of_rec_type ?(len = 1024) x =
   let ob = Buffer.create len in
   write_rec_type ob x;
   Buffer.contents ob
-let rec read__4 p lb = (
+let rec read__rec_type_list p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_rec_type
   )
 ) p lb
-and _4_of_string s =
-  read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and _rec_type_list_of_string s =
+  read__rec_type_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read_rec_type p lb = (
   Atdgen_runtime.Oj_run.read_with_adapter Json_adapters.Identity.normalize (
     fun p lb ->
@@ -108,7 +108,7 @@ and read_rec_type p lb = (
               field_more := (
                 Some (
                   (
-                    read__4
+                    read__rec_type_list
                   ) p lb
                 )
               );
@@ -139,7 +139,7 @@ and read_rec_type p lb = (
                 field_more := (
                   Some (
                     (
-                      read__4
+                      read__rec_type_list
                     ) p lb
                   )
                 );
@@ -160,31 +160,31 @@ and read_rec_type p lb = (
 ) p lb
 and rec_type_of_string s =
   read_rec_type (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__1 = (
+let write__x_69cec3c = (
   Atdgen_runtime.Oj_run.write_list (
     Atdgen_runtime.Oj_run.write_float_as_int
   )
 )
-let string_of__1 ?(len = 1024) x =
+let string_of__x_69cec3c ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__1 ob x;
+  write__x_69cec3c ob x;
   Buffer.contents ob
-let read__1 = (
+let read__x_69cec3c = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_number
   )
 )
-let _1_of_string s =
-  read__1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_69cec3c_of_string s =
+  read__x_69cec3c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_unixtime_list = (
-  write__1
+  write__x_69cec3c
 )
 let string_of_unixtime_list ?(len = 1024) x =
   let ob = Buffer.create len in
   write_unixtime_list ob x;
   Buffer.contents ob
 let read_unixtime_list = (
-  read__1
+  read__x_69cec3c
 )
 let unixtime_list_of_string s =
   read_unixtime_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -200,16 +200,16 @@ let read_json = (
 )
 let json_of_string s =
   read_json (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__5 = (
+let write__json_nullable = (
   Atdgen_runtime.Oj_run.write_nullable (
     write_json
   )
 )
-let string_of__5 ?(len = 1024) x =
+let string_of__json_nullable ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__5 ob x;
+  write__json_nullable ob x;
   Buffer.contents ob
-let read__5 = (
+let read__json_nullable = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     (if Yojson.Safe.read_null_if_possible p lb then None
@@ -217,8 +217,8 @@ let read__5 = (
       read_json
     ) p lb) : _ option)
 )
-let _5_of_string s =
-  read__5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _json_nullable_of_string s =
+  read__json_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_tf_variant2 = (
   fun ob x ->
     match x with
@@ -247,7 +247,7 @@ let write_tf_variant2 = (
             Buffer.add_char ob ',';
             (let _, x = x in
             (
-              write__5
+              write__json_nullable
             ) ob x
             );
             Buffer.add_char ob ']';
@@ -305,7 +305,7 @@ let read_tf_variant2 = (
                       let x1 =
                         let x =
                           (
-                            read__5
+                            read__json_nullable
                           ) p lb
                         in
                         incr len;
@@ -389,7 +389,7 @@ let read_tf_variant2 = (
                       let x1 =
                         let x =
                           (
-                            read__5
+                            read__json_nullable
                           ) p lb
                         in
                         incr len;
@@ -1171,44 +1171,44 @@ let read_sample_open_enum = (
 )
 let sample_open_enum_of_string s =
   read_sample_open_enum (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__6 = (
+let write__sample_open_enum_list = (
   Atdgen_runtime.Oj_run.write_list (
     write_sample_open_enum
   )
 )
-let string_of__6 ?(len = 1024) x =
+let string_of__sample_open_enum_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__6 ob x;
+  write__sample_open_enum_list ob x;
   Buffer.contents ob
-let read__6 = (
+let read__sample_open_enum_list = (
   Atdgen_runtime.Oj_run.read_list (
     read_sample_open_enum
   )
 )
-let _6_of_string s =
-  read__6 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _sample_open_enum_list_of_string s =
+  read__sample_open_enum_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_sample_open_enums = (
-  write__6
+  write__sample_open_enum_list
 )
 let string_of_sample_open_enums ?(len = 1024) x =
   let ob = Buffer.create len in
   write_sample_open_enums ob x;
   Buffer.contents ob
 let read_sample_open_enums = (
-  read__6
+  read__sample_open_enum_list
 )
 let sample_open_enums_of_string s =
   read_sample_open_enums (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__2 = (
+let write__int_nullable = (
   Atdgen_runtime.Oj_run.write_nullable (
     Yojson.Safe.write_int
   )
 )
-let string_of__2 ?(len = 1024) x =
+let string_of__int_nullable ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__2 ob x;
+  write__int_nullable ob x;
   Buffer.contents ob
-let read__2 = (
+let read__int_nullable = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     (if Yojson.Safe.read_null_if_possible p lb then None
@@ -1216,18 +1216,18 @@ let read__2 = (
       Atdgen_runtime.Oj_run.read_int
     ) p lb) : _ option)
 )
-let _2_of_string s =
-  read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__3 = (
+let _int_nullable_of_string s =
+  read__int_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__int_nullable_option = (
   Atdgen_runtime.Oj_run.write_std_option (
-    write__2
+    write__int_nullable
   )
 )
-let string_of__3 ?(len = 1024) x =
+let string_of__int_nullable_option ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__3 ob x;
+  write__int_nullable_option ob x;
   Buffer.contents ob
-let read__3 = (
+let read__int_nullable_option = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -1240,7 +1240,7 @@ let read__3 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__2
+                  read__int_nullable
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -1263,7 +1263,7 @@ let read__3 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__2
+                  read__int_nullable
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -1273,8 +1273,8 @@ let read__3 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _3_of_string s =
-  read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _int_nullable_option_of_string s =
+  read__int_nullable_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_patch : _ -> patch -> _ = (
   fun ob (x : patch) ->
     Buffer.add_char ob '{';
@@ -1286,7 +1286,7 @@ let write_patch : _ -> patch -> _ = (
         Buffer.add_char ob ',';
         Buffer.add_string ob "\"patch1\":";
       (
-        write__2
+        write__int_nullable
       )
         ob x;
     );
@@ -1297,7 +1297,7 @@ let write_patch : _ -> patch -> _ = (
         Buffer.add_char ob ',';
         Buffer.add_string ob "\"patch2\":";
       (
-        write__2
+        write__int_nullable
       )
         ob x;
     );
@@ -1308,7 +1308,7 @@ let write_patch : _ -> patch -> _ = (
         Buffer.add_char ob ',';
         Buffer.add_string ob "\"patch3\":";
       (
-        write__2
+        write__int_nullable
       )
         ob x;
     );
@@ -1360,7 +1360,7 @@ let read_patch = (
             field_patch1 := (
               Some (
                 (
-                  read__2
+                  read__int_nullable
                 ) p lb
               )
             );
@@ -1368,7 +1368,7 @@ let read_patch = (
             field_patch2 := (
               Some (
                 (
-                  read__2
+                  read__int_nullable
                 ) p lb
               )
             );
@@ -1376,7 +1376,7 @@ let read_patch = (
             field_patch3 := (
               Some (
                 (
-                  read__2
+                  read__int_nullable
                 ) p lb
               )
             );
@@ -1419,7 +1419,7 @@ let read_patch = (
               field_patch1 := (
                 Some (
                   (
-                    read__2
+                    read__int_nullable
                   ) p lb
                 )
               );
@@ -1427,7 +1427,7 @@ let read_patch = (
               field_patch2 := (
                 Some (
                   (
-                    read__2
+                    read__int_nullable
                   ) p lb
                 )
               );
@@ -1435,7 +1435,7 @@ let read_patch = (
               field_patch3 := (
                 Some (
                   (
-                    read__2
+                    read__int_nullable
                   ) p lb
                 )
               );

--- a/atdgen/test/test_abstract_j.expected.ml
+++ b/atdgen/test/test_abstract_j.expected.ml
@@ -23,31 +23,31 @@ let read_int_assoc_list = (
 )
 let int_assoc_list_of_string s =
   read_int_assoc_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__1 = (
+let write__abstract_list = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_json
   )
 )
-let string_of__1 ?(len = 1024) x =
+let string_of__abstract_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__1 ob x;
+  write__abstract_list ob x;
   Buffer.contents ob
-let read__1 = (
+let read__abstract_list = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_json
   )
 )
-let _1_of_string s =
-  read__1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _abstract_list_of_string s =
+  read__abstract_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_any_items = (
-  write__1
+  write__abstract_list
 )
 let string_of_any_items ?(len = 1024) x =
   let ob = Buffer.create len in
   write_any_items ob x;
   Buffer.contents ob
 let read_any_items = (
-  read__1
+  read__abstract_list
 )
 let any_items_of_string s =
   read_any_items (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/test_abstract_v.expected.ml
+++ b/atdgen/test/test_abstract_v.expected.ml
@@ -14,13 +14,13 @@ type 'x abs1 = 'x Test_abstract_t.abs1
 let validate_int_assoc_list = (
   Testj.validate_int_assoc_list
 )
-let validate__1 = (
+let validate__abstract_list = (
   Atdgen_runtime.Ov_run.validate_list (
     (fun _ _ -> None)
   )
 )
 let validate_any_items = (
-  validate__1
+  validate__abstract_list
 )
 let validate_any = (
   (fun _ _ -> None)

--- a/atdgen/test/test_polymorphic_wrap_j.expected.ml
+++ b/atdgen/test/test_polymorphic_wrap_j.expected.ml
@@ -3,50 +3,50 @@
 
 type 'a t = 'a Array_wrap.t
 
-let write__1 write__a = (
+let write__a_list write__a = (
   Atdgen_runtime.Oj_run.write_list (
     write__a
   )
 )
-let string_of__1 write__a ?(len = 1024) x =
+let string_of__a_list write__a ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__1 write__a ob x;
+  write__a_list write__a ob x;
   Buffer.contents ob
-let read__1 read__a = (
+let read__a_list read__a = (
   Atdgen_runtime.Oj_run.read_list (
     read__a
   )
 )
-let _1_of_string read__a s =
-  read__1 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__2 write__a = (
+let _a_list_of_string read__a s =
+  read__a_list read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_9bf0425 write__a = (
   fun ob x -> (
     let x = ( Array_wrap.unwrap ) x in (
-      write__1 write__a
+      write__a_list write__a
     ) ob x)
 )
-let string_of__2 write__a ?(len = 1024) x =
+let string_of__x_9bf0425 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__2 write__a ob x;
+  write__x_9bf0425 write__a ob x;
   Buffer.contents ob
-let read__2 read__a = (
+let read__x_9bf0425 read__a = (
   fun p lb ->
     let x = (
-      read__1 read__a
+      read__a_list read__a
     ) p lb in
     ( Array_wrap.wrap ) x
 )
-let _2_of_string read__a s =
-  read__2 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_9bf0425_of_string read__a s =
+  read__x_9bf0425 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_t write__a = (
-  write__2 write__a
+  write__x_9bf0425 write__a
 )
 let string_of_t write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_t write__a ob x;
   Buffer.contents ob
 let read_t read__a = (
-  read__2 read__a
+  read__x_9bf0425 read__a
 )
 let t_of_string read__a s =
   read_t read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/testj.expected.ml
+++ b/atdgen/test/testj.expected.ml
@@ -157,22 +157,22 @@ type 'a abs2 = 'a Test.abs2
 
 type 'a abs1 = 'a Test.abs1
 
-let write__19 write__a = (
+let write__a_list write__a = (
   Atdgen_runtime.Oj_run.write_list (
     write__a
   )
 )
-let string_of__19 write__a ?(len = 1024) x =
+let string_of__a_list write__a ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__19 write__a ob x;
+  write__a_list write__a ob x;
   Buffer.contents ob
-let read__19 read__a = (
+let read__a_list read__a = (
   Atdgen_runtime.Oj_run.read_list (
     read__a
   )
 )
-let _19_of_string read__a s =
-  read__19 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _a_list_of_string read__a s =
+  read__a_list read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_p' write__a : _ -> 'a p' -> _ = (
   fun ob x ->
     match x with
@@ -512,14 +512,234 @@ and read_r = (
 )
 and r_of_string s =
   read_r (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let rec write__20 write__a write__b ob x = (
+let rec write__test_variant_list ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_test_variant
+  )
+) ob x
+and string_of__test_variant_list ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__test_variant_list ob x;
+  Buffer.contents ob
+and write_test_variant = (
+  fun ob x ->
+    match x with
+      | `Case1 -> Buffer.add_string ob "<\"Case1\">"
+      | `Case2 x ->
+        Buffer.add_string ob "<\"Case2\":";
+        (
+          Yojson.Safe.write_int
+        ) ob x;
+        Buffer.add_char ob '>'
+      | `Case3 x ->
+        Buffer.add_string ob "<\"Case3\":";
+        (
+          Yojson.Safe.write_string
+        ) ob x;
+        Buffer.add_char ob '>'
+      | `Case4 x ->
+        Buffer.add_string ob "<\"Case4\":";
+        (
+          write__test_variant_list
+        ) ob x;
+        Buffer.add_char ob '>'
+)
+and string_of_test_variant ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_test_variant ob x;
+  Buffer.contents ob
+let rec read__test_variant_list p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_test_variant
+  )
+) p lb
+and _test_variant_list_of_string s =
+  read__test_variant_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read_test_variant = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "Case1" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case1
+            | "Case2" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case2 x
+            | "Case3" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case3 x
+            | "Case4" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__test_variant_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case4 x
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "Case1" ->
+              `Case1
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Case2" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              `Case2 x
+            | "Case3" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              `Case3 x
+            | "Case4" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__test_variant_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              `Case4 x
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+and test_variant_of_string s =
+  read_test_variant (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let rec write__int_p : _ -> _ p' -> _ = (
+  fun ob x ->
+    match x with
+      | A -> Buffer.add_string ob "<\"A\">"
+      | Bb x ->
+        Buffer.add_string ob "<\"Bb\":";
+        (
+          write__int_p
+        ) ob x;
+        Buffer.add_char ob '>'
+      | Ccccc x ->
+        Buffer.add_string ob "<\"Ccccc\":";
+        (
+          Yojson.Safe.write_int
+        ) ob x;
+        Buffer.add_char ob '>'
+)
+and string_of__int_p ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__int_p ob x;
+  Buffer.contents ob
+let rec read__int_p = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "A" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (A : _ p')
+            | "Bb" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__int_p
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Bb x : _ p')
+            | "Ccccc" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Ccccc x : _ p')
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "A" ->
+              (A : _ p')
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Bb" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__int_p
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Bb x : _ p')
+            | "Ccccc" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Ccccc x : _ p')
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+and _int_p_of_string s =
+  read__int_p (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let rec write__a_b_poly_option write__a write__b ob x = (
   Atdgen_runtime.Oj_run.write_option (
     write_poly write__a write__b
   )
 ) ob x
-and string_of__20 write__a write__b ?(len = 1024) x =
+and string_of__a_b_poly_option write__a write__b ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__20 write__a write__b ob x;
+  write__a_b_poly_option write__a write__b ob x;
   Buffer.contents ob
 and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
   fun ob (x : ('x, 'y) poly) ->
@@ -531,7 +751,7 @@ and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"fst\":";
     (
-      write__19 write__x
+      write__a_list write__x
     )
       ob x.fst;
     if !is_first then
@@ -540,7 +760,7 @@ and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"snd\":";
     (
-      write__20 write__x write__y
+      write__a_b_poly_option write__x write__y
     )
       ob x.snd;
     Buffer.add_char ob '}';
@@ -549,7 +769,7 @@ and string_of_poly write__x write__y ?(len = 1024) x =
   let ob = Buffer.create len in
   write_poly write__x write__y ob x;
   Buffer.contents ob
-let rec read__20 read__a read__b = (
+let rec read__a_b_poly_option read__a read__b = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -595,8 +815,8 @@ let rec read__20 read__a read__b = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _20_of_string read__a read__b s =
-  read__20 read__a read__b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and _a_b_poly_option_of_string read__a read__b s =
+  read__a_b_poly_option read__a read__b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read_poly read__x read__y = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
@@ -649,7 +869,7 @@ and read_poly read__x read__y = (
             field_fst := (
               Some (
                 (
-                  read__19 read__x
+                  read__a_list read__x
                 ) p lb
               )
             );
@@ -657,7 +877,7 @@ and read_poly read__x read__y = (
             field_snd := (
               Some (
                 (
-                  read__20 read__x read__y
+                  read__a_b_poly_option read__x read__y
                 ) p lb
               )
             );
@@ -711,7 +931,7 @@ and read_poly read__x read__y = (
               field_fst := (
                 Some (
                   (
-                    read__19 read__x
+                    read__a_list read__x
                   ) p lb
                 )
               );
@@ -719,7 +939,7 @@ and read_poly read__x read__y = (
               field_snd := (
                 Some (
                   (
-                    read__20 read__x read__y
+                    read__a_b_poly_option read__x read__y
                   ) p lb
                 )
               );
@@ -740,226 +960,6 @@ and read_poly read__x read__y = (
 )
 and poly_of_string read__x read__y s =
   read_poly read__x read__y (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let rec write__2 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_test_variant
-  )
-) ob x
-and string_of__2 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__2 ob x;
-  Buffer.contents ob
-and write_test_variant = (
-  fun ob x ->
-    match x with
-      | `Case1 -> Buffer.add_string ob "<\"Case1\">"
-      | `Case2 x ->
-        Buffer.add_string ob "<\"Case2\":";
-        (
-          Yojson.Safe.write_int
-        ) ob x;
-        Buffer.add_char ob '>'
-      | `Case3 x ->
-        Buffer.add_string ob "<\"Case3\":";
-        (
-          Yojson.Safe.write_string
-        ) ob x;
-        Buffer.add_char ob '>'
-      | `Case4 x ->
-        Buffer.add_string ob "<\"Case4\":";
-        (
-          write__2
-        ) ob x;
-        Buffer.add_char ob '>'
-)
-and string_of_test_variant ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write_test_variant ob x;
-  Buffer.contents ob
-let rec read__2 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_test_variant
-  )
-) p lb
-and _2_of_string s =
-  read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read_test_variant = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "Case1" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case1
-            | "Case2" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case2 x
-            | "Case3" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case3 x
-            | "Case4" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read__2
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case4 x
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "Case1" ->
-              `Case1
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Case2" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              `Case2 x
-            | "Case3" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              `Case3 x
-            | "Case4" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read__2
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              `Case4 x
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-and test_variant_of_string s =
-  read_test_variant (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let rec write__1 : _ -> _ p' -> _ = (
-  fun ob x ->
-    match x with
-      | A -> Buffer.add_string ob "<\"A\">"
-      | Bb x ->
-        Buffer.add_string ob "<\"Bb\":";
-        (
-          write__1
-        ) ob x;
-        Buffer.add_char ob '>'
-      | Ccccc x ->
-        Buffer.add_string ob "<\"Ccccc\":";
-        (
-          Yojson.Safe.write_int
-        ) ob x;
-        Buffer.add_char ob '>'
-)
-and string_of__1 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__1 ob x;
-  Buffer.contents ob
-let rec read__1 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "A" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (A : _ p')
-            | "Bb" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read__1
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Bb x : _ p')
-            | "Ccccc" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Ccccc x : _ p')
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "A" ->
-              (A : _ p')
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Bb" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read__1
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Bb x : _ p')
-            | "Ccccc" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Ccccc x : _ p')
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-and _1_of_string s =
-  read__1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_validated_string_check = (
   Yojson.Safe.write_string
 )
@@ -972,31 +972,31 @@ let read_validated_string_check = (
 )
 let validated_string_check_of_string s =
   read_validated_string_check (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__31 = (
+let write__x_5640b64 = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string
   )
 )
-let string_of__31 ?(len = 1024) x =
+let string_of__x_5640b64 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__31 ob x;
+  write__x_5640b64 ob x;
   Buffer.contents ob
-let read__31 = (
+let read__x_5640b64 = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_string
   )
 )
-let _31_of_string s =
-  read__31 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_5640b64_of_string s =
+  read__x_5640b64 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_validate_me = (
-  write__31
+  write__x_5640b64
 )
 let string_of_validate_me ?(len = 1024) x =
   let ob = Buffer.create len in
   write_validate_me ob x;
   Buffer.contents ob
 let read_validate_me = (
-  read__31
+  read__x_5640b64
 )
 let validate_me_of_string s =
   read_validate_me (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -1100,16 +1100,16 @@ let read_val1 = (
 )
 let val1_of_string s =
   read_val1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__16 = (
+let write__val1_option = (
   Atdgen_runtime.Oj_run.write_option (
     write_val1
   )
 )
-let string_of__16 ?(len = 1024) x =
+let string_of__val1_option ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__16 ob x;
+  write__val1_option ob x;
   Buffer.contents ob
-let read__16 = (
+let read__val1_option = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -1155,8 +1155,8 @@ let read__16 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _16_of_string s =
-  read__16 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _val1_option_of_string s =
+  read__val1_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_val2 : _ -> val2 -> _ = (
   fun ob (x : val2) ->
     Buffer.add_char ob '{';
@@ -1310,44 +1310,44 @@ let read_val2 = (
 )
 let val2_of_string s =
   read_val2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__29 = (
+let write__x_6089809 = (
   Atdgen_runtime.Oj_run.write_list (
     Atdgen_runtime.Oj_run.write_float_as_int
   )
 )
-let string_of__29 ?(len = 1024) x =
+let string_of__x_6089809 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__29 ob x;
+  write__x_6089809 ob x;
   Buffer.contents ob
-let read__29 = (
+let read__x_6089809 = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_number
   )
 )
-let _29_of_string s =
-  read__29 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_6089809_of_string s =
+  read__x_6089809 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_unixtime_list = (
-  write__29
+  write__x_6089809
 )
 let string_of_unixtime_list ?(len = 1024) x =
   let ob = Buffer.create len in
   write_unixtime_list ob x;
   Buffer.contents ob
 let read_unixtime_list = (
-  read__29
+  read__x_6089809
 )
 let unixtime_list_of_string s =
   read_unixtime_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__3 = (
+let write__int_nullable = (
   Atdgen_runtime.Oj_run.write_nullable (
     Yojson.Safe.write_int
   )
 )
-let string_of__3 ?(len = 1024) x =
+let string_of__int_nullable ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__3 ob x;
+  write__int_nullable ob x;
   Buffer.contents ob
-let read__3 = (
+let read__int_nullable = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     (if Yojson.Safe.read_null_if_possible p lb then None
@@ -1355,8 +1355,8 @@ let read__3 = (
       Atdgen_runtime.Oj_run.read_int
     ) p lb) : _ option)
 )
-let _3_of_string s =
-  read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _int_nullable_of_string s =
+  read__int_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_date = (
   fun ob x ->
     Buffer.add_char ob '(';
@@ -1368,13 +1368,13 @@ let write_date = (
     Buffer.add_char ob ',';
     (let _, x, _ = x in
     (
-      write__3
+      write__int_nullable
     ) ob x
     );
     Buffer.add_char ob ',';
     (let _, _, x = x in
     (
-      write__3
+      write__int_nullable
     ) ob x
     );
     Buffer.add_char ob ')';
@@ -1404,7 +1404,7 @@ let read_date = (
       let x1 =
         let x =
           (
-            read__3
+            read__int_nullable
           ) p lb
         in
         incr len;
@@ -1415,7 +1415,7 @@ let read_date = (
       let x2 =
         let x =
           (
-            read__3
+            read__int_nullable
           ) p lb
         in
         incr len;
@@ -1440,298 +1440,298 @@ let read_date = (
 )
 let date_of_string s =
   read_date (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__9 = (
-  Atdgen_runtime.Oj_run.write_array (
-    Yojson.Safe.write_string
-  )
-)
-let string_of__9 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__9 ob x;
-  Buffer.contents ob
-let read__9 = (
-  Atdgen_runtime.Oj_run.read_array (
-    Atdgen_runtime.Oj_run.read_string
-  )
-)
-let _9_of_string s =
-  read__9 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__8 = (
-  Atdgen_runtime.Oj_run.write_option (
-    Yojson.Safe.write_bool
-  )
-)
-let string_of__8 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__8 ob x;
-  Buffer.contents ob
-let read__8 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _8_of_string s =
-  read__8 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__7 = (
+let write__x_adbef7e = (
   Atdgen_runtime.Oj_run.write_array (
     Yojson.Safe.write_float
   )
 )
-let string_of__7 ?(len = 1024) x =
+let string_of__x_adbef7e ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__7 ob x;
+  write__x_adbef7e ob x;
   Buffer.contents ob
-let read__7 = (
+let read__x_adbef7e = (
   Atdgen_runtime.Oj_run.read_array (
     Atdgen_runtime.Oj_run.read_number
   )
 )
-let _7_of_string s =
-  read__7 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__6 = (
-  Atdgen_runtime.Oj_run.write_option (
+let _x_adbef7e_of_string s =
+  read__x_adbef7e (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_20d39e2 = (
+  Atdgen_runtime.Oj_run.write_array (
     Yojson.Safe.write_string
   )
 )
-let string_of__6 ?(len = 1024) x =
+let string_of__x_20d39e2 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__6 ob x;
+  write__x_20d39e2 ob x;
   Buffer.contents ob
-let read__6 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _6_of_string s =
-  read__6 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__5 = (
-  Atdgen_runtime.Oj_run.write_option (
-    Yojson.Safe.write_float
+let read__x_20d39e2 = (
+  Atdgen_runtime.Oj_run.read_array (
+    Atdgen_runtime.Oj_run.read_string
   )
 )
-let string_of__5 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__5 ob x;
-  Buffer.contents ob
-let read__5 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _5_of_string s =
-  read__5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__4 = (
-  Atdgen_runtime.Oj_run.write_option (
-    Yojson.Safe.write_int
-  )
-)
-let string_of__4 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__4 ob x;
-  Buffer.contents ob
-let read__4 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _4_of_string s =
-  read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__11 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write__6
-  )
-)
-let string_of__11 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__11 ob x;
-  Buffer.contents ob
-let read__11 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read__6
-  )
-)
-let _11_of_string s =
-  read__11 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__10 = (
+let _x_20d39e2_of_string s =
+  read__x_20d39e2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__unit_list = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_null
   )
 )
-let string_of__10 ?(len = 1024) x =
+let string_of__unit_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__10 ob x;
+  write__unit_list ob x;
   Buffer.contents ob
-let read__10 = (
+let read__unit_list = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_null
   )
 )
-let _10_of_string s =
-  read__10 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _unit_list_of_string s =
+  read__unit_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__string_option = (
+  Atdgen_runtime.Oj_run.write_option (
+    Yojson.Safe.write_string
+  )
+)
+let string_of__string_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__string_option ob x;
+  Buffer.contents ob
+let read__string_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _string_option_of_string s =
+  read__string_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__string_option_list = (
+  Atdgen_runtime.Oj_run.write_list (
+    write__string_option
+  )
+)
+let string_of__string_option_list ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__string_option_list ob x;
+  Buffer.contents ob
+let read__string_option_list = (
+  Atdgen_runtime.Oj_run.read_list (
+    read__string_option
+  )
+)
+let _string_option_list_of_string s =
+  read__string_option_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__int_option = (
+  Atdgen_runtime.Oj_run.write_option (
+    Yojson.Safe.write_int
+  )
+)
+let string_of__int_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__int_option ob x;
+  Buffer.contents ob
+let read__int_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _int_option_of_string s =
+  read__int_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__float_option = (
+  Atdgen_runtime.Oj_run.write_option (
+    Yojson.Safe.write_float
+  )
+)
+let string_of__float_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__float_option ob x;
+  Buffer.contents ob
+let read__float_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _float_option_of_string s =
+  read__float_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__bool_option = (
+  Atdgen_runtime.Oj_run.write_option (
+    Yojson.Safe.write_bool
+  )
+)
+let string_of__bool_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__bool_option ob x;
+  Buffer.contents ob
+let read__bool_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _bool_option_of_string s =
+  read__bool_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_mixed_record : _ -> mixed_record -> _ = (
   fun ob (x : mixed_record) ->
     Buffer.add_char ob '{';
@@ -1764,7 +1764,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field2\":";
     (
-      write__6
+      write__string_option
     )
       ob x.field2;
     if !is_first then
@@ -1782,7 +1782,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field4\":";
     (
-      write__7
+      write__x_adbef7e
     )
       ob x.field4;
     (match x.field5 with None -> () | Some x ->
@@ -1822,7 +1822,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field8\":";
     (
-      write__9
+      write__x_20d39e2
     )
       ob x.field8;
     if !is_first then
@@ -1897,7 +1897,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field12\":";
     (
-      write__10
+      write__unit_list
     )
       ob x.field12;
     if !is_first then
@@ -1906,7 +1906,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field13\":";
     (
-      write__11
+      write__string_option_list
     )
       ob x.field13;
     if !is_first then
@@ -2056,7 +2056,7 @@ let read_mixed_record = (
             field_field2 := (
               Some (
                 (
-                  read__6
+                  read__string_option
                 ) p lb
               )
             );
@@ -2072,7 +2072,7 @@ let read_mixed_record = (
             field_field4 := (
               Some (
                 (
-                  read__7
+                  read__x_adbef7e
                 ) p lb
               )
             );
@@ -2108,7 +2108,7 @@ let read_mixed_record = (
             field_field8 := (
               Some (
                 (
-                  read__9
+                  read__x_20d39e2
                 ) p lb
               )
             );
@@ -2225,7 +2225,7 @@ let read_mixed_record = (
             field_field12 := (
               Some (
                 (
-                  read__10
+                  read__unit_list
                 ) p lb
               )
             );
@@ -2233,7 +2233,7 @@ let read_mixed_record = (
             field_field13 := (
               Some (
                 (
-                  read__11
+                  read__string_option_list
                 ) p lb
               )
             );
@@ -2362,7 +2362,7 @@ let read_mixed_record = (
               field_field2 := (
                 Some (
                   (
-                    read__6
+                    read__string_option
                   ) p lb
                 )
               );
@@ -2378,7 +2378,7 @@ let read_mixed_record = (
               field_field4 := (
                 Some (
                   (
-                    read__7
+                    read__x_adbef7e
                   ) p lb
                 )
               );
@@ -2414,7 +2414,7 @@ let read_mixed_record = (
               field_field8 := (
                 Some (
                   (
-                    read__9
+                    read__x_20d39e2
                   ) p lb
                 )
               );
@@ -2531,7 +2531,7 @@ let read_mixed_record = (
               field_field12 := (
                 Some (
                   (
-                    read__10
+                    read__unit_list
                   ) p lb
                 )
               );
@@ -2539,7 +2539,7 @@ let read_mixed_record = (
               field_field13 := (
                 Some (
                   (
-                    read__11
+                    read__string_option_list
                   ) p lb
                 )
               );
@@ -2581,61 +2581,61 @@ let read_mixed_record = (
 )
 let mixed_record_of_string s =
   read_mixed_record (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__13 = (
+let write__x_d88f1c8 = (
   Atdgen_runtime.Oj_run.write_array (
     write_mixed_record
   )
 )
-let string_of__13 ?(len = 1024) x =
+let string_of__x_d88f1c8 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__13 ob x;
+  write__x_d88f1c8 ob x;
   Buffer.contents ob
-let read__13 = (
+let read__x_d88f1c8 = (
   Atdgen_runtime.Oj_run.read_array (
     read_mixed_record
   )
 )
-let _13_of_string s =
-  read__13 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__12 = (
+let _x_d88f1c8_of_string s =
+  read__x_d88f1c8 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_7de077c = (
   Atdgen_runtime.Oj_run.write_array (
     write_mixed_record
   )
 )
-let string_of__12 ?(len = 1024) x =
+let string_of__x_7de077c ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__12 ob x;
+  write__x_7de077c ob x;
   Buffer.contents ob
-let read__12 = (
+let read__x_7de077c = (
   Atdgen_runtime.Oj_run.read_array (
     read_mixed_record
   )
 )
-let _12_of_string s =
-  read__12 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__14 = (
+let _x_7de077c_of_string s =
+  read__x_7de077c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_c393fa9 = (
   Atdgen_runtime.Oj_run.write_list (
     fun ob x ->
       Buffer.add_char ob '(';
       (let x, _ = x in
       (
-        write__12
+        write__x_d88f1c8
       ) ob x
       );
       Buffer.add_char ob ',';
       (let _, x = x in
       (
-        write__13
+        write__x_7de077c
       ) ob x
       );
       Buffer.add_char ob ')';
   )
 )
-let string_of__14 ?(len = 1024) x =
+let string_of__x_c393fa9 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__14 ob x;
+  write__x_c393fa9 ob x;
   Buffer.contents ob
-let read__14 = (
+let read__x_c393fa9 = (
   Atdgen_runtime.Oj_run.read_list (
     fun p lb ->
       Yojson.Safe.read_space p lb;
@@ -2646,7 +2646,7 @@ let read__14 = (
         let x0 =
           let x =
             (
-              read__12
+              read__x_d88f1c8
             ) p lb
           in
           incr len;
@@ -2657,7 +2657,7 @@ let read__14 = (
         let x1 =
           let x =
             (
-              read__13
+              read__x_7de077c
             ) p lb
           in
           incr len;
@@ -2681,36 +2681,36 @@ let read__14 = (
         Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
   )
 )
-let _14_of_string s =
-  read__14 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_c393fa9_of_string s =
+  read__x_c393fa9 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_mixed = (
-  write__14
+  write__x_c393fa9
 )
 let string_of_mixed ?(len = 1024) x =
   let ob = Buffer.create len in
   write_mixed ob x;
   Buffer.contents ob
 let read_mixed = (
-  read__14
+  read__x_c393fa9
 )
 let mixed_of_string s =
   read_mixed (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__15 = (
+let write__mixed_record_list = (
   Atdgen_runtime.Oj_run.write_list (
     write_mixed_record
   )
 )
-let string_of__15 ?(len = 1024) x =
+let string_of__mixed_record_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__15 ob x;
+  write__mixed_record_list ob x;
   Buffer.contents ob
-let read__15 = (
+let read__mixed_record_list = (
   Atdgen_runtime.Oj_run.read_list (
     read_mixed_record
   )
 )
-let _15_of_string s =
-  read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _mixed_record_list_of_string s =
+  read__mixed_record_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_test : _ -> test -> _ = (
   fun ob (x : test) ->
     Buffer.add_char ob '{';
@@ -2752,7 +2752,7 @@ let write_test : _ -> test -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"x3\":";
     (
-      write__15
+      write__mixed_record_list
     )
       ob x.x3;
     if !is_first then
@@ -2850,7 +2850,7 @@ let read_test = (
             field_x3 := (
               Some (
                 (
-                  read__15
+                  read__mixed_record_list
                 ) p lb
               )
             );
@@ -2937,7 +2937,7 @@ let read_test = (
               field_x3 := (
                 Some (
                   (
-                    read__15
+                    read__mixed_record_list
                   ) p lb
                 )
               );
@@ -3218,7 +3218,7 @@ let read_star_rating = (
 )
 let star_rating_of_string s =
   read_star_rating (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__30 : _ -> _ generic -> _ = (
+let write__string_generic : _ -> _ generic -> _ = (
   fun ob (x : _ generic) ->
     Buffer.add_char ob '{';
     let is_first = ref true in
@@ -3233,11 +3233,11 @@ let write__30 : _ -> _ generic -> _ = (
       ob x.x294623;
     Buffer.add_char ob '}';
 )
-let string_of__30 ?(len = 1024) x =
+let string_of__string_generic ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__30 ob x;
+  write__string_generic ob x;
   Buffer.contents ob
-let read__30 = (
+let read__string_generic = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
@@ -3316,17 +3316,17 @@ let read__30 = (
          : _ generic)
       )
 )
-let _30_of_string s =
-  read__30 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _string_generic_of_string s =
+  read__string_generic (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_specialized = (
-  write__30
+  write__string_generic
 )
 let string_of_specialized ?(len = 1024) x =
   let ob = Buffer.create len in
   write_specialized ob x;
   Buffer.contents ob
 let read_specialized = (
-  read__30
+  read__string_generic
 )
 let specialized_of_string s =
   read_specialized (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -3661,27 +3661,27 @@ let read_precision = (
 let precision_of_string s =
   read_precision (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_p'' = (
-  write__1
+  write__int_p
 )
 let string_of_p'' ?(len = 1024) x =
   let ob = Buffer.create len in
   write_p'' ob x;
   Buffer.contents ob
 let read_p'' = (
-  read__1
+  read__int_p
 )
 let p''_of_string s =
   read_p'' (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__18 = (
+let write__x_bee1b88 = (
   Atdgen_runtime.Oj_run.write_option (
     Yojson.Safe.write_int
   )
 )
-let string_of__18 ?(len = 1024) x =
+let string_of__x_bee1b88 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__18 ob x;
+  write__x_bee1b88 ob x;
   Buffer.contents ob
-let read__18 = (
+let read__x_bee1b88 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -3727,211 +3727,211 @@ let read__18 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _18_of_string s =
-  read__18 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_bee1b88_of_string s =
+  read__x_bee1b88 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_option_validation = (
-  write__18
+  write__x_bee1b88
 )
 let string_of_option_validation ?(len = 1024) x =
   let ob = Buffer.create len in
   write_option_validation ob x;
   Buffer.contents ob
 let read_option_validation = (
-  read__18
+  read__x_bee1b88
 )
 let option_validation_of_string s =
   read_option_validation (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__28 = (
+let write__some_record_wrap = (
   write_some_record
 )
-let string_of__28 ?(len = 1024) x =
+let string_of__some_record_wrap ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__28 ob x;
+  write__some_record_wrap ob x;
   Buffer.contents ob
-let read__28 = (
+let read__some_record_wrap = (
   read_some_record
 )
-let _28_of_string s =
-  read__28 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _some_record_wrap_of_string s =
+  read__some_record_wrap (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_no_real_wrap = (
-  write__28
+  write__some_record_wrap
 )
 let string_of_no_real_wrap ?(len = 1024) x =
   let ob = Buffer.create len in
   write_no_real_wrap ob x;
   Buffer.contents ob
 let read_no_real_wrap = (
-  read__28
+  read__some_record_wrap
 )
 let no_real_wrap_of_string s =
   read_no_real_wrap (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__26 = (
+let write__x_e48509c = (
   fun ob x -> (
     let x = ( Test_lib.Natural.unwrap ) x in (
       Yojson.Safe.write_int
     ) ob x)
 )
-let string_of__26 ?(len = 1024) x =
+let string_of__x_e48509c ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__26 ob x;
+  write__x_e48509c ob x;
   Buffer.contents ob
-let read__26 = (
+let read__x_e48509c = (
   fun p lb ->
     let x = (
       Atdgen_runtime.Oj_run.read_int
     ) p lb in
     ( Test_lib.Natural.wrap ) x
 )
-let _26_of_string s =
-  read__26 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_e48509c_of_string s =
+  read__x_e48509c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_natural = (
-  write__26
+  write__x_e48509c
 )
 let string_of_natural ?(len = 1024) x =
   let ob = Buffer.create len in
   write_natural ob x;
   Buffer.contents ob
 let read_natural = (
-  read__26
+  read__x_e48509c
 )
 let natural_of_string s =
   read_natural (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__24 = (
+let write__x_2596d76 = (
   fun ob x -> (
     let x = ( function `Id s -> s ) x in (
       Yojson.Safe.write_string
     ) ob x)
 )
-let string_of__24 ?(len = 1024) x =
+let string_of__x_2596d76 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__24 ob x;
+  write__x_2596d76 ob x;
   Buffer.contents ob
-let read__24 = (
+let read__x_2596d76 = (
   fun p lb ->
     let x = (
       Atdgen_runtime.Oj_run.read_string
     ) p lb in
     ( fun s -> `Id s ) x
 )
-let _24_of_string s =
-  read__24 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_2596d76_of_string s =
+  read__x_2596d76 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_id = (
-  write__24
+  write__x_2596d76
 )
 let string_of_id ?(len = 1024) x =
   let ob = Buffer.create len in
   write_id ob x;
   Buffer.contents ob
 let read_id = (
-  read__24
+  read__x_2596d76
 )
 let id_of_string s =
   read_id (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__25 = (
+let write__x_b6e4b4c = (
   Atdgen_runtime.Oj_run.write_assoc_list (
     write_id
   ) (
     Yojson.Safe.write_int
   )
 )
-let string_of__25 ?(len = 1024) x =
+let string_of__x_b6e4b4c ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__25 ob x;
+  write__x_b6e4b4c ob x;
   Buffer.contents ob
-let read__25 = (
+let read__x_b6e4b4c = (
   Atdgen_runtime.Oj_run.read_assoc_list (
     read_id
   ) (
     Atdgen_runtime.Oj_run.read_int
   )
 )
-let _25_of_string s =
-  read__25 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_b6e4b4c_of_string s =
+  read__x_b6e4b4c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_json_map = (
-  write__25
+  write__x_b6e4b4c
 )
 let string_of_json_map ?(len = 1024) x =
   let ob = Buffer.create len in
   write_json_map ob x;
   Buffer.contents ob
 let read_json_map = (
-  read__25
+  read__x_b6e4b4c
 )
 let json_map_of_string s =
   read_json_map (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_intopt = (
-  write__4
+  write__int_option
 )
 let string_of_intopt ?(len = 1024) x =
   let ob = Buffer.create len in
   write_intopt ob x;
   Buffer.contents ob
 let read_intopt = (
-  read__4
+  read__int_option
 )
 let intopt_of_string s =
   read_intopt (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__21 = (
+let write__x_547263f = (
   Atdgen_runtime.Oj_run.write_assoc_list (
     Yojson.Safe.write_string
   ) (
     Yojson.Safe.write_int
   )
 )
-let string_of__21 ?(len = 1024) x =
+let string_of__x_547263f ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__21 ob x;
+  write__x_547263f ob x;
   Buffer.contents ob
-let read__21 = (
+let read__x_547263f = (
   Atdgen_runtime.Oj_run.read_assoc_list (
     Atdgen_runtime.Oj_run.read_string
   ) (
     Atdgen_runtime.Oj_run.read_int
   )
 )
-let _21_of_string s =
-  read__21 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_547263f_of_string s =
+  read__x_547263f (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_int_assoc_list = (
-  write__21
+  write__x_547263f
 )
 let string_of_int_assoc_list ?(len = 1024) x =
   let ob = Buffer.create len in
   write_int_assoc_list ob x;
   Buffer.contents ob
 let read_int_assoc_list = (
-  read__21
+  read__x_547263f
 )
 let int_assoc_list_of_string s =
   read_int_assoc_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__22 = (
+let write__x_0a94e5e = (
   Atdgen_runtime.Oj_run.write_assoc_array (
     Yojson.Safe.write_string
   ) (
     Yojson.Safe.write_int
   )
 )
-let string_of__22 ?(len = 1024) x =
+let string_of__x_0a94e5e ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__22 ob x;
+  write__x_0a94e5e ob x;
   Buffer.contents ob
-let read__22 = (
+let read__x_0a94e5e = (
   Atdgen_runtime.Oj_run.read_assoc_array (
     Atdgen_runtime.Oj_run.read_string
   ) (
     Atdgen_runtime.Oj_run.read_int
   )
 )
-let _22_of_string s =
-  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_0a94e5e_of_string s =
+  read__x_0a94e5e (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_int_assoc_array = (
-  write__22
+  write__x_0a94e5e
 )
 let string_of_int_assoc_array ?(len = 1024) x =
   let ob = Buffer.create len in
   write_int_assoc_array ob x;
   Buffer.contents ob
 let read_int_assoc_array = (
-  read__22
+  read__x_0a94e5e
 )
 let int_assoc_array_of_string s =
   read_int_assoc_array (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -4305,22 +4305,22 @@ let read_floats = (
 )
 let floats_of_string s =
   read_floats (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__17 = (
+let write__string_list = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string
   )
 )
-let string_of__17 ?(len = 1024) x =
+let string_of__string_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__17 ob x;
+  write__string_list ob x;
   Buffer.contents ob
-let read__17 = (
+let read__string_list = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_string
   )
 )
-let _17_of_string s =
-  read__17 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _string_list_of_string s =
+  read__string_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_extended_tuple = (
   fun ob x ->
     Buffer.add_char ob '(';
@@ -4344,7 +4344,7 @@ let write_extended_tuple = (
     Buffer.add_char ob ',';
     (let _, _, _, x, _, _ = x in
     (
-      write__4
+      write__int_option
     ) ob x
     );
     Buffer.add_char ob ',';
@@ -4356,7 +4356,7 @@ let write_extended_tuple = (
     Buffer.add_char ob ',';
     (let _, _, _, _, _, x = x in
     (
-      write__17
+      write__string_list
     ) ob x
     );
     Buffer.add_char ob ')';
@@ -4408,7 +4408,7 @@ let read_extended_tuple = (
       let x3 =
         let x =
           (
-            read__4
+            read__int_option
           ) p lb
         in
         incr len;
@@ -4434,7 +4434,7 @@ let read_extended_tuple = (
         else (
           let x = (
             (
-              read__17
+              read__string_list
             ) p lb
           ) in
           incr len;
@@ -4509,7 +4509,7 @@ let write_extended : _ -> extended -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"b4\":";
     (
-      write__6
+      write__string_option
     )
       ob x.b4x;
     if x.b5x <> 0.5 then (
@@ -4619,7 +4619,7 @@ let read_extended = (
             field_b4x := (
               Some (
                 (
-                  read__6
+                  read__string_option
                 ) p lb
               )
             );
@@ -4715,7 +4715,7 @@ let read_extended = (
               field_b4x := (
                 Some (
                   (
-                    read__6
+                    read__string_option
                   ) p lb
                 )
               );
@@ -4748,34 +4748,34 @@ let read_extended = (
 )
 let extended_of_string s =
   read_extended (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__27 = (
+let write__x_a08e9e5 = (
   fun ob x -> (
     let x = ( Test_lib.Even_natural.unwrap ) x in (
       write_natural
     ) ob x)
 )
-let string_of__27 ?(len = 1024) x =
+let string_of__x_a08e9e5 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__27 ob x;
+  write__x_a08e9e5 ob x;
   Buffer.contents ob
-let read__27 = (
+let read__x_a08e9e5 = (
   fun p lb ->
     let x = (
       read_natural
     ) p lb in
     ( Test_lib.Even_natural.wrap ) x
 )
-let _27_of_string s =
-  read__27 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_a08e9e5_of_string s =
+  read__x_a08e9e5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_even_natural = (
-  write__27
+  write__x_a08e9e5
 )
 let string_of_even_natural ?(len = 1024) x =
   let ob = Buffer.create len in
   write_even_natural ob x;
   Buffer.contents ob
 let read_even_natural = (
-  read__27
+  read__x_a08e9e5
 )
 let even_natural_of_string s =
   read_even_natural (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -5016,67 +5016,67 @@ let read_base = (
 )
 let base_of_string s =
   read_base (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__23 write__a = (
+let write__x_f9e3589 write__a = (
   Atdgen_runtime.Oj_run.write_array (
     write__a
   )
 )
-let string_of__23 write__a ?(len = 1024) x =
+let string_of__x_f9e3589 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__23 write__a ob x;
+  write__x_f9e3589 write__a ob x;
   Buffer.contents ob
-let read__23 read__a = (
+let read__x_f9e3589 read__a = (
   Atdgen_runtime.Oj_run.read_array (
     read__a
   )
 )
-let _23_of_string read__a s =
-  read__23 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_f9e3589_of_string read__a s =
+  read__x_f9e3589 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_array write__a = (
-  write__23 write__a
+  write__x_f9e3589 write__a
 )
 let string_of_array write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_array write__a ob x;
   Buffer.contents ob
 let read_array read__a = (
-  read__23 read__a
+  read__x_f9e3589 read__a
 )
 let array_of_string read__a s =
   read_array read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_abs3 write__a = (
-  write__19 write__a
+  write__a_list write__a
 )
 let string_of_abs3 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_abs3 write__a ob x;
   Buffer.contents ob
 let read_abs3 read__a = (
-  read__19 read__a
+  read__a_list read__a
 )
 let abs3_of_string read__a s =
   read_abs3 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_abs2 write__a = (
-  write__19 write__a
+  write__a_list write__a
 )
 let string_of_abs2 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_abs2 write__a ob x;
   Buffer.contents ob
 let read_abs2 read__a = (
-  read__19 read__a
+  read__a_list read__a
 )
 let abs2_of_string read__a s =
   read_abs2 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_abs1 write__a = (
-  write__19 write__a
+  write__a_list write__a
 )
 let string_of_abs1 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_abs1 write__a ob x;
   Buffer.contents ob
 let read_abs1 read__a = (
-  read__19 read__a
+  read__a_list read__a
 )
 let abs1_of_string read__a s =
   read_abs1 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/testjstd.expected.ml
+++ b/atdgen/test/testjstd.expected.ml
@@ -157,22 +157,22 @@ type 'a abs2 = 'a Test.abs2
 
 type 'a abs1 = 'a Test.abs1
 
-let write__19 write__a = (
+let write__a_list write__a = (
   Atdgen_runtime.Oj_run.write_list (
     write__a
   )
 )
-let string_of__19 write__a ?(len = 1024) x =
+let string_of__a_list write__a ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__19 write__a ob x;
+  write__a_list write__a ob x;
   Buffer.contents ob
-let read__19 read__a = (
+let read__a_list read__a = (
   Atdgen_runtime.Oj_run.read_list (
     read__a
   )
 )
-let _19_of_string read__a s =
-  read__19 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _a_list_of_string read__a s =
+  read__a_list read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_p' write__a : _ -> 'a p' -> _ = (
   fun ob x ->
     match x with
@@ -508,14 +508,234 @@ and read_r = (
 )
 and r_of_string s =
   read_r (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let rec write__20 write__a write__b ob x = (
+let rec write__test_variant_list ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_test_variant
+  )
+) ob x
+and string_of__test_variant_list ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__test_variant_list ob x;
+  Buffer.contents ob
+and write_test_variant = (
+  fun ob x ->
+    match x with
+      | `Case1 -> Buffer.add_string ob "\"Case1\""
+      | `Case2 x ->
+        Buffer.add_string ob "[\"Case2\",";
+        (
+          Yojson.Safe.write_int
+        ) ob x;
+        Buffer.add_char ob ']'
+      | `Case3 x ->
+        Buffer.add_string ob "[\"Case3\",";
+        (
+          Yojson.Safe.write_string
+        ) ob x;
+        Buffer.add_char ob ']'
+      | `Case4 x ->
+        Buffer.add_string ob "[\"Case4\",";
+        (
+          write__test_variant_list
+        ) ob x;
+        Buffer.add_char ob ']'
+)
+and string_of_test_variant ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_test_variant ob x;
+  Buffer.contents ob
+let rec read__test_variant_list p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_test_variant
+  )
+) p lb
+and _test_variant_list_of_string s =
+  read__test_variant_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read_test_variant = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "Case1" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case1
+            | "Case2" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case2 x
+            | "Case3" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case3 x
+            | "Case4" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__test_variant_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Case4 x
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "Case1" ->
+              `Case1
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Case2" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              `Case2 x
+            | "Case3" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              `Case3 x
+            | "Case4" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__test_variant_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              `Case4 x
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+and test_variant_of_string s =
+  read_test_variant (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let rec write__int_p : _ -> _ p' -> _ = (
+  fun ob x ->
+    match x with
+      | A -> Buffer.add_string ob "\"A\""
+      | Bb x ->
+        Buffer.add_string ob "[\"Bb\",";
+        (
+          write__int_p
+        ) ob x;
+        Buffer.add_char ob ']'
+      | Ccccc x ->
+        Buffer.add_string ob "[\"Ccccc\",";
+        (
+          Yojson.Safe.write_int
+        ) ob x;
+        Buffer.add_char ob ']'
+)
+and string_of__int_p ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__int_p ob x;
+  Buffer.contents ob
+let rec read__int_p = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "A" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (A : _ p')
+            | "Bb" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__int_p
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Bb x : _ p')
+            | "Ccccc" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Ccccc x : _ p')
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "A" ->
+              (A : _ p')
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Bb" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__int_p
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Bb x : _ p')
+            | "Ccccc" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Ccccc x : _ p')
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+and _int_p_of_string s =
+  read__int_p (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let rec write__a_b_poly_option write__a write__b ob x = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_poly write__a write__b
   )
 ) ob x
-and string_of__20 write__a write__b ?(len = 1024) x =
+and string_of__a_b_poly_option write__a write__b ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__20 write__a write__b ob x;
+  write__a_b_poly_option write__a write__b ob x;
   Buffer.contents ob
 and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
   fun ob (x : ('x, 'y) poly) ->
@@ -527,7 +747,7 @@ and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"fst\":";
     (
-      write__19 write__x
+      write__a_list write__x
     )
       ob x.fst;
     if !is_first then
@@ -536,7 +756,7 @@ and write_poly write__x write__y : _ -> ('x, 'y) poly -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"snd\":";
     (
-      write__20 write__x write__y
+      write__a_b_poly_option write__x write__y
     )
       ob x.snd;
     Buffer.add_char ob '}';
@@ -545,7 +765,7 @@ and string_of_poly write__x write__y ?(len = 1024) x =
   let ob = Buffer.create len in
   write_poly write__x write__y ob x;
   Buffer.contents ob
-let rec read__20 read__a read__b = (
+let rec read__a_b_poly_option read__a read__b = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -591,8 +811,8 @@ let rec read__20 read__a read__b = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _20_of_string read__a read__b s =
-  read__20 read__a read__b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and _a_b_poly_option_of_string read__a read__b s =
+  read__a_b_poly_option read__a read__b (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read_poly read__x read__y = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
@@ -641,7 +861,7 @@ and read_poly read__x read__y = (
             field_fst := (
               Some (
                 (
-                  read__19 read__x
+                  read__a_list read__x
                 ) p lb
               )
             );
@@ -649,7 +869,7 @@ and read_poly read__x read__y = (
             field_snd := (
               Some (
                 (
-                  read__20 read__x read__y
+                  read__a_b_poly_option read__x read__y
                 ) p lb
               )
             );
@@ -699,7 +919,7 @@ and read_poly read__x read__y = (
               field_fst := (
                 Some (
                   (
-                    read__19 read__x
+                    read__a_list read__x
                   ) p lb
                 )
               );
@@ -707,7 +927,7 @@ and read_poly read__x read__y = (
               field_snd := (
                 Some (
                   (
-                    read__20 read__x read__y
+                    read__a_b_poly_option read__x read__y
                   ) p lb
                 )
               );
@@ -728,226 +948,6 @@ and read_poly read__x read__y = (
 )
 and poly_of_string read__x read__y s =
   read_poly read__x read__y (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let rec write__2 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_test_variant
-  )
-) ob x
-and string_of__2 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__2 ob x;
-  Buffer.contents ob
-and write_test_variant = (
-  fun ob x ->
-    match x with
-      | `Case1 -> Buffer.add_string ob "\"Case1\""
-      | `Case2 x ->
-        Buffer.add_string ob "[\"Case2\",";
-        (
-          Yojson.Safe.write_int
-        ) ob x;
-        Buffer.add_char ob ']'
-      | `Case3 x ->
-        Buffer.add_string ob "[\"Case3\",";
-        (
-          Yojson.Safe.write_string
-        ) ob x;
-        Buffer.add_char ob ']'
-      | `Case4 x ->
-        Buffer.add_string ob "[\"Case4\",";
-        (
-          write__2
-        ) ob x;
-        Buffer.add_char ob ']'
-)
-and string_of_test_variant ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write_test_variant ob x;
-  Buffer.contents ob
-let rec read__2 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_test_variant
-  )
-) p lb
-and _2_of_string s =
-  read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read_test_variant = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "Case1" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case1
-            | "Case2" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case2 x
-            | "Case3" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case3 x
-            | "Case4" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read__2
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              `Case4 x
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "Case1" ->
-              `Case1
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Case2" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              `Case2 x
-            | "Case3" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              `Case3 x
-            | "Case4" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read__2
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              `Case4 x
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-and test_variant_of_string s =
-  read_test_variant (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let rec write__1 : _ -> _ p' -> _ = (
-  fun ob x ->
-    match x with
-      | A -> Buffer.add_string ob "\"A\""
-      | Bb x ->
-        Buffer.add_string ob "[\"Bb\",";
-        (
-          write__1
-        ) ob x;
-        Buffer.add_char ob ']'
-      | Ccccc x ->
-        Buffer.add_string ob "[\"Ccccc\",";
-        (
-          Yojson.Safe.write_int
-        ) ob x;
-        Buffer.add_char ob ']'
-)
-and string_of__1 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__1 ob x;
-  Buffer.contents ob
-let rec read__1 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "A" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (A : _ p')
-            | "Bb" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read__1
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Bb x : _ p')
-            | "Ccccc" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Ccccc x : _ p')
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "A" ->
-              (A : _ p')
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Bb" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read__1
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Bb x : _ p')
-            | "Ccccc" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Ccccc x : _ p')
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-and _1_of_string s =
-  read__1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_validated_string_check = (
   Yojson.Safe.write_string
 )
@@ -960,31 +960,31 @@ let read_validated_string_check = (
 )
 let validated_string_check_of_string s =
   read_validated_string_check (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__31 = (
+let write__x_5640b64 = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string
   )
 )
-let string_of__31 ?(len = 1024) x =
+let string_of__x_5640b64 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__31 ob x;
+  write__x_5640b64 ob x;
   Buffer.contents ob
-let read__31 = (
+let read__x_5640b64 = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_string
   )
 )
-let _31_of_string s =
-  read__31 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_5640b64_of_string s =
+  read__x_5640b64 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_validate_me = (
-  write__31
+  write__x_5640b64
 )
 let string_of_validate_me ?(len = 1024) x =
   let ob = Buffer.create len in
   write_validate_me ob x;
   Buffer.contents ob
 let read_validate_me = (
-  read__31
+  read__x_5640b64
 )
 let validate_me_of_string s =
   read_validate_me (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -1086,16 +1086,16 @@ let read_val1 = (
 )
 let val1_of_string s =
   read_val1 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__16 = (
+let write__val1_option = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_val1
   )
 )
-let string_of__16 ?(len = 1024) x =
+let string_of__val1_option ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__16 ob x;
+  write__val1_option ob x;
   Buffer.contents ob
-let read__16 = (
+let read__val1_option = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -1141,8 +1141,8 @@ let read__16 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _16_of_string s =
-  read__16 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _val1_option_of_string s =
+  read__val1_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_val2 : _ -> val2 -> _ = (
   fun ob (x : val2) ->
     Buffer.add_char ob '{';
@@ -1292,44 +1292,44 @@ let read_val2 = (
 )
 let val2_of_string s =
   read_val2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__29 = (
+let write__x_6089809 = (
   Atdgen_runtime.Oj_run.write_list (
     Atdgen_runtime.Oj_run.write_float_as_int
   )
 )
-let string_of__29 ?(len = 1024) x =
+let string_of__x_6089809 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__29 ob x;
+  write__x_6089809 ob x;
   Buffer.contents ob
-let read__29 = (
+let read__x_6089809 = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_number
   )
 )
-let _29_of_string s =
-  read__29 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_6089809_of_string s =
+  read__x_6089809 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_unixtime_list = (
-  write__29
+  write__x_6089809
 )
 let string_of_unixtime_list ?(len = 1024) x =
   let ob = Buffer.create len in
   write_unixtime_list ob x;
   Buffer.contents ob
 let read_unixtime_list = (
-  read__29
+  read__x_6089809
 )
 let unixtime_list_of_string s =
   read_unixtime_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__3 = (
+let write__int_nullable = (
   Atdgen_runtime.Oj_run.write_nullable (
     Yojson.Safe.write_int
   )
 )
-let string_of__3 ?(len = 1024) x =
+let string_of__int_nullable ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__3 ob x;
+  write__int_nullable ob x;
   Buffer.contents ob
-let read__3 = (
+let read__int_nullable = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     (if Yojson.Safe.read_null_if_possible p lb then None
@@ -1337,8 +1337,8 @@ let read__3 = (
       Atdgen_runtime.Oj_run.read_int
     ) p lb) : _ option)
 )
-let _3_of_string s =
-  read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _int_nullable_of_string s =
+  read__int_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_date = (
   fun ob x ->
     Buffer.add_char ob '[';
@@ -1350,13 +1350,13 @@ let write_date = (
     Buffer.add_char ob ',';
     (let _, x, _ = x in
     (
-      write__3
+      write__int_nullable
     ) ob x
     );
     Buffer.add_char ob ',';
     (let _, _, x = x in
     (
-      write__3
+      write__int_nullable
     ) ob x
     );
     Buffer.add_char ob ']';
@@ -1386,7 +1386,7 @@ let read_date = (
       let x1 =
         let x =
           (
-            read__3
+            read__int_nullable
           ) p lb
         in
         incr len;
@@ -1397,7 +1397,7 @@ let read_date = (
       let x2 =
         let x =
           (
-            read__3
+            read__int_nullable
           ) p lb
         in
         incr len;
@@ -1422,298 +1422,298 @@ let read_date = (
 )
 let date_of_string s =
   read_date (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__9 = (
-  Atdgen_runtime.Oj_run.write_array (
-    Yojson.Safe.write_string
-  )
-)
-let string_of__9 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__9 ob x;
-  Buffer.contents ob
-let read__9 = (
-  Atdgen_runtime.Oj_run.read_array (
-    Atdgen_runtime.Oj_run.read_string
-  )
-)
-let _9_of_string s =
-  read__9 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__8 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    Yojson.Safe.write_bool
-  )
-)
-let string_of__8 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__8 ob x;
-  Buffer.contents ob
-let read__8 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_bool
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _8_of_string s =
-  read__8 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__7 = (
+let write__x_adbef7e = (
   Atdgen_runtime.Oj_run.write_array (
     Yojson.Safe.write_std_float
   )
 )
-let string_of__7 ?(len = 1024) x =
+let string_of__x_adbef7e ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__7 ob x;
+  write__x_adbef7e ob x;
   Buffer.contents ob
-let read__7 = (
+let read__x_adbef7e = (
   Atdgen_runtime.Oj_run.read_array (
     Atdgen_runtime.Oj_run.read_number
   )
 )
-let _7_of_string s =
-  read__7 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__6 = (
-  Atdgen_runtime.Oj_run.write_std_option (
+let _x_adbef7e_of_string s =
+  read__x_adbef7e (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_20d39e2 = (
+  Atdgen_runtime.Oj_run.write_array (
     Yojson.Safe.write_string
   )
 )
-let string_of__6 ?(len = 1024) x =
+let string_of__x_20d39e2 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__6 ob x;
+  write__x_20d39e2 ob x;
   Buffer.contents ob
-let read__6 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _6_of_string s =
-  read__6 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__5 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    Yojson.Safe.write_std_float
+let read__x_20d39e2 = (
+  Atdgen_runtime.Oj_run.read_array (
+    Atdgen_runtime.Oj_run.read_string
   )
 )
-let string_of__5 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__5 ob x;
-  Buffer.contents ob
-let read__5 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_number
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _5_of_string s =
-  read__5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__4 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    Yojson.Safe.write_int
-  )
-)
-let string_of__4 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__4 ob x;
-  Buffer.contents ob
-let read__4 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _4_of_string s =
-  read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__11 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write__6
-  )
-)
-let string_of__11 ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__11 ob x;
-  Buffer.contents ob
-let read__11 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read__6
-  )
-)
-let _11_of_string s =
-  read__11 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__10 = (
+let _x_20d39e2_of_string s =
+  read__x_20d39e2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__unit_list = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_null
   )
 )
-let string_of__10 ?(len = 1024) x =
+let string_of__unit_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__10 ob x;
+  write__unit_list ob x;
   Buffer.contents ob
-let read__10 = (
+let read__unit_list = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_null
   )
 )
-let _10_of_string s =
-  read__10 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _unit_list_of_string s =
+  read__unit_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__string_option = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    Yojson.Safe.write_string
+  )
+)
+let string_of__string_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__string_option ob x;
+  Buffer.contents ob
+let read__string_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _string_option_of_string s =
+  read__string_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__string_option_list = (
+  Atdgen_runtime.Oj_run.write_list (
+    write__string_option
+  )
+)
+let string_of__string_option_list ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__string_option_list ob x;
+  Buffer.contents ob
+let read__string_option_list = (
+  Atdgen_runtime.Oj_run.read_list (
+    read__string_option
+  )
+)
+let _string_option_list_of_string s =
+  read__string_option_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__int_option = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    Yojson.Safe.write_int
+  )
+)
+let string_of__int_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__int_option ob x;
+  Buffer.contents ob
+let read__int_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _int_option_of_string s =
+  read__int_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__float_option = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    Yojson.Safe.write_std_float
+  )
+)
+let string_of__float_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__float_option ob x;
+  Buffer.contents ob
+let read__float_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _float_option_of_string s =
+  read__float_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__bool_option = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    Yojson.Safe.write_bool
+  )
+)
+let string_of__bool_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__bool_option ob x;
+  Buffer.contents ob
+let read__bool_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _bool_option_of_string s =
+  read__bool_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_mixed_record : _ -> mixed_record -> _ = (
   fun ob (x : mixed_record) ->
     Buffer.add_char ob '{';
@@ -1746,7 +1746,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field2\":";
     (
-      write__6
+      write__string_option
     )
       ob x.field2;
     if !is_first then
@@ -1764,7 +1764,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field4\":";
     (
-      write__7
+      write__x_adbef7e
     )
       ob x.field4;
     (match x.field5 with None -> () | Some x ->
@@ -1804,7 +1804,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field8\":";
     (
-      write__9
+      write__x_20d39e2
     )
       ob x.field8;
     if !is_first then
@@ -1879,7 +1879,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field12\":";
     (
-      write__10
+      write__unit_list
     )
       ob x.field12;
     if !is_first then
@@ -1888,7 +1888,7 @@ let write_mixed_record : _ -> mixed_record -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"field13\":";
     (
-      write__11
+      write__string_option_list
     )
       ob x.field13;
     if !is_first then
@@ -2033,7 +2033,7 @@ let read_mixed_record = (
             field_field2 := (
               Some (
                 (
-                  read__6
+                  read__string_option
                 ) p lb
               )
             );
@@ -2049,7 +2049,7 @@ let read_mixed_record = (
             field_field4 := (
               Some (
                 (
-                  read__7
+                  read__x_adbef7e
                 ) p lb
               )
             );
@@ -2085,7 +2085,7 @@ let read_mixed_record = (
             field_field8 := (
               Some (
                 (
-                  read__9
+                  read__x_20d39e2
                 ) p lb
               )
             );
@@ -2202,7 +2202,7 @@ let read_mixed_record = (
             field_field12 := (
               Some (
                 (
-                  read__10
+                  read__unit_list
                 ) p lb
               )
             );
@@ -2210,7 +2210,7 @@ let read_mixed_record = (
             field_field13 := (
               Some (
                 (
-                  read__11
+                  read__string_option_list
                 ) p lb
               )
             );
@@ -2334,7 +2334,7 @@ let read_mixed_record = (
               field_field2 := (
                 Some (
                   (
-                    read__6
+                    read__string_option
                   ) p lb
                 )
               );
@@ -2350,7 +2350,7 @@ let read_mixed_record = (
               field_field4 := (
                 Some (
                   (
-                    read__7
+                    read__x_adbef7e
                   ) p lb
                 )
               );
@@ -2386,7 +2386,7 @@ let read_mixed_record = (
               field_field8 := (
                 Some (
                   (
-                    read__9
+                    read__x_20d39e2
                   ) p lb
                 )
               );
@@ -2503,7 +2503,7 @@ let read_mixed_record = (
               field_field12 := (
                 Some (
                   (
-                    read__10
+                    read__unit_list
                   ) p lb
                 )
               );
@@ -2511,7 +2511,7 @@ let read_mixed_record = (
               field_field13 := (
                 Some (
                   (
-                    read__11
+                    read__string_option_list
                   ) p lb
                 )
               );
@@ -2553,61 +2553,61 @@ let read_mixed_record = (
 )
 let mixed_record_of_string s =
   read_mixed_record (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__13 = (
+let write__x_d88f1c8 = (
   Atdgen_runtime.Oj_run.write_array (
     write_mixed_record
   )
 )
-let string_of__13 ?(len = 1024) x =
+let string_of__x_d88f1c8 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__13 ob x;
+  write__x_d88f1c8 ob x;
   Buffer.contents ob
-let read__13 = (
+let read__x_d88f1c8 = (
   Atdgen_runtime.Oj_run.read_array (
     read_mixed_record
   )
 )
-let _13_of_string s =
-  read__13 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__12 = (
+let _x_d88f1c8_of_string s =
+  read__x_d88f1c8 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_7de077c = (
   Atdgen_runtime.Oj_run.write_array (
     write_mixed_record
   )
 )
-let string_of__12 ?(len = 1024) x =
+let string_of__x_7de077c ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__12 ob x;
+  write__x_7de077c ob x;
   Buffer.contents ob
-let read__12 = (
+let read__x_7de077c = (
   Atdgen_runtime.Oj_run.read_array (
     read_mixed_record
   )
 )
-let _12_of_string s =
-  read__12 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__14 = (
+let _x_7de077c_of_string s =
+  read__x_7de077c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_c393fa9 = (
   Atdgen_runtime.Oj_run.write_list (
     fun ob x ->
       Buffer.add_char ob '[';
       (let x, _ = x in
       (
-        write__12
+        write__x_d88f1c8
       ) ob x
       );
       Buffer.add_char ob ',';
       (let _, x = x in
       (
-        write__13
+        write__x_7de077c
       ) ob x
       );
       Buffer.add_char ob ']';
   )
 )
-let string_of__14 ?(len = 1024) x =
+let string_of__x_c393fa9 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__14 ob x;
+  write__x_c393fa9 ob x;
   Buffer.contents ob
-let read__14 = (
+let read__x_c393fa9 = (
   Atdgen_runtime.Oj_run.read_list (
     fun p lb ->
       Yojson.Safe.read_space p lb;
@@ -2618,7 +2618,7 @@ let read__14 = (
         let x0 =
           let x =
             (
-              read__12
+              read__x_d88f1c8
             ) p lb
           in
           incr len;
@@ -2629,7 +2629,7 @@ let read__14 = (
         let x1 =
           let x =
             (
-              read__13
+              read__x_7de077c
             ) p lb
           in
           incr len;
@@ -2653,36 +2653,36 @@ let read__14 = (
         Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
   )
 )
-let _14_of_string s =
-  read__14 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_c393fa9_of_string s =
+  read__x_c393fa9 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_mixed = (
-  write__14
+  write__x_c393fa9
 )
 let string_of_mixed ?(len = 1024) x =
   let ob = Buffer.create len in
   write_mixed ob x;
   Buffer.contents ob
 let read_mixed = (
-  read__14
+  read__x_c393fa9
 )
 let mixed_of_string s =
   read_mixed (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__15 = (
+let write__mixed_record_list = (
   Atdgen_runtime.Oj_run.write_list (
     write_mixed_record
   )
 )
-let string_of__15 ?(len = 1024) x =
+let string_of__mixed_record_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__15 ob x;
+  write__mixed_record_list ob x;
   Buffer.contents ob
-let read__15 = (
+let read__mixed_record_list = (
   Atdgen_runtime.Oj_run.read_list (
     read_mixed_record
   )
 )
-let _15_of_string s =
-  read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _mixed_record_list_of_string s =
+  read__mixed_record_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_test : _ -> test -> _ = (
   fun ob (x : test) ->
     Buffer.add_char ob '{';
@@ -2724,7 +2724,7 @@ let write_test : _ -> test -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"x3\":";
     (
-      write__15
+      write__mixed_record_list
     )
       ob x.x3;
     if !is_first then
@@ -2820,7 +2820,7 @@ let read_test = (
             field_x3 := (
               Some (
                 (
-                  read__15
+                  read__mixed_record_list
                 ) p lb
               )
             );
@@ -2905,7 +2905,7 @@ let read_test = (
               field_x3 := (
                 Some (
                   (
-                    read__15
+                    read__mixed_record_list
                   ) p lb
                 )
               );
@@ -3178,7 +3178,7 @@ let read_star_rating = (
 )
 let star_rating_of_string s =
   read_star_rating (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__30 : _ -> _ generic -> _ = (
+let write__string_generic : _ -> _ generic -> _ = (
   fun ob (x : _ generic) ->
     Buffer.add_char ob '{';
     let is_first = ref true in
@@ -3193,11 +3193,11 @@ let write__30 : _ -> _ generic -> _ = (
       ob x.x294623;
     Buffer.add_char ob '}';
 )
-let string_of__30 ?(len = 1024) x =
+let string_of__string_generic ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__30 ob x;
+  write__string_generic ob x;
   Buffer.contents ob
-let read__30 = (
+let read__string_generic = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
@@ -3274,17 +3274,17 @@ let read__30 = (
          : _ generic)
       )
 )
-let _30_of_string s =
-  read__30 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _string_generic_of_string s =
+  read__string_generic (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_specialized = (
-  write__30
+  write__string_generic
 )
 let string_of_specialized ?(len = 1024) x =
   let ob = Buffer.create len in
   write_specialized ob x;
   Buffer.contents ob
 let read_specialized = (
-  read__30
+  read__string_generic
 )
 let specialized_of_string s =
   read_specialized (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -3605,27 +3605,27 @@ let read_precision = (
 let precision_of_string s =
   read_precision (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_p'' = (
-  write__1
+  write__int_p
 )
 let string_of_p'' ?(len = 1024) x =
   let ob = Buffer.create len in
   write_p'' ob x;
   Buffer.contents ob
 let read_p'' = (
-  read__1
+  read__int_p
 )
 let p''_of_string s =
   read_p'' (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__18 = (
+let write__x_bee1b88 = (
   Atdgen_runtime.Oj_run.write_std_option (
     Yojson.Safe.write_int
   )
 )
-let string_of__18 ?(len = 1024) x =
+let string_of__x_bee1b88 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__18 ob x;
+  write__x_bee1b88 ob x;
   Buffer.contents ob
-let read__18 = (
+let read__x_bee1b88 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -3671,211 +3671,211 @@ let read__18 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _18_of_string s =
-  read__18 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_bee1b88_of_string s =
+  read__x_bee1b88 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_option_validation = (
-  write__18
+  write__x_bee1b88
 )
 let string_of_option_validation ?(len = 1024) x =
   let ob = Buffer.create len in
   write_option_validation ob x;
   Buffer.contents ob
 let read_option_validation = (
-  read__18
+  read__x_bee1b88
 )
 let option_validation_of_string s =
   read_option_validation (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__28 = (
+let write__some_record_wrap = (
   write_some_record
 )
-let string_of__28 ?(len = 1024) x =
+let string_of__some_record_wrap ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__28 ob x;
+  write__some_record_wrap ob x;
   Buffer.contents ob
-let read__28 = (
+let read__some_record_wrap = (
   read_some_record
 )
-let _28_of_string s =
-  read__28 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _some_record_wrap_of_string s =
+  read__some_record_wrap (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_no_real_wrap = (
-  write__28
+  write__some_record_wrap
 )
 let string_of_no_real_wrap ?(len = 1024) x =
   let ob = Buffer.create len in
   write_no_real_wrap ob x;
   Buffer.contents ob
 let read_no_real_wrap = (
-  read__28
+  read__some_record_wrap
 )
 let no_real_wrap_of_string s =
   read_no_real_wrap (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__26 = (
+let write__x_e48509c = (
   fun ob x -> (
     let x = ( Test_lib.Natural.unwrap ) x in (
       Yojson.Safe.write_int
     ) ob x)
 )
-let string_of__26 ?(len = 1024) x =
+let string_of__x_e48509c ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__26 ob x;
+  write__x_e48509c ob x;
   Buffer.contents ob
-let read__26 = (
+let read__x_e48509c = (
   fun p lb ->
     let x = (
       Atdgen_runtime.Oj_run.read_int
     ) p lb in
     ( Test_lib.Natural.wrap ) x
 )
-let _26_of_string s =
-  read__26 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_e48509c_of_string s =
+  read__x_e48509c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_natural = (
-  write__26
+  write__x_e48509c
 )
 let string_of_natural ?(len = 1024) x =
   let ob = Buffer.create len in
   write_natural ob x;
   Buffer.contents ob
 let read_natural = (
-  read__26
+  read__x_e48509c
 )
 let natural_of_string s =
   read_natural (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__24 = (
+let write__x_2596d76 = (
   fun ob x -> (
     let x = ( function `Id s -> s ) x in (
       Yojson.Safe.write_string
     ) ob x)
 )
-let string_of__24 ?(len = 1024) x =
+let string_of__x_2596d76 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__24 ob x;
+  write__x_2596d76 ob x;
   Buffer.contents ob
-let read__24 = (
+let read__x_2596d76 = (
   fun p lb ->
     let x = (
       Atdgen_runtime.Oj_run.read_string
     ) p lb in
     ( fun s -> `Id s ) x
 )
-let _24_of_string s =
-  read__24 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_2596d76_of_string s =
+  read__x_2596d76 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_id = (
-  write__24
+  write__x_2596d76
 )
 let string_of_id ?(len = 1024) x =
   let ob = Buffer.create len in
   write_id ob x;
   Buffer.contents ob
 let read_id = (
-  read__24
+  read__x_2596d76
 )
 let id_of_string s =
   read_id (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__25 = (
+let write__x_b6e4b4c = (
   Atdgen_runtime.Oj_run.write_assoc_list (
     write_id
   ) (
     Yojson.Safe.write_int
   )
 )
-let string_of__25 ?(len = 1024) x =
+let string_of__x_b6e4b4c ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__25 ob x;
+  write__x_b6e4b4c ob x;
   Buffer.contents ob
-let read__25 = (
+let read__x_b6e4b4c = (
   Atdgen_runtime.Oj_run.read_assoc_list (
     read_id
   ) (
     Atdgen_runtime.Oj_run.read_int
   )
 )
-let _25_of_string s =
-  read__25 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_b6e4b4c_of_string s =
+  read__x_b6e4b4c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_json_map = (
-  write__25
+  write__x_b6e4b4c
 )
 let string_of_json_map ?(len = 1024) x =
   let ob = Buffer.create len in
   write_json_map ob x;
   Buffer.contents ob
 let read_json_map = (
-  read__25
+  read__x_b6e4b4c
 )
 let json_map_of_string s =
   read_json_map (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_intopt = (
-  write__4
+  write__int_option
 )
 let string_of_intopt ?(len = 1024) x =
   let ob = Buffer.create len in
   write_intopt ob x;
   Buffer.contents ob
 let read_intopt = (
-  read__4
+  read__int_option
 )
 let intopt_of_string s =
   read_intopt (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__21 = (
+let write__x_547263f = (
   Atdgen_runtime.Oj_run.write_assoc_list (
     Yojson.Safe.write_string
   ) (
     Yojson.Safe.write_int
   )
 )
-let string_of__21 ?(len = 1024) x =
+let string_of__x_547263f ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__21 ob x;
+  write__x_547263f ob x;
   Buffer.contents ob
-let read__21 = (
+let read__x_547263f = (
   Atdgen_runtime.Oj_run.read_assoc_list (
     Atdgen_runtime.Oj_run.read_string
   ) (
     Atdgen_runtime.Oj_run.read_int
   )
 )
-let _21_of_string s =
-  read__21 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_547263f_of_string s =
+  read__x_547263f (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_int_assoc_list = (
-  write__21
+  write__x_547263f
 )
 let string_of_int_assoc_list ?(len = 1024) x =
   let ob = Buffer.create len in
   write_int_assoc_list ob x;
   Buffer.contents ob
 let read_int_assoc_list = (
-  read__21
+  read__x_547263f
 )
 let int_assoc_list_of_string s =
   read_int_assoc_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__22 = (
+let write__x_0a94e5e = (
   Atdgen_runtime.Oj_run.write_assoc_array (
     Yojson.Safe.write_string
   ) (
     Yojson.Safe.write_int
   )
 )
-let string_of__22 ?(len = 1024) x =
+let string_of__x_0a94e5e ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__22 ob x;
+  write__x_0a94e5e ob x;
   Buffer.contents ob
-let read__22 = (
+let read__x_0a94e5e = (
   Atdgen_runtime.Oj_run.read_assoc_array (
     Atdgen_runtime.Oj_run.read_string
   ) (
     Atdgen_runtime.Oj_run.read_int
   )
 )
-let _22_of_string s =
-  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_0a94e5e_of_string s =
+  read__x_0a94e5e (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_int_assoc_array = (
-  write__22
+  write__x_0a94e5e
 )
 let string_of_int_assoc_array ?(len = 1024) x =
   let ob = Buffer.create len in
   write_int_assoc_array ob x;
   Buffer.contents ob
 let read_int_assoc_array = (
-  read__22
+  read__x_0a94e5e
 )
 let int_assoc_array_of_string s =
   read_int_assoc_array (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -4239,22 +4239,22 @@ let read_floats = (
 )
 let floats_of_string s =
   read_floats (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__17 = (
+let write__string_list = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string
   )
 )
-let string_of__17 ?(len = 1024) x =
+let string_of__string_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__17 ob x;
+  write__string_list ob x;
   Buffer.contents ob
-let read__17 = (
+let read__string_list = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_string
   )
 )
-let _17_of_string s =
-  read__17 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _string_list_of_string s =
+  read__string_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_extended_tuple = (
   fun ob x ->
     Buffer.add_char ob '[';
@@ -4278,7 +4278,7 @@ let write_extended_tuple = (
     Buffer.add_char ob ',';
     (let _, _, _, x, _, _ = x in
     (
-      write__4
+      write__int_option
     ) ob x
     );
     Buffer.add_char ob ',';
@@ -4290,7 +4290,7 @@ let write_extended_tuple = (
     Buffer.add_char ob ',';
     (let _, _, _, _, _, x = x in
     (
-      write__17
+      write__string_list
     ) ob x
     );
     Buffer.add_char ob ']';
@@ -4342,7 +4342,7 @@ let read_extended_tuple = (
       let x3 =
         let x =
           (
-            read__4
+            read__int_option
           ) p lb
         in
         incr len;
@@ -4368,7 +4368,7 @@ let read_extended_tuple = (
         else (
           let x = (
             (
-              read__17
+              read__string_list
             ) p lb
           ) in
           incr len;
@@ -4443,7 +4443,7 @@ let write_extended : _ -> extended -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"b4\":";
     (
-      write__6
+      write__string_option
     )
       ob x.b4x;
     if x.b5x <> 0.5 then (
@@ -4551,7 +4551,7 @@ let read_extended = (
             field_b4x := (
               Some (
                 (
-                  read__6
+                  read__string_option
                 ) p lb
               )
             );
@@ -4645,7 +4645,7 @@ let read_extended = (
               field_b4x := (
                 Some (
                   (
-                    read__6
+                    read__string_option
                   ) p lb
                 )
               );
@@ -4678,34 +4678,34 @@ let read_extended = (
 )
 let extended_of_string s =
   read_extended (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__27 = (
+let write__x_a08e9e5 = (
   fun ob x -> (
     let x = ( Test_lib.Even_natural.unwrap ) x in (
       write_natural
     ) ob x)
 )
-let string_of__27 ?(len = 1024) x =
+let string_of__x_a08e9e5 ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__27 ob x;
+  write__x_a08e9e5 ob x;
   Buffer.contents ob
-let read__27 = (
+let read__x_a08e9e5 = (
   fun p lb ->
     let x = (
       read_natural
     ) p lb in
     ( Test_lib.Even_natural.wrap ) x
 )
-let _27_of_string s =
-  read__27 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_a08e9e5_of_string s =
+  read__x_a08e9e5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_even_natural = (
-  write__27
+  write__x_a08e9e5
 )
 let string_of_even_natural ?(len = 1024) x =
   let ob = Buffer.create len in
   write_even_natural ob x;
   Buffer.contents ob
 let read_even_natural = (
-  read__27
+  read__x_a08e9e5
 )
 let even_natural_of_string s =
   read_even_natural (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -4942,67 +4942,67 @@ let read_base = (
 )
 let base_of_string s =
   read_base (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__23 write__a = (
+let write__x_f9e3589 write__a = (
   Atdgen_runtime.Oj_run.write_array (
     write__a
   )
 )
-let string_of__23 write__a ?(len = 1024) x =
+let string_of__x_f9e3589 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__23 write__a ob x;
+  write__x_f9e3589 write__a ob x;
   Buffer.contents ob
-let read__23 read__a = (
+let read__x_f9e3589 read__a = (
   Atdgen_runtime.Oj_run.read_array (
     read__a
   )
 )
-let _23_of_string read__a s =
-  read__23 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _x_f9e3589_of_string read__a s =
+  read__x_f9e3589 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_array write__a = (
-  write__23 write__a
+  write__x_f9e3589 write__a
 )
 let string_of_array write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_array write__a ob x;
   Buffer.contents ob
 let read_array read__a = (
-  read__23 read__a
+  read__x_f9e3589 read__a
 )
 let array_of_string read__a s =
   read_array read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_abs3 write__a = (
-  write__19 write__a
+  write__a_list write__a
 )
 let string_of_abs3 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_abs3 write__a ob x;
   Buffer.contents ob
 let read_abs3 read__a = (
-  read__19 read__a
+  read__a_list read__a
 )
 let abs3_of_string read__a s =
   read_abs3 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_abs2 write__a = (
-  write__19 write__a
+  write__a_list write__a
 )
 let string_of_abs2 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_abs2 write__a ob x;
   Buffer.contents ob
 let read_abs2 read__a = (
-  read__19 read__a
+  read__a_list read__a
 )
 let abs2_of_string read__a s =
   read_abs2 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_abs1 write__a = (
-  write__19 write__a
+  write__a_list write__a
 )
 let string_of_abs1 write__a ?(len = 1024) x =
   let ob = Buffer.create len in
   write_abs1 write__a ob x;
   Buffer.contents ob
 let read_abs1 read__a = (
-  read__19 read__a
+  read__a_list read__a
 )
 let abs1_of_string read__a s =
   read_abs1 read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/atdgen/test/testv.expected.ml
+++ b/atdgen/test/testv.expected.ml
@@ -157,7 +157,7 @@ type 'a abs2 = 'a Test.abs2
 
 type 'a abs1 = 'a Test.abs1
 
-let validate__19 validate__a = (
+let validate__a_list validate__a = (
   Atdgen_runtime.Ov_run.validate_list (
     validate__a
   )
@@ -204,7 +204,16 @@ and validate_r : _ -> r -> _ = (
           validate_p
         ) (`Field "c" :: path) x.c
 )
-let rec validate__20 validate__a validate__b path x = (
+let rec validate__test_variant_list path x = (
+  fun _ _ -> None
+) path x
+and validate_test_variant path x = (
+  fun _ _ -> None
+) path x
+let rec validate__int_p path (x : _ p') = (
+  fun _ _ -> None
+) path x
+let rec validate__a_b_poly_option validate__a validate__b path x = (
   Atdgen_runtime.Ov_run.validate_option (
     validate_poly validate__a validate__b
   )
@@ -213,24 +222,15 @@ and validate_poly validate__x validate__y : _ -> ('x, 'y) poly -> _ = (
   fun path x ->
     match
       (
-        validate__19 validate__x
+        validate__a_list validate__x
       ) (`Field "fst" :: path) x.fst
     with
       | Some _ as err -> err
       | None ->
         (
-          validate__20 validate__x validate__y
+          validate__a_b_poly_option validate__x validate__y
         ) (`Field "snd" :: path) x.snd
 )
-let rec validate__2 path x = (
-  fun _ _ -> None
-) path x
-and validate_test_variant path x = (
-  fun _ _ -> None
-) path x
-let rec validate__1 path (x : _ p') = (
-  fun _ _ -> None
-) path x
 let validate_validated_string_check = (
   fun path x ->
     let msg = "Failed check by fun s -> s = \"abc\"" in
@@ -239,7 +239,7 @@ let validate_validated_string_check = (
     else
       Some (Atdgen_runtime.Util.Validation.error ~msg path)
 )
-let validate__31 = (
+let validate__x_5640b64 = (
   (fun path x ->
     (match ( fun path x ->
     let msg = "Failed check by fun l -> true" in
@@ -262,7 +262,7 @@ let validate__31 = (
   )
 )
 let validate_validate_me = (
-  validate__31
+  validate__x_5640b64
 )
 let validate_val1 : _ -> val1 -> _ = (
   fun path x ->
@@ -270,7 +270,7 @@ let validate_val1 : _ -> val1 -> _ = (
       fun path _ -> Some (Atdgen_runtime.Util.Validation.error path)
     ) (`Field "val1_x" :: path) x.val1_x
 )
-let validate__16 = (
+let validate__val1_option = (
   Atdgen_runtime.Ov_run.validate_option (
     validate_val1
   )
@@ -285,61 +285,61 @@ let validate_val2 : _ -> val2 -> _ = (
       | Some _ as err -> err
       | None ->
         (
-          validate__16
+          validate__val1_option
         ) (`Field "val2_y" :: path) x.val2_y
 )
-let validate__29 = (
+let validate__x_6089809 = (
   fun _ _ -> None
 )
 let validate_unixtime_list = (
-  validate__29
+  validate__x_6089809
 )
-let validate__3 = (
+let validate__int_nullable = (
   fun _ _ -> None
 )
 let validate_date = (
   fun _ _ -> None
 )
-let validate__9 = (
+let validate__x_adbef7e = (
   fun _ _ -> None
 )
-let validate__8 = (
+let validate__x_20d39e2 = (
   fun _ _ -> None
 )
-let validate__7 = (
+let validate__unit_list = (
   fun _ _ -> None
 )
-let validate__6 = (
+let validate__string_option = (
   fun _ _ -> None
 )
-let validate__5 = (
+let validate__string_option_list = (
   fun _ _ -> None
 )
-let validate__4 = (
+let validate__int_option = (
   fun _ _ -> None
 )
-let validate__11 = (
+let validate__float_option = (
   fun _ _ -> None
 )
-let validate__10 = (
+let validate__bool_option = (
   fun _ _ -> None
 )
 let validate_mixed_record : _ -> mixed_record -> _ = (
   fun _ _ -> None
 )
-let validate__13 = (
+let validate__x_d88f1c8 = (
   fun _ _ -> None
 )
-let validate__12 = (
+let validate__x_7de077c = (
   fun _ _ -> None
 )
-let validate__14 = (
+let validate__x_c393fa9 = (
   fun _ _ -> None
 )
 let validate_mixed = (
-  validate__14
+  validate__x_c393fa9
 )
-let validate__15 = (
+let validate__mixed_record_list = (
   fun _ _ -> None
 )
 let validate_test : _ -> test -> _ = (
@@ -359,11 +359,11 @@ let validate_star_rating = (
     else
       Some (Atdgen_runtime.Util.Validation.error ~msg path)
 )
-let validate__30 : _ -> _ generic -> _ = (
+let validate__string_generic : _ -> _ generic -> _ = (
   fun _ _ -> None
 )
 let validate_specialized = (
-  validate__30
+  validate__string_generic
 )
 let validate_some_record : _ -> some_record -> _ = (
   fun path x ->
@@ -375,38 +375,38 @@ let validate_precision : _ -> precision -> _ = (
   fun _ _ -> None
 )
 let validate_p'' = (
-  validate__1
+  validate__int_p
 )
-let validate__18 = (
+let validate__x_bee1b88 = (
   Atdgen_runtime.Ov_run.validate_option (
     fun path _ -> Some (Atdgen_runtime.Util.Validation.error path)
   )
 )
 let validate_option_validation = (
-  validate__18
+  validate__x_bee1b88
 )
-let validate__28 = (
+let validate__some_record_wrap = (
   validate_some_record
 )
 let validate_no_real_wrap = (
-  validate__28
+  validate__some_record_wrap
 )
-let validate__26 = (
+let validate__x_e48509c = (
   fun _ _ -> None
 )
 let validate_natural = (
-  validate__26
+  validate__x_e48509c
 )
-let validate__24 = (
+let validate__x_2596d76 = (
   fun path x ->
                        match x with
                          `Id "" -> failwith "empty"
                        | _ -> None
 )
 let validate_id = (
-  validate__24
+  validate__x_2596d76
 )
-let validate__25 = (
+let validate__x_b6e4b4c = (
   Atdgen_runtime.Ov_run.validate_list (
     fun path x ->
       (let x, _ = x in
@@ -417,22 +417,22 @@ let validate__25 = (
   )
 )
 let validate_json_map = (
-  validate__25
+  validate__x_b6e4b4c
 )
 let validate_intopt = (
-  validate__4
+  validate__int_option
 )
-let validate__21 = (
+let validate__x_547263f = (
   fun _ _ -> None
 )
 let validate_int_assoc_list = (
-  validate__21
+  validate__x_547263f
 )
-let validate__22 = (
+let validate__x_0a94e5e = (
   fun _ _ -> None
 )
 let validate_int_assoc_array = (
-  validate__22
+  validate__x_0a94e5e
 )
 let validate_int8 = (
   (fun _ _ -> None)
@@ -452,7 +452,7 @@ let validate_generic validate__a : _ -> 'a generic -> _ = (
 let validate_floats : _ -> floats -> _ = (
   fun _ _ -> None
 )
-let validate__17 = (
+let validate__string_list = (
   fun _ _ -> None
 )
 let validate_extended_tuple = (
@@ -470,11 +470,11 @@ let validate_extended : _ -> extended -> _ = (
         if x = false then None else Some (Atdgen_runtime.Util.Validation.error path)
         ) (`Field "b1x" :: path) x.b1x
 )
-let validate__27 = (
+let validate__x_a08e9e5 = (
   fun _ _ -> None
 )
 let validate_even_natural = (
-  validate__27
+  validate__x_a08e9e5
 )
 let validate_def = (
   (fun _ _ -> None)
@@ -488,22 +488,22 @@ let validate_base_tuple = (
 let validate_base : _ -> base -> _ = (
   fun _ _ -> None
 )
-let validate__23 validate__a = (
+let validate__x_f9e3589 validate__a = (
   Atdgen_runtime.Ov_run.validate_array (
     validate__a
   )
 )
 let validate_array validate__a = (
-  validate__23 validate__a
+  validate__x_f9e3589 validate__a
 )
 let validate_abs3 validate__a = (
-  validate__19 validate__a
+  validate__a_list validate__a
 )
 let validate_abs2 validate__a = (
-  validate__19 validate__a
+  validate__a_list validate__a
 )
 let validate_abs1 validate__a = (
-  validate__19 validate__a
+  validate__a_list validate__a
 )
 let create_r 
   ~a

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -407,20 +407,20 @@ class Alias:
 
 
 @dataclass
-class X2:
-    """Original type: _2"""
+class KindParametrizedTuple:
+    """Original type: _kind_parametrized_tuple"""
 
     value: Tuple[Kind, Kind, int]
 
     @classmethod
-    def from_json(cls, x: Any) -> 'X2':
+    def from_json(cls, x: Any) -> 'KindParametrizedTuple':
         return cls((lambda x: (Kind.from_json(x[0]), Kind.from_json(x[1]), _atd_read_int(x[2])) if isinstance(x, list) and len(x) == 3 else _atd_bad_json('array of length 3', x))(x))
 
     def to_json(self) -> Any:
         return (lambda x: [(lambda x: x.to_json())(x[0]), (lambda x: x.to_json())(x[1]), _atd_write_int(x[2])] if isinstance(x, tuple) and len(x) == 3 else _atd_bad_python('tuple of length 3', x))(self.value)
 
     @classmethod
-    def from_json_string(cls, x: str) -> 'X2':
+    def from_json_string(cls, x: str) -> 'KindParametrizedTuple':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -428,21 +428,21 @@ class X2:
 
 
 @dataclass
-class X1:
-    """Original type: _1 = { ... }"""
+class IntFloatParametrizedRecord:
+    """Original type: _int_float_parametrized_record = { ... }"""
 
     field_a: int
     field_b: List[float]
 
     @classmethod
-    def from_json(cls, x: Any) -> 'X1':
+    def from_json(cls, x: Any) -> 'IntFloatParametrizedRecord':
         if isinstance(x, dict):
             return cls(
-                field_a=_atd_read_int(x['field_a']) if 'field_a' in x else _atd_missing_json_field('X1', 'field_a'),
+                field_a=_atd_read_int(x['field_a']) if 'field_a' in x else _atd_missing_json_field('IntFloatParametrizedRecord', 'field_a'),
                 field_b=_atd_read_list(_atd_read_float)(x['field_b']) if 'field_b' in x else [],
             )
         else:
-            _atd_bad_json('X1', x)
+            _atd_bad_json('IntFloatParametrizedRecord', x)
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
@@ -451,7 +451,7 @@ class X1:
         return res
 
     @classmethod
-    def from_json_string(cls, x: str) -> 'X1':
+    def from_json_string(cls, x: str) -> 'IntFloatParametrizedRecord':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -477,8 +477,8 @@ class Root:
     nullables: List[Optional[int]]
     options: List[Optional[int]]
     untyped_things: List[Any]
-    parametrized_record: X1
-    parametrized_tuple: X2
+    parametrized_record: IntFloatParametrizedRecord
+    parametrized_tuple: KindParametrizedTuple
     maybe: Optional[int] = None
     answer: int = 42
 
@@ -501,8 +501,8 @@ class Root:
                 nullables=_atd_read_list(_atd_read_nullable(_atd_read_int))(x['nullables']) if 'nullables' in x else _atd_missing_json_field('Root', 'nullables'),
                 options=_atd_read_list(_atd_read_nullable(_atd_read_int))(x['options']) if 'options' in x else _atd_missing_json_field('Root', 'options'),
                 untyped_things=_atd_read_list((lambda x: x))(x['untyped_things']) if 'untyped_things' in x else _atd_missing_json_field('Root', 'untyped_things'),
-                parametrized_record=X1.from_json(x['parametrized_record']) if 'parametrized_record' in x else _atd_missing_json_field('Root', 'parametrized_record'),
-                parametrized_tuple=X2.from_json(x['parametrized_tuple']) if 'parametrized_tuple' in x else _atd_missing_json_field('Root', 'parametrized_tuple'),
+                parametrized_record=IntFloatParametrizedRecord.from_json(x['parametrized_record']) if 'parametrized_record' in x else _atd_missing_json_field('Root', 'parametrized_record'),
+                parametrized_tuple=KindParametrizedTuple.from_json(x['parametrized_tuple']) if 'parametrized_tuple' in x else _atd_missing_json_field('Root', 'parametrized_tuple'),
                 maybe=_atd_read_int(x['maybe']) if 'maybe' in x else None,
                 answer=_atd_read_int(x['answer']) if 'answer' in x else 42,
             )

--- a/atdpy/test/python-tests/test_atdpy.py
+++ b/atdpy/test/python-tests/test_atdpy.py
@@ -82,11 +82,11 @@ def test_everything_to_json() -> None:
         nullables=[12, None, 34],
         options=[56, None, 78],
         untyped_things=[[["hello"]], {}, None, 123],
-        parametrized_record=e.X1(
+        parametrized_record=e.IntFloatParametrizedRecord(
             field_a=42,
             field_b=[9.9, 8.8],
         ),
-        parametrized_tuple=e.X2(
+        parametrized_tuple=e.KindParametrizedTuple(
             (e.Kind(e.WOW()), e.Kind(e.WOW()), 100)
         )
     )


### PR DESCRIPTION
This is a follow-up to yesterday's PR on which I commented: https://github.com/ahrefs/atd/pull/319#pullrequestreview-1176225840

The nicer type names are used:

* internally in `.ml` files generated by atdgen. The name changes shouldn't affect the users since they're not part of the generated .mli` interfaces.
* for Python class names resulting from monomorphization. Check out the changes in the generated file `everything.py`.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
