### PR TITLE
Add support for parametrized type definitions to atdts.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 * atdpy: Support parametrized type definitions (#303)
 * atdpy: Support options approximately by treating them as nullables (#320)
+* atdts: Support parametrized type definitions (#303)
 
 2.10.0 (2022-08-09)
 -------------------

--- a/atdts/test/atd-input/everything.atd
+++ b/atdts/test/atd-input/everything.atd
@@ -8,6 +8,13 @@ type different_kinds_of_things = [
 (* TS keyword *)
 type this = int
 
+type ('a, 'b) parametrized_record = {
+  field_a: 'a;
+  ~field_b: 'b list;
+}
+
+type 'a parametrized_tuple = ('a * 'a * int)
+
 type root = {
   id <json name="ID">: string;
   this: this;
@@ -26,6 +33,8 @@ type root = {
   ~nullables: int nullable list;
   untyped_things: abstract list;
   foo: foo nullable;
+  parametrized_record: (int, float) parametrized_record;
+  parametrized_tuple: different_kinds_of_things parametrized_tuple;
 }
 
 type alias = int list

--- a/atdts/test/ts-expected/everything.ts
+++ b/atdts/test/ts-expected/everything.ts
@@ -34,6 +34,8 @@ export type Root = {
   nullables: (Int | null)[];
   untyped_things: any[];
   foo: (Foo | null);
+  parametrized_record: IntFloatParametrizedRecord;
+  parametrized_tuple: TupleE1a4b40;
 }
 
 export type Alias = Int[]
@@ -43,6 +45,13 @@ export type Pair = [string, Int]
 export type Foo = {
   foo: string;
 }
+
+export type IntFloatParametrizedRecord = {
+  field_a: Int;
+  field_b: number[];
+}
+
+export type TupleE1a4b40 = [DifferentKindsOfThings, DifferentKindsOfThings, Int]
 
 export function writeDifferentKindsOfThings(x: DifferentKindsOfThings, context: any = x): any {
   switch (x.kind) {
@@ -110,6 +119,8 @@ export function writeRoot(x: Root, context: any = x): any {
     'nullables': _atd_write_field_with_default(_atd_write_array(_atd_write_nullable(_atd_write_int)), [], x.nullables, x),
     'untyped_things': _atd_write_required_field('Root', 'untyped_things', _atd_write_array(((x: any): any => x)), x.untyped_things, x),
     'foo': _atd_write_required_field('Root', 'foo', _atd_write_nullable(writeFoo), x.foo, x),
+    'parametrized_record': _atd_write_required_field('Root', 'parametrized_record', writeIntFloatParametrizedRecord, x.parametrized_record, x),
+    'parametrized_tuple': _atd_write_required_field('Root', 'parametrized_tuple', writeTupleE1a4b40, x.parametrized_tuple, x),
   };
 }
 
@@ -132,6 +143,8 @@ export function readRoot(x: any, context: any = x): Root {
     nullables: _atd_read_field_with_default(_atd_read_array(_atd_read_nullable(_atd_read_int)), [], x['nullables'], x),
     untyped_things: _atd_read_required_field('Root', 'untyped_things', _atd_read_array(((x: any): any => x)), x['untyped_things'], x),
     foo: _atd_read_required_field('Root', 'foo', _atd_read_nullable(readFoo), x['foo'], x),
+    parametrized_record: _atd_read_required_field('Root', 'parametrized_record', readIntFloatParametrizedRecord, x['parametrized_record'], x),
+    parametrized_tuple: _atd_read_required_field('Root', 'parametrized_tuple', readTupleE1a4b40, x['parametrized_tuple'], x),
   };
 }
 
@@ -161,6 +174,28 @@ export function readFoo(x: any, context: any = x): Foo {
   return {
     foo: _atd_read_required_field('Foo', 'foo', _atd_read_string, x['foo'], x),
   };
+}
+
+export function writeIntFloatParametrizedRecord(x: IntFloatParametrizedRecord, context: any = x): any {
+  return {
+    'field_a': _atd_write_required_field('IntFloatParametrizedRecord', 'field_a', _atd_write_int, x.field_a, x),
+    'field_b': _atd_write_field_with_default(_atd_write_array(_atd_write_float), [], x.field_b, x),
+  };
+}
+
+export function readIntFloatParametrizedRecord(x: any, context: any = x): IntFloatParametrizedRecord {
+  return {
+    field_a: _atd_read_required_field('IntFloatParametrizedRecord', 'field_a', _atd_read_int, x['field_a'], x),
+    field_b: _atd_read_field_with_default(_atd_read_array(_atd_read_float), [], x['field_b'], x),
+  };
+}
+
+export function writeTupleE1a4b40(x: TupleE1a4b40, context: any = x): any {
+  return ((x, context) => [writeDifferentKindsOfThings(x[0], x), writeDifferentKindsOfThings(x[1], x), _atd_write_int(x[2], x)])(x, context);
+}
+
+export function readTupleE1a4b40(x: any, context: any = x): TupleE1a4b40 {
+  return ((x, context): [DifferentKindsOfThings, DifferentKindsOfThings, Int] => { _atd_check_json_tuple(3, x, context); return [readDifferentKindsOfThings(x[0], x), readDifferentKindsOfThings(x[1], x), _atd_read_int(x[2], x)] })(x, context);
 }
 
 

--- a/atdts/test/ts-tests/test_atdts.ts
+++ b/atdts/test/ts-tests/test_atdts.ts
@@ -57,6 +57,18 @@ function test_everything() {
     nullables: [13, 71],
     untyped_things: [{}, [["hello"]], 123],
     foo: null,
+    parametrized_record: {
+      field_a: 42,
+      field_b: [
+        9.9,
+        8.8
+      ]
+    },
+    parametrized_tuple: [
+      { kind: 'WOW' },
+      { kind: 'WOW' },
+      100
+    ],
   }
   const a_str = JSON.stringify(API.writeRoot(a_obj), null, 2)
   save('a_str', a_str)
@@ -159,7 +171,19 @@ ${a_str}`
     ],
     123
   ],
-  "foo": null
+  "foo": null,
+  "parametrized_record": {
+    "field_a": 42,
+    "field_b": [
+      9.9,
+      8.8
+    ]
+  },
+  "parametrized_tuple": [
+    "wow",
+    "wow",
+    100
+  ]
 }`
   save('b_str', b_str)
   const b_obj = API.readRoot(JSON.parse(a_str))


### PR DESCRIPTION
This uses monomorphization and generation of stable type names just like it was done for atdpy (#319, #321).

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
