### PR TITLE
Fix small typo in data validation tutorial

### DIFF
--- a/doc/atdgen-tutorial-data/validate/resume.ml
+++ b/doc/atdgen-tutorial-data/validate/resume.ml
@@ -1,7 +1,7 @@
 let check_experience x =
   let is_valid = match Resume_v.validate_work_experience [] x with
-    | None -> false
-    | _ -> true
+    | None -> true
+    | _ -> false
   in
   Printf.printf "%s:\n%s\n"
     (if is_valid then "VALID" else "INVALID")
@@ -11,7 +11,7 @@ let () =
   (* one valid date *)
   let valid = { Resume_t.year = 2000; month = 2; day = 29 } in
   (* one invalid date *)
-  let invalid = { Resume_t.year = 2010; month = 0; day = 0 } in
+  let invalid = { Resume_t.year = 1900; month = 0; day = 0 } in
   (* two more valid dates, created with Resume_v.create_date *)
   let date1 = { Resume_t.year = 2005; month = 8; day = 1 } in
   let date2 = { Resume_t.year = 2006; month = 3; day = 22 } in

--- a/doc/atdgen-tutorial.rst
+++ b/doc/atdgen-tutorial.rst
@@ -708,8 +708,8 @@ generated ``Resume_j`` in the following program written in ``resume.ml``:
 
   let check_experience x =
     let is_valid = match Resume_v.validate_work_experience [] x with
-      | None -> false
-      | _ -> true
+      | None -> true
+      | _ -> false
     in
     Printf.printf "%s:\n%s\n"
       (if is_valid then "VALID" else "INVALID")


### PR DESCRIPTION
Hello,

I've spotted a minor code inconsistency in `atdgen-tutorial.rst`, in the [data-validation](https://atd.readthedocs.io/en/latest/atdgen.html#data-validation) section. The test for validation was reversed, `Some _` should indicate some errors were found, and `None` means validation passed (`is_valid = true`).

I've updated the test file to align with the code quoted in the doc, also changed a date which was out of sync (unimportant).

Thank you!

### PR checklist

- [x] New code has tests to catch future regressions
  Not applicable, no new code.

- [ ] Documentation is up-to-date
  Successfully ran `dune build @doc`. Any other checks required? 

- [x] `CHANGES.md` is up-to-date
  Not applicable.
