### PR TITLE
Allow `<json repr="string">` for int types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 2.12.0 (xxxx-xx-xx)
+-------------------
 
 * atdgen: Annotate generated code with types to disambiguate OCaml
   classic variants (#331)
@@ -8,6 +9,8 @@
   however, is still a nullable (`Optional`) to make things simpler for
   Python programmers. This prevents distinguishing `["Some", "None"]`
   from `"None"` which both translate to `None` in Python. (#332)
+* (BREAKING) atdgen: revert default encoding of int64 values as string (#330)
+* atdgen: Support `<json repr="string">` for `int` values (#330)
 
 2.11.0 (2023-02-08)
 -------------------

--- a/atd/src/json.ml
+++ b/atd/src/json.ml
@@ -2,6 +2,10 @@
   Mapping from ATD to JSON
 *)
 
+type json_int =
+   | Int
+   | String
+
 type json_float =
   | Float of int option (* max decimal places *)
   | Int
@@ -57,7 +61,7 @@ type json_repr =
   | External
   | Field of json_field
   | Float of json_float
-  | Int
+  | Int of json_int
   | List of json_list
   | Nullable
   | Option
@@ -107,6 +111,12 @@ let json_float_of_string s : [ `Float | `Int ] option =
     | "int" -> Some `Int
     | _ -> None
 
+let json_int_of_string s : [ `String | `Int ] option =
+  match s with
+      "int" -> Some `Int
+    | "string" -> Some `String
+    | _ -> None
+
 let json_precision_of_string s =
   try Some (int_of_string s)
   with _ -> None
@@ -129,6 +139,18 @@ let get_json_float an : json_float =
   with
       `Float -> Float (get_json_precision an)
     | `Int -> Int
+
+let get_json_int an : json_int =
+  match
+    Annot.get_field
+      ~parse:json_int_of_string
+      ~default:`Int
+      ~sections:["json"]
+      ~field:"repr"
+      an
+  with
+      `Int -> Int
+    | `String -> String
 
 let json_list_of_string s : json_list option =
   match s with

--- a/atd/src/json.mli
+++ b/atd/src/json.mli
@@ -19,6 +19,10 @@ type json_adapter = {
 
 val no_adapter : json_adapter
 
+type json_int =
+   | Int
+   | String
+
 type json_float =
   | Float of int option (* max decimal places *)
   | Int
@@ -52,7 +56,7 @@ type json_repr =
   | External
   | Field of json_field
   | Float of json_float
-  | Int
+  | Int of json_int
   | List of json_list
   | Nullable
   | Option
@@ -69,6 +73,8 @@ val annot_schema_json : Annot.schema
 val get_json_list : Annot.t -> json_list
 
 val get_json_float : Annot.t -> json_float
+
+val get_json_int : Annot.t -> json_int
 
 val get_json_cons : string -> Annot.t -> string
 

--- a/atdgen-runtime/src/oj_run.ml
+++ b/atdgen-runtime/src/oj_run.ml
@@ -105,9 +105,7 @@ let write_int32 ob x =
   Buffer.add_string ob (Int32.to_string x)
 
 let write_int64 ob x =
-  Buffer.add_char ob '"';
-  Buffer.add_string ob (Int64.to_string x);
-  Buffer.add_char ob '"'
+  Buffer.add_string ob (Int64.to_string x)
 
 let min_float = float min_int
 let max_float = float max_int

--- a/atdgen-runtime/src/oj_run.ml
+++ b/atdgen-runtime/src/oj_run.ml
@@ -98,14 +98,34 @@ let write_nullable write_item ob = function
     None -> Buffer.add_string ob "null"
   | Some x -> write_item ob x
 
+let write_int_as_string ob x =
+  Buffer.add_char ob '"';
+  Yojson.Safe.write_int ob x;
+  Buffer.add_char ob '"'
+
 let write_int8 ob x =
   Yojson.Safe.write_int ob (int_of_char x)
+
+let write_int8_as_string ob x =
+  Buffer.add_char ob '"';
+  write_int8 ob x;
+  Buffer.add_char ob '"'
 
 let write_int32 ob x =
   Buffer.add_string ob (Int32.to_string x)
 
+let write_int32_as_string ob x =
+  Buffer.add_char ob '"';
+  write_int32 ob x;
+  Buffer.add_char ob '"'
+
 let write_int64 ob x =
   Buffer.add_string ob (Int64.to_string x)
+
+let write_int64_as_string ob x =
+  Buffer.add_char ob '"';
+  write_int64 ob x;
+  Buffer.add_char ob '"'
 
 let min_float = float min_int
 let max_float = float max_int
@@ -121,6 +141,11 @@ let write_float_as_int ob x =
       | FP_zero -> Buffer.add_string ob (Printf.sprintf "%.0f" x)
       | FP_infinite -> error "Cannot convert inf or -inf into a JSON int"
       | FP_nan -> error "Cannot convert NaN into a JSON int"
+
+let write_float_as_int_string ob x =
+  Buffer.add_char ob '"';
+  write_float_as_int ob x;
+  Buffer.add_char ob '"'
 
 type 'a read = Yojson.lexer_state -> Lexing.lexbuf -> 'a
 

--- a/atdgen-runtime/src/oj_run.mli
+++ b/atdgen-runtime/src/oj_run.mli
@@ -9,14 +9,19 @@ val error : string -> _
 val write_list : 'a write -> 'a list write
 val write_array : 'a write -> 'a array write
 val write_float_as_int : float write
+val write_float_as_int_string : float write
 val write_assoc_list : 'a write -> 'b write -> ('a * 'b) list write
 val write_assoc_array : 'a write -> 'b write -> ('a * 'b) array write
 val write_option : 'a write -> 'a option write
 val write_std_option : 'a write -> 'a option write
 val write_nullable : 'a write -> 'a option write
+val write_int_as_string : int write
 val write_int8 : char write
+val write_int8_as_string : char write
 val write_int32 : int32 write
+val write_int32_as_string : int32 write
 val write_int64 : int64 write
+val write_int64_as_string : int64 write
 
 type 'a read = Yojson.lexer_state -> Lexing.lexbuf -> 'a
 

--- a/atdgen/src/obuckle_emit.ml
+++ b/atdgen/src/obuckle_emit.ml
@@ -89,7 +89,7 @@ let rec get_reader_name
   match x with
     Unit (_, Unit, Unit) -> decoder_ident "unit"
   | Bool (_, Bool, Bool) -> decoder_ident "bool"
-  | Int (_, Int o, Int) ->
+  | Int (_, Int o, Int _) ->
       decoder_ident (
         match o with
         | Int -> "int"
@@ -357,7 +357,7 @@ let rec get_writer_name
       encoder_ident "unit"
   | Bool (_, Bool, Bool) ->
       encoder_ident "bool"
-  | Int (_, Int o, Int) ->
+  | Int (_, Int o, Int _) ->
       encoder_ident (
         match o with
         | Int -> "int"

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -127,13 +127,18 @@ let rec get_writer_name
       "Yojson.Safe.write_null"
   | Bool (_, Bool, Bool) ->
       "Yojson.Safe.write_bool"
-  | Int (_, Int o, Int) ->
-      (match o with
-         Int -> "Yojson.Safe.write_int"
-       | Char ->  "Atdgen_runtime.Oj_run.write_int8"
-       | Int32 -> "Atdgen_runtime.Oj_run.write_int32"
-       | Int64 -> "Atdgen_runtime.Oj_run.write_int64"
-       | Float -> "Atdgen_runtime.Oj_run.write_float_as_int"
+  | Int (_, Int o, Int j) ->
+      (match o, j with
+       | Int, Int -> "Yojson.Safe.write_int"
+       | Int, String -> "Atdgen_runtime.Oj_run.write_int_as_string"
+       | Char, Int ->  "Atdgen_runtime.Oj_run.write_int8"
+       | Char, String ->  "Atdgen_runtime.Oj_run.write_int8_as_string"
+       | Int32, Int -> "Atdgen_runtime.Oj_run.write_int32"
+       | Int32, String -> "Atdgen_runtime.Oj_run.write_int32_as_string"
+       | Int64, Int -> "Atdgen_runtime.Oj_run.write_int64"
+       | Int64, String -> "Atdgen_runtime.Oj_run.write_int64_as_string"
+       | Float, Int -> "Atdgen_runtime.Oj_run.write_float_as_int"
+       | Float, String -> "Atdgen_runtime.Oj_run.write_float_as_int_string"
       )
 
   | Float (_, Float, Float j) ->
@@ -196,7 +201,7 @@ let rec get_reader_name
   match x with
     Unit (_, Unit, Unit) -> "Atdgen_runtime.Oj_run.read_null"
   | Bool (_, Bool, Bool) -> "Atdgen_runtime.Oj_run.read_bool"
-  | Int (_, Int o, Int) ->
+  | Int (_, Int o, Int _) ->
       (match o with
          Int -> "Atdgen_runtime.Oj_run.read_int"
        | Char -> "Atdgen_runtime.Oj_run.read_int8"

--- a/atdgen/src/oj_mapping.ml
+++ b/atdgen/src/oj_mapping.ml
@@ -94,7 +94,8 @@ let rec mapping_of_expr (x : type_expr) =
            Bool (loc, Bool, Bool)
        | "int" ->
            let o = Ocaml.get_ocaml_int Json an in
-           Int (loc, Int o, Int)
+           let j = Json.get_json_int an in
+           Int (loc, Int o, Int j)
        | "float" ->
            let j = Json.get_json_float an in
            Float (loc, Float, Float j)

--- a/atdgen/test/dune
+++ b/atdgen/test/dune
@@ -49,6 +49,16 @@
  (action  (run %{bin:atdgen} -t %{deps})))
 
 (rule
+ (targets test_int_t.ml test_int_t.mli)
+ (deps    test_int.atd)
+ (action  (run %{bin:atdgen} -t %{deps})))
+
+(rule
+ (targets test_int_j.ml test_int_j.mli)
+ (deps    test_int.atd)
+ (action  (run %{bin:atdgen} -j %{deps})))
+
+(rule
  (targets test_int_with_string_repr_t.ml test_int_with_string_repr_t.mli)
  (deps    test_int_with_string_repr.atd)
  (action  (run %{bin:atdgen} -t %{deps})))
@@ -381,6 +391,8 @@
   testv
   test_unit_biniou_t
   test_unit_biniou_b
+  test_int_t
+  test_int_j
   test_int_with_string_repr_t
   test_int_with_string_repr_j
   test_atdgen_main

--- a/atdgen/test/dune
+++ b/atdgen/test/dune
@@ -49,13 +49,13 @@
  (action  (run %{bin:atdgen} -t %{deps})))
 
 (rule
- (targets test_int64_enc_t.ml test_int64_enc_t.mli)
- (deps    test_int64_enc.atd)
+ (targets test_int_with_string_repr_t.ml test_int_with_string_repr_t.mli)
+ (deps    test_int_with_string_repr.atd)
  (action  (run %{bin:atdgen} -t %{deps})))
 
 (rule
- (targets test_int64_enc_j.ml test_int64_enc_j.mli)
- (deps    test_int64_enc.atd)
+ (targets test_int_with_string_repr_j.ml test_int_with_string_repr_j.mli)
+ (deps    test_int_with_string_repr.atd)
  (action  (run %{bin:atdgen} -j %{deps})))
 
 (rule
@@ -381,8 +381,8 @@
   testv
   test_unit_biniou_t
   test_unit_biniou_b
-  test_int64_enc_t
-  test_int64_enc_j
+  test_int_with_string_repr_t
+  test_int_with_string_repr_j
   test_atdgen_main
   test_lib
   test_ppx_t

--- a/atdgen/test/test_atdgen_main.ml
+++ b/atdgen/test/test_atdgen_main.ml
@@ -610,13 +610,25 @@ let test_polymorphic_wrap () =
     Test_polymorphic_wrap_j.t_of_string Yojson.Safe.read_string json_out in
   check (x = x2)
 
-let test_encoding_int64 () =
-  let encoded = Test_int64_enc_j.string_of_int64 Int64.max_int in
-  check (String.equal encoded {|9223372036854775807|})
+let test_encoding_int_with_string_repr () =
+  let encoded = Test_int_with_string_repr_j.string_of_char 'A' in
+  check (String.equal encoded {|"65"|});
+  let encoded = Test_int_with_string_repr_j.string_of_int32 Int32.max_int in
+  check (String.equal encoded {|"2147483647"|});
+  let encoded = Test_int_with_string_repr_j.string_of_int64 Int64.max_int in
+  check (String.equal encoded {|"9223372036854775807"|});
+  let encoded = Test_int_with_string_repr_j.string_of_afloat 123.456 in
+  check (String.equal encoded {|"123"|})
 
-let test_encoding_decoding_int64 () =
-  let encoded = Test_int64_enc_j.string_of_int64 Int64.max_int in
-  let decoded = Test_int64_enc_j.int64_of_string encoded in
+let test_encoding_decoding_int_with_string_repr () =
+  let encoded = Test_int_with_string_repr_j.string_of_char 'A' in
+  let decoded = Test_int_with_string_repr_j.char_of_string encoded in
+  check (decoded = 'A');
+  let encoded = Test_int_with_string_repr_j.string_of_int32 Int32.max_int in
+  let decoded = Test_int_with_string_repr_j.int32_of_string encoded in
+  check (decoded = Int32.max_int);
+  let encoded = Test_int_with_string_repr_j.string_of_int64 Int64.max_int in
+  let decoded = Test_int_with_string_repr_j.int64_of_string encoded in
   check (decoded = Int64.max_int)
 
 let test_raw_json () =
@@ -683,8 +695,8 @@ let all_tests : (string * (unit -> unit)) list = [
   "test ambiguous record with json adapters", test_ambiguous_record;
   "test ambiguous classic variants with json adapters", test_ambiguous_classic_variants;
   "test wrapping of polymorphic types", test_polymorphic_wrap;
-  "json encoding int64", test_encoding_int64;
-  "json encoding & decoding int64", test_encoding_decoding_int64;
+  "json encoding int with string representation", test_encoding_int_with_string_repr;
+  "json encoding & decoding int with string representation", test_encoding_decoding_int_with_string_repr;
   "abstract types", test_abstract_types;
   "untyped json", test_untyped_json;
 ]

--- a/atdgen/test/test_atdgen_main.ml
+++ b/atdgen/test/test_atdgen_main.ml
@@ -612,7 +612,7 @@ let test_polymorphic_wrap () =
 
 let test_encoding_int64 () =
   let encoded = Test_int64_enc_j.string_of_int64 Int64.max_int in
-  check (String.equal encoded {|"9223372036854775807"|})
+  check (String.equal encoded {|9223372036854775807|})
 
 let test_encoding_decoding_int64 () =
   let encoded = Test_int64_enc_j.string_of_int64 Int64.max_int in
@@ -683,7 +683,7 @@ let all_tests : (string * (unit -> unit)) list = [
   "test ambiguous record with json adapters", test_ambiguous_record;
   "test ambiguous classic variants with json adapters", test_ambiguous_classic_variants;
   "test wrapping of polymorphic types", test_polymorphic_wrap;
-  "json encoding int64 as string", test_encoding_int64;
+  "json encoding int64", test_encoding_int64;
   "json encoding & decoding int64", test_encoding_decoding_int64;
   "abstract types", test_abstract_types;
   "untyped json", test_untyped_json;

--- a/atdgen/test/test_atdgen_main.ml
+++ b/atdgen/test/test_atdgen_main.ml
@@ -610,6 +610,27 @@ let test_polymorphic_wrap () =
     Test_polymorphic_wrap_j.t_of_string Yojson.Safe.read_string json_out in
   check (x = x2)
 
+let test_encoding_int () =
+  let encoded = Test_int_j.string_of_char 'A' in
+  check (String.equal encoded {|65|});
+  let encoded = Test_int_j.string_of_int32 Int32.max_int in
+  check (String.equal encoded {|2147483647|});
+  let encoded = Test_int_j.string_of_int64 Int64.max_int in
+  check (String.equal encoded {|9223372036854775807|});
+  let encoded = Test_int_j.string_of_afloat 123.456 in
+  check (String.equal encoded {|123|})
+
+let test_encoding_decoding_int () =
+  let encoded = Test_int_j.string_of_char 'A' in
+  let decoded = Test_int_j.char_of_string encoded in
+  check (decoded = 'A');
+  let encoded = Test_int_j.string_of_int32 Int32.max_int in
+  let decoded = Test_int_j.int32_of_string encoded in
+  check (decoded = Int32.max_int);
+  let encoded = Test_int_j.string_of_int64 Int64.max_int in
+  let decoded = Test_int_j.int64_of_string encoded in
+  check (decoded = Int64.max_int)
+
 let test_encoding_int_with_string_repr () =
   let encoded = Test_int_with_string_repr_j.string_of_char 'A' in
   check (String.equal encoded {|"65"|});
@@ -695,6 +716,8 @@ let all_tests : (string * (unit -> unit)) list = [
   "test ambiguous record with json adapters", test_ambiguous_record;
   "test ambiguous classic variants with json adapters", test_ambiguous_classic_variants;
   "test wrapping of polymorphic types", test_polymorphic_wrap;
+  "json encoding int", test_encoding_int;
+  "json encoding & decoding int", test_encoding_decoding_int;
   "json encoding int with string representation", test_encoding_int_with_string_repr;
   "json encoding & decoding int with string representation", test_encoding_decoding_int_with_string_repr;
   "abstract types", test_abstract_types;

--- a/atdgen/test/test_int.atd
+++ b/atdgen/test/test_int.atd
@@ -1,0 +1,4 @@
+type char = int <ocaml repr="char"> (* json repr should default to the same type as atd (int) *)
+type int32 = int <ocaml repr="int32"> <json repr="int">
+type int64 = int <ocaml repr="int64"> <json repr="int">
+type afloat = int <ocaml repr="float"> <json repr="int">

--- a/atdgen/test/test_int64_enc.atd
+++ b/atdgen/test/test_int64_enc.atd
@@ -1,1 +1,0 @@
-type int64 = int <ocaml repr="int64">

--- a/atdgen/test/test_int_with_string_repr.atd
+++ b/atdgen/test/test_int_with_string_repr.atd
@@ -1,0 +1,4 @@
+type char = int <ocaml repr="char"> <json repr="string">
+type int32 = int <ocaml repr="int32"> <json repr="string">
+type int64 = int <ocaml repr="int64"> <json repr="string">
+type afloat = int <ocaml repr="float"> <json repr="string">

--- a/doc/atdgen-reference.rst
+++ b/doc/atdgen-reference.rst
@@ -644,6 +644,22 @@ Example:
 
     type unixtime = float <json repr="int">
 
+Ints
+~~~~
+
+Position: after ``int`` type 
+
+Values: ``string``
+
+Semantics: specifies a int value that must be represented in JSON as 
+a string.
+
+Example:
+
+.. code:: ocaml
+
+    type int64 = int <ocaml repr="int64"> <json repr="string">
+
 Field ``tag_field``
 """""""""""""""""""
 


### PR DESCRIPTION
This PR addresses issue https://github.com/ahrefs/atd/issues/273 and supersedes https://github.com/ahrefs/atd/pull/291

- Added `<json repr="string">` annotation for int types
- Reverted default encoding of int64 values as string (i.e. changes made in #231)

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
