### PR TITLE
atdd: recursive variants and records

### DIFF
--- a/atdd/src/lib/Codegen.ml
+++ b/atdd/src/lib/Codegen.ml
@@ -931,7 +931,8 @@ let case_class env  type_name
           Line (sprintf {|// Original type: %s = [ ... | %s of ... | ... ]|}
                   type_name
                   orig_name);
-          Line (sprintf "struct %s { %s value; }" (trans env unique_name) (type_name_of_expr env e)); (* TODO : very dubious*)
+          Line (sprintf "struct %s {\n%s value; alias value this;" (trans env unique_name) (type_name_of_expr env e) ); 
+          Line (sprintf "@safe this(T)(T init) {value = init;} @safe this(%s init) {value = init.value;}}" (trans env unique_name));
           Line (sprintf "@trusted JSONValue toJson(T : %s)(T e) {"  (trans env unique_name));
           Block [Line(sprintf "return JSONValue([JSONValue(\"%s\"), %s(e.value)]);" (single_esc json_name) (json_writer env e))];
           Line("}");

--- a/atdd/src/lib/Codegen.ml
+++ b/atdd/src/lib/Codegen.ml
@@ -26,6 +26,7 @@ let annot_schema_dlang : Atd.Annot.schema_section =
   {
     section = "dlang";
     fields = [
+      Type_def, "shape";
       Type_expr, "t";
       Type_expr, "repr";
       Type_expr, "unwrap";

--- a/atdd/src/lib/Dlang_annot.ml
+++ b/atdd/src/lib/Dlang_annot.ml
@@ -8,6 +8,11 @@ type assoc_repr =
   | List
   | Dict
 
+type shape =
+  | Enum
+  | Default
+  | Recursive
+
 type atd_dlang_wrap = {
   dlang_wrap_t : string;
   dlang_wrap : string;
@@ -20,6 +25,19 @@ let get_dlang_default an : string option =
       ~sections:["dlang"]
       ~field:"default"
       an
+
+let get_dlang_type_shape an : shape =
+  Atd.Annot.get_field
+    ~parse:(function
+      | "enum" -> Some Enum
+      | "default" -> Some Default
+      | "rec" | "recursive" -> Some Recursive
+      | _ -> None
+    )
+    ~default:Default
+    ~sections:["dlang"]
+    ~field:"shape"
+    an
 
 let get_dlang_assoc_repr an : assoc_repr =
   Atd.Annot.get_field

--- a/atdd/src/lib/Dlang_annot.mli
+++ b/atdd/src/lib/Dlang_annot.mli
@@ -19,6 +19,18 @@ type assoc_repr =
   | List
   | Dict
 
+
+(** How to represent a variant or record.
+    [Recursive] Use this option when the type has recursive references, leading to members defined as pointers.
+    [Enum] If a variant doesn't contain fields, this option will allow to represent it as an enum instead of a sum type.
+*)
+type shape =
+  | Enum
+  | Default
+  | Recursive
+
+val get_dlang_type_shape : Atd.Annot.t -> shape
+
 (** Inspect annotations placed on lists of pairs such as
     [(string * foo) list <dlang repr="dict">].
     Permissible values for the [repr] field are ["dict"] and ["list"].

--- a/atdd/test/atd-input/everything.atd
+++ b/atdd/test/atd-input/everything.atd
@@ -21,6 +21,7 @@ type planet <dlang shape="enum"> = [
   | Jupiter
   | Neptune
   | Uranus
+  | Pluto <json name="not a planet">
 ]
 
 type ('a, 'b) parametrized_record = {

--- a/atdd/test/atd-input/everything.atd
+++ b/atdd/test/atd-input/everything.atd
@@ -89,6 +89,17 @@ type recursive_class <dlang shape="recursive"> = {
   children: recursive_class;
 }
 
+type record_that_uses_recursive_variant = 
+{
+  v: recursive_variant;
+  i: int;
+}
+
+type recursive_variant <dlang shape="recursive"> = [
+  | Int of int
+  | Record of record_that_uses_recursive_variant
+]
+
 type default_list = {
   ~items: int list;
 }

--- a/atdd/test/atd-input/everything.atd
+++ b/atdd/test/atd-input/everything.atd
@@ -12,6 +12,17 @@ type frozen = [
   | B of int
 ]
 
+type planet <dlang shape="enum"> = [
+  | Mercury
+  | Venus
+  | Earth
+  | Mars
+  | Saturn
+  | Jupiter
+  | Neptune
+  | Uranus
+]
+
 type ('a, 'b) parametrized_record = {
   field_a: 'a;
   ~field_b: 'b list;
@@ -71,10 +82,10 @@ type require_field = {
   req: string;
 }
 
-type recursive_class = {
+type recursive_class <dlang shape="recursive"> = {
   id: int;
   flag: bool;
-  children: recursive_class list;
+  children: recursive_class;
 }
 
 type default_list = {

--- a/atdd/test/atd-input/everything.atd
+++ b/atdd/test/atd-input/everything.atd
@@ -86,7 +86,7 @@ type require_field = {
 type recursive_class <dlang shape="recursive"> = {
   id: int;
   flag: bool;
-  children: recursive_class;
+  children: recursive_class nullable;
 }
 
 type record_that_uses_recursive_variant = 

--- a/atdd/test/dlang-expected/everything_atd.d
+++ b/atdd/test/dlang-expected/everything_atd.d
@@ -440,6 +440,67 @@ struct RecursiveClass {
 }
 
 
+struct RecordThatUsesRecursiveVariant {
+    RecursiveVariant v;
+    int i;
+}
+
+@trusted RecordThatUsesRecursiveVariant fromJson(T : RecordThatUsesRecursiveVariant)(JSONValue x) {
+    RecordThatUsesRecursiveVariant obj;
+    obj.v = ("v" in x) ? fromJson!RecursiveVariant(x["v"]) : _atd_missing_json_field!(typeof(obj.v))("RecordThatUsesRecursiveVariant", "v");
+    obj.i = ("i" in x) ? _atd_read_int(x["i"]) : _atd_missing_json_field!(typeof(obj.i))("RecordThatUsesRecursiveVariant", "i");
+    return obj;
+}
+@trusted JSONValue toJson(T : RecordThatUsesRecursiveVariant)(T obj) {
+    JSONValue res;
+    res["v"] = ((RecursiveVariant x) => x.toJson!(RecursiveVariant))(obj.v);
+    res["i"] = _atd_write_int(obj.i);
+    return res;
+}
+
+// Original type: recursive_variant = [ ... | Int of ... | ... ]
+struct Int {
+int* value; alias getValue this;
+this(T)(T init) @safe  {value = new int(init);} int getValue() @safe {return value is null ? (int).init : *value;}
+this(int init) @trusted {value = new int; *value = init;}}
+@trusted JSONValue toJson(T : Int)(T e) {
+    return JSONValue([JSONValue("Int"), _atd_write_int(e)]);
+}
+
+
+// Original type: recursive_variant = [ ... | Record of ... | ... ]
+struct Record {
+RecordThatUsesRecursiveVariant* value; alias getValue this;
+this(T)(T init) @safe  {value = new RecordThatUsesRecursiveVariant(init);} RecordThatUsesRecursiveVariant getValue() @safe {return value is null ? (RecordThatUsesRecursiveVariant).init : *value;}
+this(RecordThatUsesRecursiveVariant init) @trusted {value = new RecordThatUsesRecursiveVariant; *value = init;}}
+@trusted JSONValue toJson(T : Record)(T e) {
+    return JSONValue([JSONValue("Record"), ((RecordThatUsesRecursiveVariant x) => x.toJson!(RecordThatUsesRecursiveVariant))(e)]);
+}
+
+
+struct RecursiveVariant{ SumType!(Int, Record) _data; alias _data this;
+@safe this(T)(T init) {_data = init;} @safe this(RecursiveVariant init) {_data = init._data;}}
+
+@trusted RecursiveVariant fromJson(T : RecursiveVariant)(JSONValue x) {
+    if (x.type == JSONType.array && x.array.length == 2 && x[0].type == JSONType.string) {
+        string cons = x[0].str;
+        if (cons == "Int")
+            return RecursiveVariant(Int(_atd_read_int(x[1])));
+        if (cons == "Record")
+            return RecursiveVariant(Record(fromJson!RecordThatUsesRecursiveVariant(x[1])));
+        throw _atd_bad_json("RecursiveVariant", x);
+    }
+    throw _atd_bad_json("RecursiveVariant", x);
+}
+
+@trusted JSONValue toJson(T : RecursiveVariant)(T x) {
+    return x.match!(
+    (Int v) => v.toJson!(Int),
+(Record v) => v.toJson!(Record)
+    );
+}
+
+
 struct St{int _data; alias _data this;
 this(int init) @safe {_data = init;}
 this(St init) @safe {_data = init._data;}
@@ -463,9 +524,9 @@ struct Root_ {}
 // Original type: kind = [ ... | Thing of ... | ... ]
 struct Thing {
 int value; alias value this;
-@safe this(T)(T init) {value = init;} @safe this(Thing init) {value = init.value;}}
+this(T)(T init) @safe {value = init;} this(Thing init) @safe{value = init.value;}}
 @trusted JSONValue toJson(T : Thing)(T e) {
-    return JSONValue([JSONValue("Thing"), _atd_write_int(e.value)]);
+    return JSONValue([JSONValue("Thing"), _atd_write_int(e)]);
 }
 
 
@@ -479,9 +540,9 @@ struct WOW {}
 // Original type: kind = [ ... | Amaze of ... | ... ]
 struct Amaze {
 string[] value; alias value this;
-@safe this(T)(T init) {value = init;} @safe this(Amaze init) {value = init.value;}}
+this(T)(T init) @safe {value = init;} this(Amaze init) @safe{value = init.value;}}
 @trusted JSONValue toJson(T : Amaze)(T e) {
-    return JSONValue([JSONValue("!!!"), _atd_write_list!(_atd_write_string)(e.value)]);
+    return JSONValue([JSONValue("!!!"), _atd_write_list!(_atd_write_string)(e)]);
 }
 
 
@@ -838,9 +899,9 @@ struct A {}
 // Original type: frozen = [ ... | B of ... | ... ]
 struct B {
 int value; alias value this;
-@safe this(T)(T init) {value = init;} @safe this(B init) {value = init.value;}}
+this(T)(T init) @safe {value = init;} this(B init) @safe{value = init.value;}}
 @trusted JSONValue toJson(T : B)(T e) {
-    return JSONValue([JSONValue("B"), _atd_write_int(e.value)]);
+    return JSONValue([JSONValue("B"), _atd_write_int(e)]);
 }
 
 

--- a/atdd/test/dlang-expected/everything_atd.d
+++ b/atdd/test/dlang-expected/everything_atd.d
@@ -373,7 +373,9 @@ struct Root_ {}
 
 
 // Original type: kind = [ ... | Thing of ... | ... ]
-struct Thing { int value; }
+struct Thing {
+int value; alias value this;
+@safe this(T)(T init) {value = init;} @safe this(Thing init) {value = init.value;}}
 @trusted JSONValue toJson(T : Thing)(T e) {
     return JSONValue([JSONValue("Thing"), _atd_write_int(e.value)]);
 }
@@ -387,7 +389,9 @@ struct WOW {}
 
 
 // Original type: kind = [ ... | Amaze of ... | ... ]
-struct Amaze { string[] value; }
+struct Amaze {
+string[] value; alias value this;
+@safe this(T)(T init) {value = init;} @safe this(Amaze init) {value = init.value;}}
 @trusted JSONValue toJson(T : Amaze)(T e) {
     return JSONValue([JSONValue("!!!"), _atd_write_list!(_atd_write_string)(e.value)]);
 }
@@ -680,7 +684,9 @@ struct A {}
 
 
 // Original type: frozen = [ ... | B of ... | ... ]
-struct B { int value; }
+struct B {
+int value; alias value this;
+@safe this(T)(T init) {value = init;} @safe this(B init) {value = init.value;}}
 @trusted JSONValue toJson(T : B)(T e) {
     return JSONValue([JSONValue("B"), _atd_write_int(e.value)]);
 }

--- a/atdd/test/dlang-expected/everything_atd.d
+++ b/atdd/test/dlang-expected/everything_atd.d
@@ -421,21 +421,22 @@ import std.stdint : uint32_t, uint16_t;
 struct RecursiveClass {
     int id;
     bool flag;
-    RecursiveClass* children;
+    alias __children_type__ = Nullable!(RecursiveClass)*;
+    __children_type__ children;
 }
 
 @trusted RecursiveClass fromJson(T : RecursiveClass)(JSONValue x) {
     RecursiveClass obj;
     obj.id = ("id" in x) ? _atd_read_int(x["id"]) : _atd_missing_json_field!(typeof(obj.id))("RecursiveClass", "id");
     obj.flag = ("flag" in x) ? _atd_read_bool(x["flag"]) : _atd_missing_json_field!(typeof(obj.flag))("RecursiveClass", "flag");
-    obj.children = ("children" in x) ? _atd_read_ptr!(fromJson!RecursiveClass)(x["children"]) : _atd_missing_json_field!(typeof(obj.children))("RecursiveClass", "children");
+    obj.children = ("children" in x) ? _atd_read_ptr!(_atd_read_nullable!(fromJson!RecursiveClass))(x["children"]) : _atd_missing_json_field!(typeof(obj.children))("RecursiveClass", "children");
     return obj;
 }
 @trusted JSONValue toJson(T : RecursiveClass)(T obj) {
     JSONValue res;
     res["id"] = _atd_write_int(obj.id);
     res["flag"] = _atd_write_bool(obj.flag);
-    res["children"] = _atd_write_ptr!(((RecursiveClass x) => x.toJson!(RecursiveClass)))(obj.children);
+    res["children"] = _atd_write_ptr!(_atd_write_nullable!(((RecursiveClass x) => x.toJson!(RecursiveClass))))(obj.children);
     return res;
 }
 

--- a/atdd/test/dlang-expected/everything_atd.d
+++ b/atdd/test/dlang-expected/everything_atd.d
@@ -733,99 +733,68 @@ struct RecordWithWrappedType {
 }
 
 
-// Original type: planet = [ ... | Mercury | ... ]
-struct Mercury {}
-@trusted JSONValue toJson(T : Mercury)(T e) {
-    return JSONValue("Mercury");
+enum Planet{
+Mercury,
+Venus,
+Earth,
+Mars,
+Saturn,
+Jupiter,
+Neptune,
+Uranus,
+Pluto
 }
 
-
-// Original type: planet = [ ... | Venus | ... ]
-struct Venus {}
-@trusted JSONValue toJson(T : Venus)(T e) {
-    return JSONValue("Venus");
-}
-
-
-// Original type: planet = [ ... | Earth | ... ]
-struct Earth {}
-@trusted JSONValue toJson(T : Earth)(T e) {
-    return JSONValue("Earth");
-}
-
-
-// Original type: planet = [ ... | Mars | ... ]
-struct Mars {}
-@trusted JSONValue toJson(T : Mars)(T e) {
-    return JSONValue("Mars");
-}
-
-
-// Original type: planet = [ ... | Saturn | ... ]
-struct Saturn {}
-@trusted JSONValue toJson(T : Saturn)(T e) {
-    return JSONValue("Saturn");
-}
-
-
-// Original type: planet = [ ... | Jupiter | ... ]
-struct Jupiter {}
-@trusted JSONValue toJson(T : Jupiter)(T e) {
-    return JSONValue("Jupiter");
-}
-
-
-// Original type: planet = [ ... | Neptune | ... ]
-struct Neptune {}
-@trusted JSONValue toJson(T : Neptune)(T e) {
-    return JSONValue("Neptune");
-}
-
-
-// Original type: planet = [ ... | Uranus | ... ]
-struct Uranus {}
-@trusted JSONValue toJson(T : Uranus)(T e) {
-    return JSONValue("Uranus");
-}
-
-
-struct Planet{ SumType!(Mercury, Venus, Earth, Mars, Saturn, Jupiter, Neptune, Uranus) _data; alias _data this;
-@safe this(T)(T init) {_data = init;} @safe this(Planet init) {_data = init._data;}}
-
-@trusted Planet fromJson(T : Planet)(JSONValue x) {
-    if (x.type == JSONType.string) {
-        if (x.str == "Mercury") 
-            return Planet(Mercury());
-        if (x.str == "Venus") 
-            return Planet(Venus());
-        if (x.str == "Earth") 
-            return Planet(Earth());
-        if (x.str == "Mars") 
-            return Planet(Mars());
-        if (x.str == "Saturn") 
-            return Planet(Saturn());
-        if (x.str == "Jupiter") 
-            return Planet(Jupiter());
-        if (x.str == "Neptune") 
-            return Planet(Neptune());
-        if (x.str == "Uranus") 
-            return Planet(Uranus());
-        throw _atd_bad_json("Planet", x);
+Planet fromJson(T : Planet)(JSONValue x) @trusted {
+if (x.type == JSONType.string) {
+    switch (x.str)
+    {
+    case "Mercury":
+ return Planet.Mercury;
+case "Venus":
+ return Planet.Venus;
+case "Earth":
+ return Planet.Earth;
+case "Mars":
+ return Planet.Mars;
+case "Saturn":
+ return Planet.Saturn;
+case "Jupiter":
+ return Planet.Jupiter;
+case "Neptune":
+ return Planet.Neptune;
+case "Uranus":
+ return Planet.Uranus;
+case "not a planet":
+ return Planet.Pluto;
+    default: throw _atd_bad_json("Planet", x);
     }
-    throw _atd_bad_json("Planet", x);
+}
+throw _atd_bad_json("Planet", x);
 }
 
-@trusted JSONValue toJson(T : Planet)(T x) {
-    return x.match!(
-    (Mercury v) => v.toJson!(Mercury),
-(Venus v) => v.toJson!(Venus),
-(Earth v) => v.toJson!(Earth),
-(Mars v) => v.toJson!(Mars),
-(Saturn v) => v.toJson!(Saturn),
-(Jupiter v) => v.toJson!(Jupiter),
-(Neptune v) => v.toJson!(Neptune),
-(Uranus v) => v.toJson!(Uranus)
-    );
+JSONValue toJson(T : Planet)(T x) @trusted {
+    final switch (x) with (x)
+    {
+    case Mercury:
+ return JSONValue("Mercury");
+case Venus:
+ return JSONValue("Venus");
+case Earth:
+ return JSONValue("Earth");
+case Mars:
+ return JSONValue("Mars");
+case Saturn:
+ return JSONValue("Saturn");
+case Jupiter:
+ return JSONValue("Jupiter");
+case Neptune:
+ return JSONValue("Neptune");
+case Uranus:
+ return JSONValue("Uranus");
+case Pluto:
+ return JSONValue("not a planet");
+    }
 }
 
 

--- a/atdd/test/dlang-expected/everything_atd.d
+++ b/atdd/test/dlang-expected/everything_atd.d
@@ -421,21 +421,21 @@ import std.stdint : uint32_t, uint16_t;
 struct RecursiveClass {
     int id;
     bool flag;
-    RecursiveClass[] children;
+    RecursiveClass* children;
 }
 
 @trusted RecursiveClass fromJson(T : RecursiveClass)(JSONValue x) {
     RecursiveClass obj;
     obj.id = ("id" in x) ? _atd_read_int(x["id"]) : _atd_missing_json_field!(typeof(obj.id))("RecursiveClass", "id");
     obj.flag = ("flag" in x) ? _atd_read_bool(x["flag"]) : _atd_missing_json_field!(typeof(obj.flag))("RecursiveClass", "flag");
-    obj.children = ("children" in x) ? _atd_read_list!(fromJson!RecursiveClass)(x["children"]) : _atd_missing_json_field!(typeof(obj.children))("RecursiveClass", "children");
+    obj.children = ("children" in x) ? _atd_read_ptr!(fromJson!RecursiveClass)(x["children"]) : _atd_missing_json_field!(typeof(obj.children))("RecursiveClass", "children");
     return obj;
 }
 @trusted JSONValue toJson(T : RecursiveClass)(T obj) {
     JSONValue res;
     res["id"] = _atd_write_int(obj.id);
     res["flag"] = _atd_write_bool(obj.flag);
-    res["children"] = _atd_write_list!(((RecursiveClass x) => x.toJson!(RecursiveClass)))(obj.children);
+    res["children"] = _atd_write_ptr!(((RecursiveClass x) => x.toJson!(RecursiveClass)))(obj.children);
     return res;
 }
 
@@ -613,12 +613,12 @@ struct Root {
     float float_with_auto_default = 0.0;
     float float_with_default = 0.1;
     int[][] items;
-    Nullable!(int)* maybe;
+    Nullable!(int) maybe;
     int[] extras = [];
     int answer = 42;
-    Alias* aliased;
-    Tuple!(float, float)* point;
-    Kind* kind;
+    Alias aliased;
+    Tuple!(float, float) point;
+    Kind kind;
     Kind[] kinds;
     Tuple!(float, int)[] assoc1;
     Tuple!(string, int)[] assoc2;
@@ -627,10 +627,10 @@ struct Root {
     Nullable!(int)[] nullables;
     Nullable!(int)[] options;
     JSONValue[] untyped_things;
-    IntFloatParametrizedRecord* parametrized_record;
-    KindParametrizedTuple* parametrized_tuple;
+    IntFloatParametrizedRecord parametrized_record;
+    KindParametrizedTuple parametrized_tuple;
     uint16_t wrapped;
-    AliasOfAliasOfAlias* aaa;
+    AliasOfAliasOfAlias aaa;
 }
 
 @trusted Root fromJson(T : Root)(JSONValue x) {
@@ -642,16 +642,16 @@ struct Root {
     obj.float_with_auto_default = ("float_with_auto_default" in x) ? _atd_read_float(x["float_with_auto_default"]) : 0.0;
     obj.float_with_default = ("float_with_default" in x) ? _atd_read_float(x["float_with_default"]) : 0.1;
     obj.items = ("items" in x) ? _atd_read_list!(_atd_read_list!(_atd_read_int))(x["items"]) : _atd_missing_json_field!(typeof(obj.items))("Root", "items");
-    obj.maybe = ("maybe" in x) ? _atd_read_ptr!(_atd_read_option!(_atd_read_int))(x["maybe"]) : typeof(obj.maybe).init;
+    obj.maybe = ("maybe" in x) ? _atd_read_option!(_atd_read_int)(x["maybe"]) : typeof(obj.maybe).init;
     obj.extras = ("extras" in x) ? _atd_read_list!(_atd_read_int)(x["extras"]) : [];
     obj.answer = ("answer" in x) ? _atd_read_int(x["answer"]) : 42;
-    obj.aliased = ("aliased" in x) ? _atd_read_ptr!(fromJson!Alias)(x["aliased"]) : _atd_missing_json_field!(typeof(obj.aliased))("Root", "aliased");
-    obj.point = ("point" in x) ? _atd_read_ptr!(((JSONValue x) @trusted { 
+    obj.aliased = ("aliased" in x) ? fromJson!Alias(x["aliased"]) : _atd_missing_json_field!(typeof(obj.aliased))("Root", "aliased");
+    obj.point = ("point" in x) ? ((JSONValue x) @trusted { 
     if (x.type != JSONType.array || x.array.length != 2)
       throw _atd_bad_json("Tuple of size 2", x);
     return tuple(_atd_read_float(x[0]), _atd_read_float(x[1]));
-  }))(x["point"]) : _atd_missing_json_field!(typeof(obj.point))("Root", "point");
-    obj.kind = ("kind" in x) ? _atd_read_ptr!(fromJson!Kind)(x["kind"]) : _atd_missing_json_field!(typeof(obj.kind))("Root", "kind");
+  })(x["point"]) : _atd_missing_json_field!(typeof(obj.point))("Root", "point");
+    obj.kind = ("kind" in x) ? fromJson!Kind(x["kind"]) : _atd_missing_json_field!(typeof(obj.kind))("Root", "kind");
     obj.kinds = ("kinds" in x) ? _atd_read_list!(fromJson!Kind)(x["kinds"]) : _atd_missing_json_field!(typeof(obj.kinds))("Root", "kinds");
     obj.assoc1 = ("assoc1" in x) ? _atd_read_list!(((JSONValue x) @trusted { 
     if (x.type != JSONType.array || x.array.length != 2)
@@ -664,10 +664,10 @@ struct Root {
     obj.nullables = ("nullables" in x) ? _atd_read_list!(_atd_read_nullable!(_atd_read_int))(x["nullables"]) : _atd_missing_json_field!(typeof(obj.nullables))("Root", "nullables");
     obj.options = ("options" in x) ? _atd_read_list!(_atd_read_option!(_atd_read_int))(x["options"]) : _atd_missing_json_field!(typeof(obj.options))("Root", "options");
     obj.untyped_things = ("untyped_things" in x) ? _atd_read_list!(((JSONValue x) => x))(x["untyped_things"]) : _atd_missing_json_field!(typeof(obj.untyped_things))("Root", "untyped_things");
-    obj.parametrized_record = ("parametrized_record" in x) ? _atd_read_ptr!(fromJson!IntFloatParametrizedRecord)(x["parametrized_record"]) : _atd_missing_json_field!(typeof(obj.parametrized_record))("Root", "parametrized_record");
-    obj.parametrized_tuple = ("parametrized_tuple" in x) ? _atd_read_ptr!(fromJson!KindParametrizedTuple)(x["parametrized_tuple"]) : _atd_missing_json_field!(typeof(obj.parametrized_tuple))("Root", "parametrized_tuple");
+    obj.parametrized_record = ("parametrized_record" in x) ? fromJson!IntFloatParametrizedRecord(x["parametrized_record"]) : _atd_missing_json_field!(typeof(obj.parametrized_record))("Root", "parametrized_record");
+    obj.parametrized_tuple = ("parametrized_tuple" in x) ? fromJson!KindParametrizedTuple(x["parametrized_tuple"]) : _atd_missing_json_field!(typeof(obj.parametrized_tuple))("Root", "parametrized_tuple");
     obj.wrapped = ("wrapped" in x) ? _atd_read_wrap!(fromJson!St, (St e) => ((St st) => st.to!int.to!uint16_t)(e))(x["wrapped"]) : _atd_missing_json_field!(typeof(obj.wrapped))("Root", "wrapped");
-    obj.aaa = ("aaa" in x) ? _atd_read_ptr!(fromJson!AliasOfAliasOfAlias)(x["aaa"]) : _atd_missing_json_field!(typeof(obj.aaa))("Root", "aaa");
+    obj.aaa = ("aaa" in x) ? fromJson!AliasOfAliasOfAlias(x["aaa"]) : _atd_missing_json_field!(typeof(obj.aaa))("Root", "aaa");
     return obj;
 }
 @trusted JSONValue toJson(T : Root)(T obj) {
@@ -679,12 +679,12 @@ struct Root {
     res["float_with_auto_default"] = _atd_write_float(obj.float_with_auto_default);
     res["float_with_default"] = _atd_write_float(obj.float_with_default);
     res["items"] = _atd_write_list!(_atd_write_list!(_atd_write_int))(obj.items);
-    res["maybe"] = _atd_write_ptr!(_atd_write_option!(_atd_write_int))(obj.maybe);
+    res["maybe"] = _atd_write_option!(_atd_write_int)(obj.maybe);
     res["extras"] = _atd_write_list!(_atd_write_int)(obj.extras);
     res["answer"] = _atd_write_int(obj.answer);
-    res["aliased"] = _atd_write_ptr!(((Alias x) => x.toJson!(Alias)))(obj.aliased);
-    res["point"] = _atd_write_ptr!(((Tuple!(float, float) x) => JSONValue([_atd_write_float(x[0]), _atd_write_float(x[1])])))(obj.point);
-    res["kind"] = _atd_write_ptr!(((Kind x) => x.toJson!(Kind)))(obj.kind);
+    res["aliased"] = ((Alias x) => x.toJson!(Alias))(obj.aliased);
+    res["point"] = ((Tuple!(float, float) x) => JSONValue([_atd_write_float(x[0]), _atd_write_float(x[1])]))(obj.point);
+    res["kind"] = ((Kind x) => x.toJson!(Kind))(obj.kind);
     res["kinds"] = _atd_write_list!(((Kind x) => x.toJson!(Kind)))(obj.kinds);
     res["assoc1"] = _atd_write_list!(((Tuple!(float, int) x) => JSONValue([_atd_write_float(x[0]), _atd_write_int(x[1])])))(obj.assoc1);
     res["assoc2"] = _atd_write_tuple_list_to_object!(_atd_write_int)(obj.assoc2);
@@ -693,10 +693,10 @@ struct Root {
     res["nullables"] = _atd_write_list!(_atd_write_nullable!(_atd_write_int))(obj.nullables);
     res["options"] = _atd_write_list!(_atd_write_option!(_atd_write_int))(obj.options);
     res["untyped_things"] = _atd_write_list!((JSONValue x) => x)(obj.untyped_things);
-    res["parametrized_record"] = _atd_write_ptr!(((IntFloatParametrizedRecord x) => x.toJson!(IntFloatParametrizedRecord)))(obj.parametrized_record);
-    res["parametrized_tuple"] = _atd_write_ptr!(((KindParametrizedTuple x) => x.toJson!(KindParametrizedTuple)))(obj.parametrized_tuple);
+    res["parametrized_record"] = ((IntFloatParametrizedRecord x) => x.toJson!(IntFloatParametrizedRecord))(obj.parametrized_record);
+    res["parametrized_tuple"] = ((KindParametrizedTuple x) => x.toJson!(KindParametrizedTuple))(obj.parametrized_tuple);
     res["wrapped"] = _atd_write_wrap!(((St x) => x.toJson!(St)), (uint16_t e) => ((uint16_t e) => St(e.to!int))(e))(obj.wrapped);
-    res["aaa"] = _atd_write_ptr!(((AliasOfAliasOfAlias x) => x.toJson!(AliasOfAliasOfAlias)))(obj.aaa);
+    res["aaa"] = ((AliasOfAliasOfAlias x) => x.toJson!(AliasOfAliasOfAlias))(obj.aaa);
     return res;
 }
 
@@ -730,6 +730,102 @@ struct RecordWithWrappedType {
     JSONValue res;
     res["item"] = _atd_write_wrap!(_atd_write_string, (int e) => to!string(e))(obj.item);
     return res;
+}
+
+
+// Original type: planet = [ ... | Mercury | ... ]
+struct Mercury {}
+@trusted JSONValue toJson(T : Mercury)(T e) {
+    return JSONValue("Mercury");
+}
+
+
+// Original type: planet = [ ... | Venus | ... ]
+struct Venus {}
+@trusted JSONValue toJson(T : Venus)(T e) {
+    return JSONValue("Venus");
+}
+
+
+// Original type: planet = [ ... | Earth | ... ]
+struct Earth {}
+@trusted JSONValue toJson(T : Earth)(T e) {
+    return JSONValue("Earth");
+}
+
+
+// Original type: planet = [ ... | Mars | ... ]
+struct Mars {}
+@trusted JSONValue toJson(T : Mars)(T e) {
+    return JSONValue("Mars");
+}
+
+
+// Original type: planet = [ ... | Saturn | ... ]
+struct Saturn {}
+@trusted JSONValue toJson(T : Saturn)(T e) {
+    return JSONValue("Saturn");
+}
+
+
+// Original type: planet = [ ... | Jupiter | ... ]
+struct Jupiter {}
+@trusted JSONValue toJson(T : Jupiter)(T e) {
+    return JSONValue("Jupiter");
+}
+
+
+// Original type: planet = [ ... | Neptune | ... ]
+struct Neptune {}
+@trusted JSONValue toJson(T : Neptune)(T e) {
+    return JSONValue("Neptune");
+}
+
+
+// Original type: planet = [ ... | Uranus | ... ]
+struct Uranus {}
+@trusted JSONValue toJson(T : Uranus)(T e) {
+    return JSONValue("Uranus");
+}
+
+
+struct Planet{ SumType!(Mercury, Venus, Earth, Mars, Saturn, Jupiter, Neptune, Uranus) _data; alias _data this;
+@safe this(T)(T init) {_data = init;} @safe this(Planet init) {_data = init._data;}}
+
+@trusted Planet fromJson(T : Planet)(JSONValue x) {
+    if (x.type == JSONType.string) {
+        if (x.str == "Mercury") 
+            return Planet(Mercury());
+        if (x.str == "Venus") 
+            return Planet(Venus());
+        if (x.str == "Earth") 
+            return Planet(Earth());
+        if (x.str == "Mars") 
+            return Planet(Mars());
+        if (x.str == "Saturn") 
+            return Planet(Saturn());
+        if (x.str == "Jupiter") 
+            return Planet(Jupiter());
+        if (x.str == "Neptune") 
+            return Planet(Neptune());
+        if (x.str == "Uranus") 
+            return Planet(Uranus());
+        throw _atd_bad_json("Planet", x);
+    }
+    throw _atd_bad_json("Planet", x);
+}
+
+@trusted JSONValue toJson(T : Planet)(T x) {
+    return x.match!(
+    (Mercury v) => v.toJson!(Mercury),
+(Venus v) => v.toJson!(Venus),
+(Earth v) => v.toJson!(Earth),
+(Mars v) => v.toJson!(Mars),
+(Saturn v) => v.toJson!(Saturn),
+(Jupiter v) => v.toJson!(Jupiter),
+(Neptune v) => v.toJson!(Neptune),
+(Uranus v) => v.toJson!(Uranus)
+    );
 }
 
 
@@ -823,19 +919,19 @@ struct DefaultList {
 
 struct Credential {
     string name;
-    Password* password;
+    Password password;
 }
 
 @trusted Credential fromJson(T : Credential)(JSONValue x) {
     Credential obj;
     obj.name = ("name" in x) ? _atd_read_string(x["name"]) : _atd_missing_json_field!(typeof(obj.name))("Credential", "name");
-    obj.password = ("password" in x) ? _atd_read_ptr!(fromJson!Password)(x["password"]) : _atd_missing_json_field!(typeof(obj.password))("Credential", "password");
+    obj.password = ("password" in x) ? fromJson!Password(x["password"]) : _atd_missing_json_field!(typeof(obj.password))("Credential", "password");
     return obj;
 }
 @trusted JSONValue toJson(T : Credential)(T obj) {
     JSONValue res;
     res["name"] = _atd_write_string(obj.name);
-    res["password"] = _atd_write_ptr!(((Password x) => x.toJson!(Password)))(obj.password);
+    res["password"] = ((Password x) => x.toJson!(Password))(obj.password);
     return res;
 }
 

--- a/atdd/test/dlang-tests/test_atdd.d
+++ b/atdd/test/dlang-tests/test_atdd.d
@@ -171,8 +171,9 @@ void setupTests()
     };
 
     tests["recursiveClass"] = {
-        auto child1 = new RecursiveClass(1, true, null);
-        auto a_obj = RecursiveClass(0, false, child1);
+        import std.typecons;
+        auto child = new Nullable!RecursiveClass(RecursiveClass(1, true, null));
+        auto a_obj = RecursiveClass(0, false, child);
 
         assert (a_obj.toJsonString == a_obj.toJsonString.fromJsonString!RecursiveClass.toJsonString);
     };

--- a/atdd/test/dlang-tests/test_atdd.d
+++ b/atdd/test/dlang-tests/test_atdd.d
@@ -71,7 +71,7 @@ void setupTests()
         obj.assoc4 = ["g": 7, "h": 8];
         obj.kind = Root_().to!Kind;
         obj.kinds = [
-            WOW().to!Kind, Thing(99).to!Kind, Amaze(["a", "b"]).to!Kind, Root_().to!Kind
+            WOW().to!Kind, 99.to!Thing.to!Kind, ["a", "b"].to!Amaze.to!Kind, Root_().to!Kind
         ];
         obj.nullables = [
             12.Nullable!int, Nullable!int.init, Nullable!int.init,

--- a/atdd/test/dlang-tests/test_atdd.d
+++ b/atdd/test/dlang-tests/test_atdd.d
@@ -10,6 +10,13 @@ bool testFailed = false;
 
 void setupTests()
 {
+    tests["basicTypes"] = {
+        auto floatList = [0.1, 0.5, -0.8];
+        auto jsonStr = floatList.toJsonString;
+
+        assert(floatList.toJsonString == jsonStr.fromJsonString!(float[]).toJsonString);
+    };
+
     tests["simpleRecord"] = {
         auto record = IntFloatParametrizedRecord(32, [5.4, 3.3]);
 
@@ -62,14 +69,14 @@ void setupTests()
         obj.x___init__ = 0.32f;
         obj.items = [[], [1, 2]];
         obj.extras = [17, 53];
-        obj.aliased = [1, 6, 8];
-        obj.maybe = 43;
-        obj.point = tuple(4.3, 1.2);
+        obj.aliased = new Alias([1, 6, 8]);
+        obj.maybe = new Nullable!int(43);
+        obj.point = new Tuple!(float, float)(tuple(4.3, 1.2));
         obj.assoc1 = [tuple(3.4f, 2), tuple(1.1f, 2)]; // Can be not ordered by key
         obj.assoc2 = [tuple("d", 3), tuple("e", 7)]; // Must be ordered by key because we lose ordering when writing
         obj.assoc3 = [4.4f: 4, 5.5f: 5];
         obj.assoc4 = ["g": 7, "h": 8];
-        obj.kind = Root_().to!Kind;
+        obj.kind = new Kind(Root_().to!Kind);
         obj.kinds = [
             WOW().to!Kind, 99.to!Thing.to!Kind, ["a", "b"].to!Amaze.to!Kind, Root_().to!Kind
         ];
@@ -86,14 +93,14 @@ void setupTests()
             JSONValue(new int[string]),
             JSONValue(123)
         ];
-        obj.parametrized_record = IntFloatParametrizedRecord(42, [9.9f, 8.8f]);
-        obj.parametrized_tuple = KindParametrizedTuple(WOW(), WOW(), 100);
+        obj.parametrized_record = new IntFloatParametrizedRecord(42, [9.9f, 8.8f]);
+        obj.parametrized_tuple = new KindParametrizedTuple(WOW(), WOW(), 100);
 
         () @safe {
             auto jsonStr = obj.toJsonString;
             auto newObj = jsonStr.fromJsonString!Root;
 
-            assert(obj == newObj);
+            assert(obj.toJsonString == newObj.toJsonString);
         }();
     };
 

--- a/atdd/test/dlang-tests/test_atdd.d
+++ b/atdd/test/dlang-tests/test_atdd.d
@@ -193,6 +193,14 @@ void setupTests()
 
         auto mapResult = credientials.map!((c) => c);
     };
+
+    tests["variant enum"] = {
+        Planet p = Planet.Earth;
+
+        auto res = p.toJsonString.fromJsonString!Planet;
+
+        assert(res.toJsonString == p.toJsonString);
+    };
 }
 
 void assertThrows(T)(T fn, bool writeMsg = false)

--- a/atdd/test/dlang-tests/test_atdd.d
+++ b/atdd/test/dlang-tests/test_atdd.d
@@ -201,6 +201,17 @@ void setupTests()
 
         assert(res.toJsonString == p.toJsonString);
     };
+
+    tests["recursive variant"] = {
+        import std.sumtype;
+        import std.conv;
+
+        auto v = RecursiveVariant(Int(43));
+        auto r = RecordThatUsesRecursiveVariant(v, 42);
+        auto vv = RecursiveVariant(Record(r));
+
+        assert(vv.toJsonString == vv.toJsonString.fromJsonString!RecursiveVariant.toJsonString);
+    };
 }
 
 void assertThrows(T)(T fn, bool writeMsg = false)

--- a/atdd/test/dlang-tests/test_atdd.d
+++ b/atdd/test/dlang-tests/test_atdd.d
@@ -69,14 +69,14 @@ void setupTests()
         obj.x___init__ = 0.32f;
         obj.items = [[], [1, 2]];
         obj.extras = [17, 53];
-        obj.aliased = new Alias([1, 6, 8]);
-        obj.maybe = new Nullable!int(43);
-        obj.point = new Tuple!(float, float)(tuple(4.3, 1.2));
+        obj.aliased = [1, 6, 8];
+        obj.maybe = 43;
+        obj.point = tuple(4.3, 1.2);
         obj.assoc1 = [tuple(3.4f, 2), tuple(1.1f, 2)]; // Can be not ordered by key
         obj.assoc2 = [tuple("d", 3), tuple("e", 7)]; // Must be ordered by key because we lose ordering when writing
         obj.assoc3 = [4.4f: 4, 5.5f: 5];
         obj.assoc4 = ["g": 7, "h": 8];
-        obj.kind = new Kind(Root_().to!Kind);
+        obj.kind = Root_().to!Kind;
         obj.kinds = [
             WOW().to!Kind, 99.to!Thing.to!Kind, ["a", "b"].to!Amaze.to!Kind, Root_().to!Kind
         ];
@@ -93,8 +93,8 @@ void setupTests()
             JSONValue(new int[string]),
             JSONValue(123)
         ];
-        obj.parametrized_record = new IntFloatParametrizedRecord(42, [9.9f, 8.8f]);
-        obj.parametrized_tuple = new KindParametrizedTuple(WOW(), WOW(), 100);
+        obj.parametrized_record = IntFloatParametrizedRecord(42, [9.9f, 8.8f]);
+        obj.parametrized_tuple = KindParametrizedTuple(WOW(), WOW(), 100);
 
         () @safe {
             auto jsonStr = obj.toJsonString;
@@ -171,11 +171,10 @@ void setupTests()
     };
 
     tests["recursiveClass"] = {
-        auto child1 = RecursiveClass(1, true, []);
-        auto child2 = RecursiveClass(2, true, []);
-        auto a_obj = RecursiveClass(0, false, [child1, child2]);
+        auto child1 = new RecursiveClass(1, true, null);
+        auto a_obj = RecursiveClass(0, false, child1);
 
-        assert (a_obj == a_obj.toJsonString.fromJsonString!RecursiveClass);
+        assert (a_obj.toJsonString == a_obj.toJsonString.fromJsonString!RecursiveClass.toJsonString);
     };
 
     tests["using wrapped type"] = {


### PR DESCRIPTION
- Add support for recursive variants through the following syntax :
```ocaml
type record_that_uses_recursive_variant = 
{
  v: recursive_variant;
  i: int;
}

type recursive_variant <dlang shape="recursive"> = [
  | Int of int
  | Record of record_that_uses_recursive_variant
]
```
- Add support for recursive records :
```ocaml
type recursive_class <dlang shape="recursive"> = {
  id: int;
  flag: bool;
  children: recursive_class nullable;
}
```
- Add option to use `enum` as data type for variant without data 
```ocaml
type planet <dlang shape="enum"> = [
  | Mercury
  | Venus
  | Earth
  | Mars
  | Saturn
  | Jupiter
  | Neptune
  | Uranus
]
```
Closes https://github.com/ahrefs/atd/issues/392