### PR TITLE
atdts: fix eslint error

### DIFF
--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -192,6 +192,7 @@ let runtime_start atd_filename =
     of type 'Foo'.
 */
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */|}

--- a/atdts/test/ts-expected/everything.ts
+++ b/atdts/test/ts-expected/everything.ts
@@ -9,6 +9,7 @@
     of type 'Foo'.
 */
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /* tslint:disable */
 /* eslint-disable */


### PR DESCRIPTION
The CI fails because of an eslint error on `@ts-nocheck`, which is necessary for us.
