### PR TITLE
Remove unused code for supporting '<json lowercase_tags>'

### DIFF
--- a/atd/src/json.ml
+++ b/atd/src/json.ml
@@ -42,7 +42,6 @@ type json_record = {
 type json_sum = {
   json_sum_adapter : json_adapter;
   json_open_enum : bool;
-  json_lowercase_tags : bool;
 }
 
 (*
@@ -206,13 +205,9 @@ let get_json_adapter an =
 let get_json_open_enum an =
   Annot.get_flag ~sections:["json"] ~field:"open_enum" an
 
-let get_json_lowercase_tags an =
-  Annot.get_flag ~sections:["json"] ~field:"lowercase_tags" an
-
 let get_json_sum an = {
   json_sum_adapter = get_json_adapter an;
   json_open_enum = get_json_open_enum an;
-  json_lowercase_tags = get_json_lowercase_tags an;
 }
 
 let get_json_list an =

--- a/atd/src/json.mli
+++ b/atd/src/json.mli
@@ -44,7 +44,6 @@ type json_record = {
 type json_sum = {
   json_sum_adapter : json_adapter;
   json_open_enum : bool;
-  json_lowercase_tags : bool;
 }
 
 (** The different kinds of ATD nodes with their json-specific options. *)

--- a/atdgen/src/oj_emit.ml
+++ b/atdgen/src/oj_emit.ml
@@ -757,7 +757,6 @@ let rec make_reader p type_annot (x : Oj_mapping.t) : Indent.t list =
       let json_options = {
         Json.json_sum_adapter = Json.no_adapter;
         json_open_enum = false;
-        json_lowercase_tags = false;
       } in
       make_reader p
         (Some "_ option")


### PR DESCRIPTION
`<json lowercase_tags>` was meant to be supported but I see that none of the code generators consult it, so I'm removing the support we have for it from our `Atd.Json` module.

This is an internal change so I don't think it deserves an entry in the changelog. Let me know if you think otherwise.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
