### PR TITLE
Add test to exercise validation tutorial demo

### DIFF
--- a/doc/atdgen-tutorial-data/validate/dune
+++ b/doc/atdgen-tutorial-data/validate/dune
@@ -1,0 +1,24 @@
+(executable
+ (name resume)
+ (libraries atdgen-runtime yojson))
+
+(rule
+ (targets resume_t.ml resume_t.mli)
+ (deps resume.atd)
+ (action
+  (run %{bin:atdgen} %{deps} -t)))
+
+(rule
+ (targets resume_j.ml resume_j.mli)
+ (deps resume.atd)
+ (action
+  (run %{bin:atdgen} %{deps} -j)))
+
+(rule
+ (targets resume_v.ml resume_v.mli)
+ (deps resume.atd)
+ (action
+  (run %{bin:atdgen} %{deps} -v)))
+
+(cram
+ (deps resume.exe))

--- a/doc/atdgen-tutorial-data/validate/run.t
+++ b/doc/atdgen-tutorial-data/validate/run.t
@@ -1,0 +1,33 @@
+Capturing the current output of the demo.
+
+  $ ./resume.exe
+  VALID:
+  [
+    {
+      "company": "Acme Corp.",
+      "title": "Tester",
+      "start_date": { "year": 2005, "month": 8, "day": 1 },
+      "end_date": { "year": 2006, "month": 3, "day": 22 }
+    },
+    {
+      "company": "Acme Corp.",
+      "title": "Tester",
+      "start_date": { "year": 2000, "month": 2, "day": 29 },
+      "end_date": { "year": 2006, "month": 3, "day": 22 }
+    }
+  ]
+  INVALID:
+  [
+    {
+      "company": "Acme Corp.",
+      "title": "Tester",
+      "start_date": { "year": 2005, "month": 8, "day": 1 },
+      "end_date": { "year": 2006, "month": 3, "day": 22 }
+    },
+    {
+      "company": "Acme Corp.",
+      "title": "Tester",
+      "start_date": { "year": 2005, "month": 8, "day": 1 },
+      "end_date": { "year": 1900, "month": 0, "day": 0 }
+    }
+  ]

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 2.8)
 (using menhir 2.0)
 (implicit_transitive_deps false)
+(cram enable)
 
 (name atd)
 (license MIT)


### PR DESCRIPTION
Hello,

In this PR, I've proposed running the tutorial demo as part of `dune runtest` to ensure future-proofing. This change was prompted by the fix I made in test #395 (thanks for merging!).

If you find this approach beneficial, I'm more than willing to apply similar changes to the other tutorials. Assuming these would involve adding a few `dune` and `*.t` files, I'd be happy to contribute further.

I've noticed that adding `(cram enable)` to `dune-project` was necessary, which I believe is the default in a later version of `dune-lang`. If you're not comfortable with enabling cram tests globally, but still want diff tests in the tutorial, we can store the output in a file and use a dune diff rule instead. Please let me know your preference.

Thank you for considering my changes and for your work on `atd`.

PR checklist

- [x] New code has tests to catch future regressions
This PR adds a new test that is run as part of `dune runtest`.
- [x] Documentation is up-to-date 
This PR does not involve changes that require updates to the documentation.
- [x] CHANGES.md is up-to-date
This PR does not involve changes that require updates to CHANGES.md.