### PR TITLE
Catch and improve display of generic `Parser.Error` 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Unreleased
 ----------
 
 * atdgen: Add option `-j-gen-modules` to generate JSON generic submodules (#420)
-
+* atd-parser: improve (syntax) error messages (#426)
 
 2.16.0 (2025-01-22)
 -------------------


### PR DESCRIPTION
Cf. #391

I tried adding to the menhir grammar but would get shift/reduce conflicts and/or would be incomplete.

Catching and improving the error message is what Menhir themselves do:
https://gitlab.inria.fr/fpottier/menhir/blob/master/src/stage2/Driver.ml


### PR checklist

- [ ] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
