### PR TITLE
Remove the library 'atdgen' which has been deprecated since 2018

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,8 @@ Unreleased
 * atdcpp: Initial Release (#404)
 * atdcpp: Use `double` c++ type as default floating point type (#411)
 * atdgen: Fix JSON I/O for inline records (#419)
-
+* atdgen: The deprecated `atdgen` library is no longer available.
+          Use `atdgen-runtime` instead (#421)
 
 2.15.0 (2023-10-26)
 -------------------

--- a/atdgen/src/deprecated/atdgen.ml
+++ b/atdgen/src/deprecated/atdgen.ml
@@ -1,3 +1,0 @@
-[@@@deprecated "The runtime for Atdgen is now the module Atdgen_runtime existing
-in the atdgen-runtime opam package"]
-include Atdgen_runtime

--- a/atdgen/src/deprecated/dune
+++ b/atdgen/src/deprecated/dune
@@ -1,6 +1,0 @@
-;; this is a deprecated library whose only purpose is to re-export the runtime
-;; new users should be using atdgen_runtime
-(library
- (name atdgen)
- (public_name atdgen)
- (libraries atdgen-runtime))

--- a/atdgen/src/deprecated/version.ml
+++ b/atdgen/src/deprecated/version.ml
@@ -1,1 +1,0 @@
-../../../atd/src/version.ml


### PR DESCRIPTION
With OCaml 5.2.1, I was getting this error message when running `make`:
```
...
dune build
File "atdgen/src/deprecated/atdgen.ml", line 1, characters 4-15:
1 | [@@@ocaml.alert deprecated "The runtime for Atdgen is now the module Atdgen_runtime existing in the atdgen-runtime opam package"]
        ^^^^^^^^^^^
Error (warning 53 [misplaced-attribute]): the "ocaml.alert" attribute cannot appear in this context
make: *** [Makefile:16: all] Error 1               
...
```

I'm not sure if there's a way to report a whole ml or mli file as deprecated. Since the `atdgen` library is now known as `atdgen-runtime` and it's been the case for 6+ years, let's just remove it.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
