### PR TITLE
docs(atdpy): remove outdated comments on lists with default values

### DIFF
--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -794,8 +794,8 @@ let inst_var_declaration
         match get_python_default unwrapped_e an with
         | None -> ""
         | Some x ->
-            (* This constructs ensures that a fresh default value is
-               evaluated for each class instanciation. It's important for
+            (* This construct ensures that a fresh default value is
+               evaluated for each class instantiation. It's important for
                default lists since Python lists are mutable. *)
             sprintf " = field(default_factory=lambda: %s)" x
   in

--- a/doc/atdpy.rst
+++ b/doc/atdpy.rst
@@ -284,28 +284,7 @@ expression e.g.
     ~answer <python default="42">: int;
   }
 
-Default values are always honored when reading JSON data from
-Python. However, the implementation of ``dataclass`` via the
-``@dataclass`` decorator prevents the use of mutable values for
-defaults. This causes class constructors to not have default fields
-that are mutable such as ``[]``. For example:
-
-.. code-block:: ocaml
-
-   type bar = {
-     ~items: int list;
-   }
-
-will translate to a class constructor that requires one argument of
-type list. For example, ``Bar([1, 2, 3])`` would be legal but
-``Bar()`` would be illegal. Reading from the JSON object ``{}`` would
-however succeed. Therefore, the following two Python expressions would
-be valid and equivalent:
-
-.. code-block:: python
-
-   Bar([])
-   Bar.from_json_string('{}')
+Default values are always honored when reading JSON data from Python.
 
 
 Field and constructor renaming


### PR DESCRIPTION
Clean up the docs a little since this behavior was improved in #339 

### PR checklist

- [X] New code has tests to catch future regressions
- [X] Documentation is up-to-date
- [ ] `CHANGES.md` is up-to-date
