### PR TITLE
Fixes in generated TypeScript code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 * atdts: Support parametrized type definitions (#303)
 * atdts: Fix incorrect type for TypeScript readers/writers generated
          for type `abstract`.
+* atdts: Fix incorrect type for TypeScript writers of optional fields.
+         It was working only in special cases such as `foo?: int`.
 
 2.10.0 (2022-08-09)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 * atdpy: Support parametrized type definitions (#303)
 * atdpy: Support options approximately by treating them as nullables (#320)
 * atdts: Support parametrized type definitions (#303)
+* atdts: Fix incorrect type for TypeScript readers/writers generated
+         for type `abstract`.
 
 2.10.0 (2022-08-09)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
          for type `abstract`.
 * atdts: Fix incorrect type for TypeScript writers of optional fields.
          It was working only in special cases such as `foo?: int`.
+* atdts: Eliminate the type alias `type Int = number` since it was
+         more confusing than helpful. Occurrences of `Int` are replaced
+         by `number /*int*/`.
 
 2.10.0 (2022-08-09)
 -------------------

--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -708,7 +708,7 @@ let rec json_reader env e =
   | Name (loc, (loc2, name, []), an) ->
       (match name with
        | "bool" | "int" | "float" | "string" -> sprintf "_atd_read_%s" name
-       | "abstract" -> "((x: any): any => x)"
+       | "abstract" -> "((x: any, context): any => x)"
        | _ -> reader_name env name)
   | Name (loc, _, _) -> assert false
   | Tvar (loc, _) -> not_implemented loc "type variables"
@@ -756,7 +756,7 @@ let rec json_writer env e =
   | Name (loc, (loc2, name, []), an) ->
       (match name with
        | "bool" | "int" | "float" | "string" -> sprintf "_atd_write_%s" name
-       | "abstract" -> "((x: any): any => x)"
+       | "abstract" -> "((x: any, context): any => x)"
        | _ -> writer_name env name)
   | Name (loc, _, _) -> not_implemented loc "parametrized types"
   | Tvar (loc, _) -> not_implemented loc "type variables"

--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -197,8 +197,6 @@ let runtime_end = {|
 // Runtime library
 /////////////////////////////////////////////////////////////////////
 
-export type Int = number
-
 export type Option<T> = null | { value: T }
 
 function _atd_missing_json_field(type_name: string, json_field_name: string) {
@@ -231,7 +229,7 @@ function _atd_bad_ts(expected_type: string, ts_value: any, context: any) {
                   ` Occurs in '${JSON.stringify(context)}'.`)
 }
 
-function _atd_check_json_tuple(len: Int, x: any, context: any) {
+function _atd_check_json_tuple(len: number /*int*/, x: any, context: any) {
   if (! Array.isArray(x) || x.length !== len)
     _atd_bad_json('tuple of length ' + len, x, context);
 }
@@ -254,7 +252,7 @@ function _atd_read_bool(x: any, context: any): boolean {
   }
 }
 
-function _atd_read_int(x: any, context: any): Int {
+function _atd_read_int(x: any, context: any): number /*int*/ {
   if (Number.isInteger(x))
     return x
   else {
@@ -435,7 +433,7 @@ function _atd_write_bool(x: any, context: any): boolean {
   }
 }
 
-function _atd_write_int(x: any, context: any): Int {
+function _atd_write_int(x: any, context: any): number /*int*/ {
   if (Number.isInteger(x))
     return x
   else {
@@ -596,7 +594,7 @@ let ts_type_name env (name : string) =
   match name with
   | "unit" -> "Null"
   | "bool" -> "boolean"
-  | "int" -> "Int"
+  | "int" -> "number /*int*/"
   | "float" -> "number"
   | "string" -> "string"
   | "abstract" -> "any"

--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -544,7 +544,7 @@ function _atd_write_required_field<T>(type_name: string,
 }
 
 function _atd_write_optional_field<T>(write_elt: (x: T, context: any) => any,
-                                      x: T,
+                                      x: T | undefined,
                                       context: any): any {
   if (x === undefined || x === null)
     return x

--- a/atdts/test/atd-input/everything.atd
+++ b/atdts/test/atd-input/everything.atd
@@ -22,11 +22,16 @@ type ('a, 'b) parametrized_record = {
 
 type 'a parametrized_tuple = ('a * 'a * int)
 
+type simple_record = {
+  str: string;
+}
+
 type root = {
   id <json name="ID">: string;
   this: this;
   items: int list list;
   ?maybe: int option;
+  ?maybe2: simple_record option;
   ~extras: int list;
   ~answer <ts default="42">: int;
   aliased: alias;

--- a/atdts/test/atd-input/everything.atd
+++ b/atdts/test/atd-input/everything.atd
@@ -1,3 +1,10 @@
+(*
+   ATD type definitions for testing their translation to TypeScript.
+*)
+
+(* Testing raw JSON. Should map to type 'any'. *)
+type anything = abstract
+
 type different_kinds_of_things = [
   | Root (* class name conflict *)
   | Thing of int
@@ -35,6 +42,7 @@ type root = {
   foo: foo nullable;
   parametrized_record: (int, float) parametrized_record;
   parametrized_tuple: different_kinds_of_things parametrized_tuple;
+  anything: anything;
 }
 
 type alias = int list

--- a/atdts/test/ts-expected/everything.ts
+++ b/atdts/test/ts-expected/everything.ts
@@ -8,6 +8,8 @@
 //   of type 'Foo'.
 
 
+export type Anything = any
+
 export type DifferentKindsOfThings =
 | { kind: 'Root' }
 | { kind: 'Thing'; value: Int }
@@ -36,6 +38,7 @@ export type Root = {
   foo: (Foo | null);
   parametrized_record: IntFloatParametrizedRecord;
   parametrized_tuple: TupleE1a4b40;
+  anything: Anything;
 }
 
 export type Alias = Int[]
@@ -52,6 +55,14 @@ export type IntFloatParametrizedRecord = {
 }
 
 export type TupleE1a4b40 = [DifferentKindsOfThings, DifferentKindsOfThings, Int]
+
+export function writeAnything(x: Anything, context: any = x): any {
+  return ((x: any, context): any => x)(x, context);
+}
+
+export function readAnything(x: any, context: any = x): Anything {
+  return ((x: any, context): any => x)(x, context);
+}
 
 export function writeDifferentKindsOfThings(x: DifferentKindsOfThings, context: any = x): any {
   switch (x.kind) {
@@ -117,10 +128,11 @@ export function writeRoot(x: Root, context: any = x): any {
     'assoc4': _atd_write_required_field('Root', 'assoc4', _atd_write_assoc_map_to_object(_atd_write_int), x.assoc4, x),
     'options': _atd_write_field_with_default(_atd_write_array(_atd_write_option(_atd_write_int)), [], x.options, x),
     'nullables': _atd_write_field_with_default(_atd_write_array(_atd_write_nullable(_atd_write_int)), [], x.nullables, x),
-    'untyped_things': _atd_write_required_field('Root', 'untyped_things', _atd_write_array(((x: any): any => x)), x.untyped_things, x),
+    'untyped_things': _atd_write_required_field('Root', 'untyped_things', _atd_write_array(((x: any, context): any => x)), x.untyped_things, x),
     'foo': _atd_write_required_field('Root', 'foo', _atd_write_nullable(writeFoo), x.foo, x),
     'parametrized_record': _atd_write_required_field('Root', 'parametrized_record', writeIntFloatParametrizedRecord, x.parametrized_record, x),
     'parametrized_tuple': _atd_write_required_field('Root', 'parametrized_tuple', writeTupleE1a4b40, x.parametrized_tuple, x),
+    'anything': _atd_write_required_field('Root', 'anything', writeAnything, x.anything, x),
   };
 }
 
@@ -141,10 +153,11 @@ export function readRoot(x: any, context: any = x): Root {
     assoc4: _atd_read_required_field('Root', 'assoc4', _atd_read_assoc_object_into_map(_atd_read_int), x['assoc4'], x),
     options: _atd_read_field_with_default(_atd_read_array(_atd_read_option(_atd_read_int)), [], x['options'], x),
     nullables: _atd_read_field_with_default(_atd_read_array(_atd_read_nullable(_atd_read_int)), [], x['nullables'], x),
-    untyped_things: _atd_read_required_field('Root', 'untyped_things', _atd_read_array(((x: any): any => x)), x['untyped_things'], x),
+    untyped_things: _atd_read_required_field('Root', 'untyped_things', _atd_read_array(((x: any, context): any => x)), x['untyped_things'], x),
     foo: _atd_read_required_field('Root', 'foo', _atd_read_nullable(readFoo), x['foo'], x),
     parametrized_record: _atd_read_required_field('Root', 'parametrized_record', readIntFloatParametrizedRecord, x['parametrized_record'], x),
     parametrized_tuple: _atd_read_required_field('Root', 'parametrized_tuple', readTupleE1a4b40, x['parametrized_tuple'], x),
+    anything: _atd_read_required_field('Root', 'anything', readAnything, x['anything'], x),
   };
 }
 

--- a/atdts/test/ts-expected/everything.ts
+++ b/atdts/test/ts-expected/everything.ts
@@ -12,11 +12,11 @@ export type Anything = any
 
 export type DifferentKindsOfThings =
 | { kind: 'Root' }
-| { kind: 'Thing'; value: Int }
+| { kind: 'Thing'; value: number /*int*/ }
 | { kind: 'WOW' /* JSON: "wow" */ }
 | { kind: 'Amaze' /* JSON: "!!!" */; value: string[] }
 
-export type This = Int
+export type This = number /*int*/
 
 export type SimpleRecord = {
   str: string;
@@ -25,20 +25,20 @@ export type SimpleRecord = {
 export type Root = {
   id: string;
   this_: This;
-  items: Int[][];
-  maybe?: Int;
+  items: number /*int*/[][];
+  maybe?: number /*int*/;
   maybe2?: SimpleRecord;
-  extras: Int[];
-  answer: Int;
+  extras: number /*int*/[];
+  answer: number /*int*/;
   aliased: Alias;
   point: [number, number];
   kinds: DifferentKindsOfThings[];
-  assoc1: [number, Int][];
-  assoc2: [string, Int][];
-  assoc3: Map<number, Int>;
-  assoc4: Map<string, Int>;
-  options: Option<Int>[];
-  nullables: (Int | null)[];
+  assoc1: [number, number /*int*/][];
+  assoc2: [string, number /*int*/][];
+  assoc3: Map<number, number /*int*/>;
+  assoc4: Map<string, number /*int*/>;
+  options: Option<number /*int*/>[];
+  nullables: (number /*int*/ | null)[];
   untyped_things: any[];
   foo: (Foo | null);
   parametrized_record: IntFloatParametrizedRecord;
@@ -46,20 +46,20 @@ export type Root = {
   anything: Anything;
 }
 
-export type Alias = Int[]
+export type Alias = number /*int*/[]
 
-export type Pair = [string, Int]
+export type Pair = [string, number /*int*/]
 
 export type Foo = {
   foo: string;
 }
 
 export type IntFloatParametrizedRecord = {
-  field_a: Int;
+  field_a: number /*int*/;
   field_b: number[];
 }
 
-export type TupleE1a4b40 = [DifferentKindsOfThings, DifferentKindsOfThings, Int]
+export type TupleE1a4b40 = [DifferentKindsOfThings, DifferentKindsOfThings, number /*int*/]
 
 export function writeAnything(x: Anything, context: any = x): any {
   return ((x: any, context): any => x)(x, context);
@@ -166,7 +166,7 @@ export function readRoot(x: any, context: any = x): Root {
     aliased: _atd_read_required_field('Root', 'aliased', readAlias, x['aliased'], x),
     point: _atd_read_required_field('Root', 'point', ((x, context): [number, number] => { _atd_check_json_tuple(2, x, context); return [_atd_read_float(x[0], x), _atd_read_float(x[1], x)] }), x['point'], x),
     kinds: _atd_read_required_field('Root', 'kinds', _atd_read_array(readDifferentKindsOfThings), x['kinds'], x),
-    assoc1: _atd_read_required_field('Root', 'assoc1', _atd_read_array(((x, context): [number, Int] => { _atd_check_json_tuple(2, x, context); return [_atd_read_float(x[0], x), _atd_read_int(x[1], x)] })), x['assoc1'], x),
+    assoc1: _atd_read_required_field('Root', 'assoc1', _atd_read_array(((x, context): [number, number /*int*/] => { _atd_check_json_tuple(2, x, context); return [_atd_read_float(x[0], x), _atd_read_int(x[1], x)] })), x['assoc1'], x),
     assoc2: _atd_read_required_field('Root', 'assoc2', _atd_read_assoc_object_into_array(_atd_read_int), x['assoc2'], x),
     assoc3: _atd_read_required_field('Root', 'assoc3', _atd_read_assoc_array_into_map(_atd_read_float, _atd_read_int), x['assoc3'], x),
     assoc4: _atd_read_required_field('Root', 'assoc4', _atd_read_assoc_object_into_map(_atd_read_int), x['assoc4'], x),
@@ -193,7 +193,7 @@ export function writePair(x: Pair, context: any = x): any {
 }
 
 export function readPair(x: any, context: any = x): Pair {
-  return ((x, context): [string, Int] => { _atd_check_json_tuple(2, x, context); return [_atd_read_string(x[0], x), _atd_read_int(x[1], x)] })(x, context);
+  return ((x, context): [string, number /*int*/] => { _atd_check_json_tuple(2, x, context); return [_atd_read_string(x[0], x), _atd_read_int(x[1], x)] })(x, context);
 }
 
 export function writeFoo(x: Foo, context: any = x): any {
@@ -227,15 +227,13 @@ export function writeTupleE1a4b40(x: TupleE1a4b40, context: any = x): any {
 }
 
 export function readTupleE1a4b40(x: any, context: any = x): TupleE1a4b40 {
-  return ((x, context): [DifferentKindsOfThings, DifferentKindsOfThings, Int] => { _atd_check_json_tuple(3, x, context); return [readDifferentKindsOfThings(x[0], x), readDifferentKindsOfThings(x[1], x), _atd_read_int(x[2], x)] })(x, context);
+  return ((x, context): [DifferentKindsOfThings, DifferentKindsOfThings, number /*int*/] => { _atd_check_json_tuple(3, x, context); return [readDifferentKindsOfThings(x[0], x), readDifferentKindsOfThings(x[1], x), _atd_read_int(x[2], x)] })(x, context);
 }
 
 
 /////////////////////////////////////////////////////////////////////
 // Runtime library
 /////////////////////////////////////////////////////////////////////
-
-export type Int = number
 
 export type Option<T> = null | { value: T }
 
@@ -269,7 +267,7 @@ function _atd_bad_ts(expected_type: string, ts_value: any, context: any) {
                   ` Occurs in '${JSON.stringify(context)}'.`)
 }
 
-function _atd_check_json_tuple(len: Int, x: any, context: any) {
+function _atd_check_json_tuple(len: number /*int*/, x: any, context: any) {
   if (! Array.isArray(x) || x.length !== len)
     _atd_bad_json('tuple of length ' + len, x, context);
 }
@@ -292,7 +290,7 @@ function _atd_read_bool(x: any, context: any): boolean {
   }
 }
 
-function _atd_read_int(x: any, context: any): Int {
+function _atd_read_int(x: any, context: any): number /*int*/ {
   if (Number.isInteger(x))
     return x
   else {
@@ -473,7 +471,7 @@ function _atd_write_bool(x: any, context: any): boolean {
   }
 }
 
-function _atd_write_int(x: any, context: any): Int {
+function _atd_write_int(x: any, context: any): number /*int*/ {
   if (Number.isInteger(x))
     return x
   else {
@@ -582,7 +580,7 @@ function _atd_write_required_field<T>(type_name: string,
 }
 
 function _atd_write_optional_field<T>(write_elt: (x: T, context: any) => any,
-                                      x: T,
+                                      x: T | undefined,
                                       context: any): any {
   if (x === undefined || x === null)
     return x

--- a/atdts/test/ts-expected/everything.ts
+++ b/atdts/test/ts-expected/everything.ts
@@ -18,11 +18,16 @@ export type DifferentKindsOfThings =
 
 export type This = Int
 
+export type SimpleRecord = {
+  str: string;
+}
+
 export type Root = {
   id: string;
   this_: This;
   items: Int[][];
   maybe?: Int;
+  maybe2?: SimpleRecord;
   extras: Int[];
   answer: Int;
   aliased: Alias;
@@ -111,12 +116,25 @@ export function readThis(x: any, context: any = x): This {
   return _atd_read_int(x, context);
 }
 
+export function writeSimpleRecord(x: SimpleRecord, context: any = x): any {
+  return {
+    'str': _atd_write_required_field('SimpleRecord', 'str', _atd_write_string, x.str, x),
+  };
+}
+
+export function readSimpleRecord(x: any, context: any = x): SimpleRecord {
+  return {
+    str: _atd_read_required_field('SimpleRecord', 'str', _atd_read_string, x['str'], x),
+  };
+}
+
 export function writeRoot(x: Root, context: any = x): any {
   return {
     'ID': _atd_write_required_field('Root', 'id', _atd_write_string, x.id, x),
     'this': _atd_write_required_field('Root', 'this', writeThis, x.this_, x),
     'items': _atd_write_required_field('Root', 'items', _atd_write_array(_atd_write_array(_atd_write_int)), x.items, x),
     'maybe': _atd_write_optional_field(_atd_write_int, x.maybe, x),
+    'maybe2': _atd_write_optional_field(writeSimpleRecord, x.maybe2, x),
     'extras': _atd_write_field_with_default(_atd_write_array(_atd_write_int), [], x.extras, x),
     'answer': _atd_write_field_with_default(_atd_write_int, 42, x.answer, x),
     'aliased': _atd_write_required_field('Root', 'aliased', writeAlias, x.aliased, x),
@@ -142,6 +160,7 @@ export function readRoot(x: any, context: any = x): Root {
     this_: _atd_read_required_field('Root', 'this', readThis, x['this'], x),
     items: _atd_read_required_field('Root', 'items', _atd_read_array(_atd_read_array(_atd_read_int)), x['items'], x),
     maybe: _atd_read_optional_field(_atd_read_int, x['maybe'], x),
+    maybe2: _atd_read_optional_field(readSimpleRecord, x['maybe2'], x),
     extras: _atd_read_field_with_default(_atd_read_array(_atd_read_int), [], x['extras'], x),
     answer: _atd_read_field_with_default(_atd_read_int, 42, x['answer'], x),
     aliased: _atd_read_required_field('Root', 'aliased', readAlias, x['aliased'], x),

--- a/atdts/test/ts-tests/test_atdts.ts
+++ b/atdts/test/ts-tests/test_atdts.ts
@@ -4,8 +4,7 @@ import * as API from "./everything"
 import * as fs from "fs"
 
 // Check that types are exported
-const a: API.Int = 0
-const b: API.Option<string> = null
+const aaa: API.Option<string> = null
 
 function assert(is_true: boolean, errmsg: string) {
   if (!is_true) {

--- a/atdts/test/ts-tests/test_atdts.ts
+++ b/atdts/test/ts-tests/test_atdts.ts
@@ -69,6 +69,10 @@ function test_everything() {
       { kind: 'WOW' },
       100
     ],
+    anything: {
+      any_a: 1234,
+      any_b: [ [], [[[]]], true, {}, null ]
+    },
   }
   const a_str = JSON.stringify(API.writeRoot(a_obj), null, 2)
   save('a_str', a_str)
@@ -183,7 +187,21 @@ ${a_str}`
     "wow",
     "wow",
     100
-  ]
+  ],
+  "anything": {
+    "any_a": 1234,
+    "any_b": [
+      [],
+      [
+        [
+          []
+        ]
+      ],
+      true,
+      {},
+      null
+    ]
+  }
 }`
   save('b_str', b_str)
   const b_obj = API.readRoot(JSON.parse(a_str))


### PR DESCRIPTION
* atdts: Fix incorrect type for TypeScript readers/writers generated for type `abstract`.
* atdts: Fix incorrect type for TypeScript writers of optional fields. It was working only in special cases such as `foo?: int`.
* atdts: Eliminate the type alias `type Int = number` since it was more confusing than helpful. Occurrences of `Int` are replaced by `number /*int*/`.

This eliminates errors produced by tsc when compiling the TypeScript code derived from [semgrep_output_v1.atd](https://github.com/returntocorp/semgrep-interfaces/blob/5b72b91f82884de2be55183d2c91221ff517a7c5/semgrep_output_v1.atd).

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
