### PR TITLE
atdgen >= 2.14.0 requires atd >= 2.14.0

### DIFF
--- a/atdgen.opam
+++ b/atdgen.opam
@@ -74,7 +74,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
   "alcotest" {with-test}
-  "atd" {>= "2.13.0"}
+  "atd" {>= "2.14.0"}
   "atdgen-runtime" {>= "2.1.0"}
   "atdgen-codec-runtime" {with-test}
   "biniou" {>= "1.0.6"}

--- a/dune-project
+++ b/dune-project
@@ -98,7 +98,7 @@ utilities."))
  (depends
   (ocaml (>= 4.08))
   (alcotest :with-test)
-  (atd (>= 2.13.0))
+  (atd (>= 2.14.0))
   (atdgen-runtime (>= 2.1.0))
   (atdgen-codec-runtime :with-test)
   (biniou (>= 1.0.6))


### PR DESCRIPTION
Fixed also in opam-repository for the 2.14.0 release https://github.com/ocaml/opam-repository/pull/24646

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
