### PR TITLE
atdgen: support for wrapped keys for object repr in melange

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Unreleased
 * atdgen: Breaking change, migrate from Bucklescript to Melange (#375)
 * atdd: Workaround d compiler bug regarding declaration order when using aliases (#393)
         Algebraic data types (SumType) now uses `alias this` syntax.
-* atdgen: Add support for wrapped keys when using `json repr="object` (#403)
+* atdgen: Add support for wrapped keys when using `json repr="object"` (#403)
 
 2.15.0 (2023-10-26)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Unreleased
 * atdgen: Breaking change, migrate from Bucklescript to Melange (#375)
 * atdd: Workaround d compiler bug regarding declaration order when using aliases (#393)
         Algebraic data types (SumType) now uses `alias this` syntax.
+* atdgen: Add support for wrapped keys when using `json repr="object` (#403)
 
 2.15.0 (2023-10-26)
 -------------------

--- a/atdgen-codec-runtime/src/decode.ml
+++ b/atdgen-codec-runtime/src/decode.ml
@@ -38,12 +38,12 @@ let array f = function
   | `List l -> Array.map f (Array.of_list l)
   | _ -> raise DecoderError
 
-let obj_list f = function
-  | `Assoc l -> List.map (fun (k, v) -> k, f v) l
+let obj_list ~decode_name f = function
+  | `Assoc l -> List.map (fun (k, v) -> decode_name (`String k), f v) l
   | _ -> raise DecoderError
 
-let obj_array f = function
-  | `Assoc l -> Array.map (fun (k, v) -> k, f v) (Array.of_list l)
+let obj_array ~decode_name f = function
+  | `Assoc l -> Array.map (fun (k, v) -> decode_name (`String k), f v) (Array.of_list l)
   | _ -> raise DecoderError
 
 let optional f j =

--- a/atdgen-codec-runtime/src/decode.mli
+++ b/atdgen-codec-runtime/src/decode.mli
@@ -14,8 +14,8 @@ val string : string t
 val optional : 'a t -> 'a option t
 val list : 'a t -> 'a list t
 val array : 'a t -> 'a array t
-val obj_list : 'a t -> (string * 'a) list t
-val obj_array : 'a t -> (string * 'a) array t
+val obj_list : decode_name:'k t -> 'a t -> ('k * 'a) list t
+val obj_array : decode_name:'k t -> 'a t -> ('k * 'a) array t
 
 (* a field that should be present *)
 val field : string -> 'a t -> 'a t

--- a/atdgen-codec-runtime/src/encode.mli
+++ b/atdgen-codec-runtime/src/encode.mli
@@ -19,8 +19,8 @@ val int64 : int64 t
 
 type field
 
-val field : ?default:'a -> 'a t -> name:string -> 'a -> field
-val field_o : ?default:'a -> 'a t -> name:string -> 'a option -> field
+val field : ?default:'a -> encode_name:'k t -> 'a t -> name:'k -> 'a -> field
+val field_o : ?default:'a -> encode_name:'k t -> 'a t -> name:'k -> 'a option -> field
 
 val obj : field list -> Json.t
 

--- a/atdgen/test/melange/melangespec.atd
+++ b/atdgen/test/melange/melangespec.atd
@@ -108,3 +108,7 @@ type variant2 = [
   | A
   | C
 ] <ocaml repr="classic">
+
+type int_object =
+   ( string wrap <ocaml t="int" wrap="int_of_string" unwrap="string_of_int">
+   * int) list <json repr="object">

--- a/atdgen/test/melange/melangespec_j.expected.ml
+++ b/atdgen/test/melange/melangespec_j.expected.ml
@@ -52,6 +52,8 @@ type label = Melangespec_t.label
 
 type labeled = Melangespec_t.labeled = { flag: valid; lb: label; count: int }
 
+type int_object = Melangespec_t.int_object
+
 type from_module_a = A_t.from_module_a
 
 type b = Melangespec_t.b = { thing: int }
@@ -2332,6 +2334,57 @@ let read_labeled = (
 )
 let labeled_of_string s =
   read_labeled (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_2a90d8e = (
+  fun ob x -> (
+    let x = ( string_of_int ) x in (
+      Yojson.Safe.write_string
+    ) ob x)
+)
+let string_of__x_2a90d8e ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__x_2a90d8e ob x;
+  Buffer.contents ob
+let read__x_2a90d8e = (
+  fun p lb ->
+    let x = (
+      Atdgen_runtime.Oj_run.read_string
+    ) p lb in
+    ( int_of_string ) x
+)
+let _x_2a90d8e_of_string s =
+  read__x_2a90d8e (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_946c399 = (
+  Atdgen_runtime.Oj_run.write_assoc_list (
+    write__x_2a90d8e
+  ) (
+    Yojson.Safe.write_int
+  )
+)
+let string_of__x_946c399 ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__x_946c399 ob x;
+  Buffer.contents ob
+let read__x_946c399 = (
+  Atdgen_runtime.Oj_run.read_assoc_list (
+    read__x_2a90d8e
+  ) (
+    Atdgen_runtime.Oj_run.read_int
+  )
+)
+let _x_946c399_of_string s =
+  read__x_946c399 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_int_object = (
+  write__x_946c399
+)
+let string_of_int_object ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_int_object ob x;
+  Buffer.contents ob
+let read_int_object = (
+  read__x_946c399
+)
+let int_object_of_string s =
+  read_int_object (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_from_module_a = (
   A_j.write_from_module_a
 )

--- a/atdgen/test/melange/melangespec_mel.expected.ml
+++ b/atdgen/test/melange/melangespec_mel.expected.ml
@@ -52,6 +52,8 @@ type label = Melangespec_t.label
 
 type labeled = Melangespec_t.labeled = { flag: valid; lb: label; count: int }
 
+type int_object = Melangespec_t.int_object
+
 type from_module_a = A_t.from_module_a
 
 type b = Melangespec_t.b = { thing: int }
@@ -66,6 +68,7 @@ let rec write_mutual_recurse1 js = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write_mutual_recurse2
             )
@@ -81,6 +84,7 @@ and write_mutual_recurse2 js = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write_mutual_recurse1
             )
@@ -129,6 +133,7 @@ and write_recurse js = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write__recurse_list
             )
@@ -290,6 +295,10 @@ let write__x_547263f = (
     List.map (
       fun (key, value) ->
         Atdgen_codec_runtime.Encode.field
+          ~encode_name:
+          (
+            Atdgen_codec_runtime.Encode.string
+          )
           (
             Atdgen_codec_runtime.Encode.int
           )
@@ -300,7 +309,10 @@ let write__x_547263f = (
   )
 )
 let read__x_547263f = (
-  Atdgen_codec_runtime.Decode.obj_list (
+  Atdgen_codec_runtime.Decode.obj_list ~decode_name:(
+    Atdgen_codec_runtime.Decode.string
+  )
+  (
     Atdgen_codec_runtime.Decode.int
   )
 )
@@ -310,6 +322,7 @@ let write_using_object = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write__x_547263f
             )
@@ -549,6 +562,7 @@ let write_record_json_name = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             Atdgen_codec_runtime.Encode.int
             )
@@ -608,6 +622,7 @@ let write_param_similar write__a = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write__a
             )
@@ -615,6 +630,7 @@ let write_param_similar write__a = (
           t.data
         ;
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             Atdgen_codec_runtime.Encode.int
             )
@@ -650,6 +666,7 @@ let write_param write__a = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write__a
             )
@@ -657,6 +674,7 @@ let write_param write__a = (
           t.data
         ;
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             Atdgen_codec_runtime.Encode.unit
             )
@@ -692,6 +710,7 @@ let write_pair write__a write__b = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write__a
             )
@@ -699,6 +718,7 @@ let write_pair write__a write__b = (
           t.left
         ;
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write__b
             )
@@ -756,6 +776,7 @@ let write_labeled = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write_valid
             )
@@ -763,6 +784,7 @@ let write_labeled = (
           t.flag
         ;
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             write_label
             )
@@ -770,6 +792,7 @@ let write_labeled = (
           t.lb
         ;
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             Atdgen_codec_runtime.Encode.int
             )
@@ -805,6 +828,48 @@ let read_labeled = (
     )
   )
 )
+let write__x_2a90d8e = (
+    Atdgen_codec_runtime.Encode.string
+  |> Atdgen_codec_runtime.Encode.contramap (string_of_int)
+)
+let read__x_2a90d8e = (
+  (
+    Atdgen_codec_runtime.Decode.string
+  ) |> (Atdgen_codec_runtime.Decode.map (int_of_string))
+)
+let write__x_946c399 = (
+  Atdgen_codec_runtime.Encode.make (fun (t : _) ->
+    t |>
+    List.map (
+      fun (key, value) ->
+        Atdgen_codec_runtime.Encode.field
+          ~encode_name:
+          (
+            write__x_2a90d8e
+          )
+          (
+            Atdgen_codec_runtime.Encode.int
+          )
+          ~name:key
+          value
+    ) |>
+    Atdgen_codec_runtime.Encode.obj
+  )
+)
+let read__x_946c399 = (
+  Atdgen_codec_runtime.Decode.obj_list ~decode_name:(
+    read__x_2a90d8e
+  )
+  (
+    Atdgen_codec_runtime.Decode.int
+  )
+)
+let write_int_object = (
+  write__x_946c399
+)
+let read_int_object = (
+  read__x_946c399
+)
 let write_from_module_a = (
   A_mel.write_from_module_a
 )
@@ -817,6 +882,7 @@ let write_b = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             Atdgen_codec_runtime.Encode.int
             )
@@ -846,6 +912,7 @@ let write_a = (
     Atdgen_codec_runtime.Encode.obj
       [
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             Atdgen_codec_runtime.Encode.string
             )
@@ -853,6 +920,7 @@ let write_a = (
           t.thing
         ;
           Atdgen_codec_runtime.Encode.field
+            ~encode_name:Atdgen_codec_runtime.Encode.string
             (
             Atdgen_codec_runtime.Encode.bool
             )

--- a/atdgen/test/melange/melangespec_mel.expected.mli
+++ b/atdgen/test/melange/melangespec_mel.expected.mli
@@ -52,6 +52,8 @@ type label = Melangespec_t.label
 
 type labeled = Melangespec_t.labeled = { flag: valid; lb: label; count: int }
 
+type int_object = Melangespec_t.int_object
+
 type from_module_a = A_t.from_module_a
 
 type b = Melangespec_t.b = { thing: int }
@@ -147,6 +149,10 @@ val write_label :  label Atdgen_codec_runtime.Encode.t
 val read_labeled :  labeled Atdgen_codec_runtime.Decode.t
 
 val write_labeled :  labeled Atdgen_codec_runtime.Encode.t
+
+val read_int_object :  int_object Atdgen_codec_runtime.Decode.t
+
+val write_int_object :  int_object Atdgen_codec_runtime.Encode.t
 
 val read_from_module_a :  from_module_a Atdgen_codec_runtime.Decode.t
 


### PR DESCRIPTION
This PR implements support for wrapped keys when using `<json repr="object">`:

As a simple example:
```ocaml
type t =
   ( string wrap <ocaml t="int" wrap="int_of_string" unwrap="string_of_int">
   * int) list <json repr="object">
```

Really unsure if this is the correct approach as re-using the encoder/decoder for the name is the simplest solution I found. This emulates what is done in `oj_emit.ml`. But this changes the Encode/Decode APIs