### PR TITLE
atdcpp: use double by default instead of float

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@ Unreleased
 * atdd: Workaround d compiler bug regarding declaration order when using aliases (#393)
         Algebraic data types (SumType) now uses `alias this` syntax.
 * atdgen: Add support for `<json open_enum>` in Melange (#401)
-* atdcpp: Initial Release
+* atdcpp: Initial Release (#404)
+* atdcpp: Use `double` c++ type as default floating point type (#411)
 
 2.15.0 (2023-10-26)
 -------------------

--- a/atdcpp/src/lib/Codegen.ml
+++ b/atdcpp/src/lib/Codegen.ml
@@ -297,22 +297,14 @@ template <typename T>
 }
 
 // Reading a float from JSON
-[[maybe_unused]] float _atd_read_float(const rapidjson::Value &val)
+[[maybe_unused]] double _atd_read_float(const rapidjson::Value &val)
 {
-    if (val.IsInt())
+    if (!val.IsNumber())
     {
-        return static_cast<float>(val.GetInt());
-    }
-    else if (val.IsUint())
-    {
-        return static_cast<float>(val.GetUint());
-    }
-    if (!val.IsFloat())
-    {
-        throw AtdException("Expected a float but got" + _rapid_json_type_to_string(val.GetType()));
+        throw AtdException("Expected a number but got" + _rapid_json_type_to_string(val.GetType()));
     }
 
-    return val.GetFloat();
+    return val.GetDouble();
 }
 
 [[maybe_unused]] std::string _atd_read_string(const rapidjson::Value &val)
@@ -475,7 +467,7 @@ template <typename T>
     writer.Bool(value);
 }
 
-[[maybe_unused]] void _atd_write_float(float value, rapidjson::Writer<rapidjson::StringBuffer>& writer)
+[[maybe_unused]] void _atd_write_float(double value, rapidjson::Writer<rapidjson::StringBuffer>& writer)
 {
     writer.Double(value);
 }
@@ -633,7 +625,7 @@ let cpp_type_name env (name : string) =
   | "unit" -> "void"
   | "bool" -> "bool"
   | "int" -> "int"
-  | "float" -> "float"
+  | "float" -> "double"
   | "string" -> "std::string"
   | "abstract" -> "std::string"
   | user_defined -> 
@@ -645,7 +637,7 @@ let cpp_type_name_namespaced env (name : string) =
   | "unit" -> "void"
   | "bool" -> "bool"
   | "int" -> "int"
-  | "float" -> "float"
+  | "float" -> "double"
   | "string" -> "std::string"
   | "abstract" -> "std::string"
   | user_defined -> 

--- a/atdcpp/test/cpp-expected/everything_atd.cpp
+++ b/atdcpp/test/cpp-expected/everything_atd.cpp
@@ -86,22 +86,14 @@ template <typename T>
 }
 
 // Reading a float from JSON
-[[maybe_unused]] float _atd_read_float(const rapidjson::Value &val)
+[[maybe_unused]] double _atd_read_float(const rapidjson::Value &val)
 {
-    if (val.IsInt())
+    if (!val.IsNumber())
     {
-        return static_cast<float>(val.GetInt());
-    }
-    else if (val.IsUint())
-    {
-        return static_cast<float>(val.GetUint());
-    }
-    if (!val.IsFloat())
-    {
-        throw AtdException("Expected a float but got" + _rapid_json_type_to_string(val.GetType()));
+        throw AtdException("Expected a number but got" + _rapid_json_type_to_string(val.GetType()));
     }
 
-    return val.GetFloat();
+    return val.GetDouble();
 }
 
 [[maybe_unused]] std::string _atd_read_string(const rapidjson::Value &val)
@@ -264,7 +256,7 @@ template <typename T>
     writer.Bool(value);
 }
 
-[[maybe_unused]] void _atd_write_float(float value, rapidjson::Writer<rapidjson::StringBuffer>& writer)
+[[maybe_unused]] void _atd_write_float(double value, rapidjson::Writer<rapidjson::StringBuffer>& writer)
 {
     writer.Double(value);
 }
@@ -1008,11 +1000,11 @@ void Root::to_json(const Root &t, rapidjson::Writer<rapidjson::StringBuffer> &wr
     _atd_write_int(t.integer, writer);
     writer.Key("__init__");
     _atd_write_float(t.x___init__, writer);
-    if (t.float_with_auto_default != float(0.0f)) {
+    if (t.float_with_auto_default != double(0.0f)) {
         writer.Key("float_with_auto_default");
         _atd_write_float(t.float_with_auto_default, writer);
     }
-    if (t.float_with_default != float(0.1f)) {
+    if (t.float_with_default != double(0.1f)) {
         writer.Key("float_with_default");
         _atd_write_float(t.float_with_default, writer);
     }

--- a/atdcpp/test/cpp-expected/everything_atd.hpp
+++ b/atdcpp/test/cpp-expected/everything_atd.hpp
@@ -253,7 +253,7 @@ namespace KindParametrizedTuple {
 
 struct IntFloatParametrizedRecord {
     int field_a;
-    std::vector<float> field_b = {};
+    std::vector<double> field_b = {};
 
     static IntFloatParametrizedRecord from_json(const rapidjson::Value & doc);
     static IntFloatParametrizedRecord from_json_string(const std::string &s);
@@ -267,20 +267,20 @@ struct Root {
     std::string id;
     bool await;
     int integer;
-    float x___init__;
-    float float_with_auto_default = 0.0f;
-    float float_with_default = 0.1f;
+    double x___init__;
+    double float_with_auto_default = 0.0f;
+    double float_with_default = 0.1f;
     std::vector<std::vector<int>> items;
     std::optional<int> maybe;
     std::vector<int> extras = {};
     int answer = 42;
     typedefs::Alias aliased;
-    std::tuple<float, float> point;
+    std::tuple<double, double> point;
     typedefs::Kind kind;
     std::vector<typedefs::Kind> kinds;
-    std::vector<std::tuple<float, int>> assoc1;
+    std::vector<std::tuple<double, int>> assoc1;
     std::vector<std::tuple<std::string, int>> assoc2;
-    std::map<float, int> assoc3;
+    std::map<double, int> assoc3;
     std::map<std::string, int> assoc4;
     std::vector<std::optional<int>> nullables;
     std::vector<std::optional<int>> options;

--- a/atdcpp/test/cpp-tests/test_atdd.cpp
+++ b/atdcpp/test/cpp-tests/test_atdd.cpp
@@ -37,7 +37,7 @@ int main() {
         root.await = false;
         root.integer = 43;
         root.x___init__ = 3.14;
-        root.float_with_auto_default = 90.03;
+        root.float_with_auto_default = 90.036990;
         root.float_with_default = 32.1;
         root.items = {{1, 2}, {-1, -2}};
         root.maybe = 422;


### PR DESCRIPTION
This PR changes the default floating point type of the c++ backend to be `double` instead of `float`. This is to be closer to OCaml, where the `float` type uses double precision by default.
