### PR TITLE
atddiff: fix incorrect direction reported for new variant cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Unreleased
+-------------------
+
+* atddiff: Fixed reports for new variant cases. They are now correctly 
+  reported as forward incompatibilities (#373)
+
 2.14.0 (2023-10-19)
 -------------------
 

--- a/atddiff/src/lib/Compare.ml
+++ b/atddiff/src/lib/Compare.ml
@@ -441,7 +441,7 @@ let report_structural_mismatches options def_tbl1 def_tbl2 shared_types :
       |> List.iter (fun json_name ->
         let loc, (_name, _an), _opt_e = List.assoc json_name named2 in
         add stacks {
-          direction = Backward;
+          direction = Forward;
           kind = Missing_variant { variant_name = json_name };
           location_old = None;
           location_new = Some (loc |> Loc.of_atd_loc);

--- a/atddiff/test/default/forward_incompatible_variant.expected.txt
+++ b/atddiff/test/default/forward_incompatible_variant.expected.txt
@@ -1,4 +1,4 @@
-Backward incompatibility:
+Forward incompatibility:
 File "forward_incompatible_variant_new.atd", line 1, characters 42-43:
 Case 'B' is new.
 The following types are affected:

--- a/atddiff/test/default/json_variant_name_change.expected.txt
+++ b/atddiff/test/default/json_variant_name_change.expected.txt
@@ -22,25 +22,25 @@ Case 'dee' disappeared.
 The following types are affected:
   with_constructor_renames
 
-Backward incompatibility:
+Forward incompatibility:
 File "json_variant_name_change_new.atd", line 2, characters 4-22:
 Case 'a!' is new.
 The following types are affected:
   with_constructor_renames
 
-Backward incompatibility:
+Forward incompatibility:
 File "json_variant_name_change_new.atd", line 3, characters 4-29:
 Case 'b!' is new.
 The following types are affected:
   with_constructor_renames
 
-Backward incompatibility:
+Forward incompatibility:
 File "json_variant_name_change_new.atd", line 4, characters 4-5:
 Case 'C' is new.
 The following types are affected:
   with_constructor_renames
 
-Backward incompatibility:
+Forward incompatibility:
 File "json_variant_name_change_new.atd", line 5, characters 4-12:
 Case 'D' is new.
 The following types are affected:

--- a/atddiff/test/default/recursive.expected.txt
+++ b/atddiff/test/default/recursive.expected.txt
@@ -1,4 +1,4 @@
-Backward incompatibility:
+Forward incompatibility:
 File "recursive_new.atd", line 9, characters 52-53:
 Case 'B' is new.
 The following types are affected:

--- a/atddiff/test/json_output/all_errors.expected.txt
+++ b/atddiff/test/json_output/all_errors.expected.txt
@@ -100,7 +100,7 @@
     },
     {
       "finding": {
-        "direction": "Backward",
+        "direction": "Forward",
         "kind": [ "Missing_variant", { "variant_name": "New_case" } ],
         "location_new": {
           "start": { "path": "all_errors_new.atd", "line": 13, "column": 4 },
@@ -112,7 +112,7 @@
     },
     {
       "finding": {
-        "direction": "Backward",
+        "direction": "Forward",
         "kind": [
           "Missing_variant", { "variant_name": "New_case_with_arg" }
         ],


### PR DESCRIPTION
This is an ordinary bug.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
