### PR TITLE
[atdts] Avoid "make: node: Permission denied"

### DIFF
--- a/atdts/test/ts-tests/Makefile
+++ b/atdts/test/ts-tests/Makefile
@@ -14,7 +14,7 @@ test:
 	# The empty comments are used to force Make to call the shell without
 	# which it tries to execute the command directly and fails in some
 	# setups (nvm, Node v24.1.0, Ubuntu 24.04, GNU Make 4.3)
-        # with "Permission denied" for an unknown reason.
+	# with "Permission denied" for an unknown reason.
 	$(JS) manual_sample.js   #
 	$(JS) test_atdts.js      #
 


### PR DESCRIPTION
This works around a problem occurring on my machine when running the atdts tests. I don't understand exactly what's going on but this fix is sufficient to unblock me and possibly other people. I left what I understand as comments in the makefile where the problem occurs.

The output of running `make -C atdts test` was:
```
...
node manual_sample.js
make[1]: node: Permission denied
make[1]: *** [Makefile:18: test] Error 127
make[1]: Leaving directory '/home/martin/atd/atdts/test/ts-tests'
make: *** [Makefile:22: test] Error 2
```

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
