### PR TITLE
atdts: Stub compiler warnings for unused parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+2.12.1 (2023-07-25)
+-------------------
+
+* atdts: Stop compiler errors on generated typescript (#348)
+
 2.12.0 (2023-05-12)
 -------------------
 
@@ -11,7 +16,7 @@
   from `"None"` which both translate to `None` in Python. (#332)
 * (BREAKING) atdgen: revert default encoding of int64 values as string (#330)
 * atdgen: Support `<json repr="string">` for `int` values (#330)
-* atdpy: Treat default field values as expressions to evaluate each time 
+* atdpy: Treat default field values as expressions to evaluate each time
   they're assigned to a field. This allows the use of mutable defaults such as
   lists (#339)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-2.12.1 (2023-07-25)
+Unreleased
 -------------------
 
 * atdts: Stop compiler errors on generated typescript (#348)

--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -192,6 +192,7 @@ let runtime_start atd_filename =
     of type 'Foo'.
 */
 
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */|}
     atd_filename

--- a/atdts/test/ts-expected/everything.ts
+++ b/atdts/test/ts-expected/everything.ts
@@ -9,6 +9,7 @@
     of type 'Foo'.
 */
 
+// @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */
 

--- a/doc/atdts.rst
+++ b/doc/atdts.rst
@@ -364,3 +364,8 @@ TypeScript maps if the correct annotations are provided:
 * ``(foo * bar) list <ts repr="map">`` will use a TypeScript
   map of type ``Map<Foo, Bar>`` to represent the association list.
   Using the annotation ``<ts repr="array">`` is equivalent to the default.
+
+Caveats
+=========
+* Generated typescript contains a flag telling the compiler not to run
+  checks on the file.

--- a/doc/atdts.rst
+++ b/doc/atdts.rst
@@ -368,4 +368,4 @@ TypeScript maps if the correct annotations are provided:
 Caveats
 =========
 * Generated typescript contains a flag telling the compiler not to run
-  checks on the file.
+  checks on the file. `(Read) <https://github.com/ahrefs/atd/issues/347>`_


### PR DESCRIPTION
This PR adds the quick fix mentioned in [issue 347](https://github.com/ahrefs/atd/issues/347)

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
