### PR TITLE
atdml: Use hash tables to read large objects a little faster

### DIFF
--- a/atdml/src/lib/Codegen.ml
+++ b/atdml/src/lib/Codegen.ml
@@ -502,6 +502,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -710,7 +716,7 @@ let gen_of_yojson_field tr ftr type_name (loc, (fname, kind, an), e) : B.node =
     match kind with
     | Required ->
         [
-          B.Line (sprintf "match List.assoc_opt \"%s\" fields with" json_name);
+          B.Line (sprintf "match assoc_ \"%s\" with" json_name);
           B.Line (sprintf "| Some v -> %s v" (reader_expr tr e));
           B.Line
             (sprintf "| None -> Atdml_runtime.missing_field \"%s\" \"%s\""
@@ -723,7 +729,7 @@ let gen_of_yojson_field tr ftr type_name (loc, (fname, kind, an), e) : B.node =
           | _ -> e
         in
         [
-          B.Line (sprintf "match List.assoc_opt \"%s\" fields with" json_name);
+          B.Line (sprintf "match assoc_ \"%s\" with" json_name);
           B.Line "| None | Some `Null -> None";
           B.Line (sprintf "| Some v -> Some (%s v)" (reader_expr tr inner_e));
         ]
@@ -731,7 +737,7 @@ let gen_of_yojson_field tr ftr type_name (loc, (fname, kind, an), e) : B.node =
         (match get_ocaml_default an with
         | Some default ->
             [
-              B.Line (sprintf "match List.assoc_opt \"%s\" fields with" json_name);
+              B.Line (sprintf "match assoc_ \"%s\" with" json_name);
               B.Line (sprintf "| None -> %s" default);
               B.Line (sprintf "| Some v -> %s v" (reader_expr tr e));
             ]
@@ -739,14 +745,14 @@ let gen_of_yojson_field tr ftr type_name (loc, (fname, kind, an), e) : B.node =
             match get_implicit_default e with
             | Some default ->
                 [
-                  B.Line (sprintf "match List.assoc_opt \"%s\" fields with" json_name);
+                  B.Line (sprintf "match assoc_ \"%s\" with" json_name);
                   B.Line (sprintf "| None -> %s" default);
                   B.Line (sprintf "| Some v -> %s v" (reader_expr tr e));
                 ]
             | None ->
                 (* No OCaml default — treat as required; warned by warn_defs *)
                 [
-                  B.Line (sprintf "match List.assoc_opt \"%s\" fields with" json_name);
+                  B.Line (sprintf "match assoc_ \"%s\" with" json_name);
                   B.Line (sprintf "| Some v -> %s v" (reader_expr tr e));
                   B.Line
                     (sprintf "| None -> Atdml_runtime.missing_field \"%s\" \"%s\""
@@ -833,7 +839,22 @@ let gen_of_yojson tr ((loc, (name, params, an), e) : A.type_def) : B.t =
              @ [ B.Line "match x with";
                  B.Line "| `Assoc fields ->";
                  B.Block
-                   (List.map (gen_of_yojson_field tr ftr name) fields
+                   ([ (* Duplicate JSON keys: behavior is intentionally unspecified.
+                         The list path returns the first binding; the hashtable path
+                         returns the last. JSON keys SHOULD be unique (RFC 8259 §4). *)
+                      B.Line "(* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD";
+                      B.Line "   be unique). Below the threshold, List.assoc_opt returns the first binding;";
+                      B.Line "   above it, the hashtable returns the last. *)";
+                      B.Line "let assoc_ =";
+                      B.Block
+                        [ B.Line "if Atdml_runtime.list_length_gt 5 fields then";
+                          B.Block
+                            [ B.Line "let tbl = Hashtbl.create 16 in";
+                              B.Line "List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;";
+                              B.Line "(fun key -> Hashtbl.find_opt tbl key)" ];
+                          B.Line "else (fun key -> List.assoc_opt key fields)" ];
+                      B.Line "in" ]
+                    @ List.map (gen_of_yojson_field tr ftr name) fields
                     @ [B.Line (sprintf "{ %s }" (String.concat "; " field_names))]);
                  B.Line (sprintf "| _ -> Atdml_runtime.bad_type \"%s\" x" name) ])
         in

--- a/atdml/tests/named-snapshots/adapter
+++ b/atdml/tests/named-snapshots/adapter
@@ -128,6 +128,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -147,13 +153,23 @@ let make_text ~title ~body () : text =
 let text_of_yojson (x : Yojson.Safe.t) : text =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let title =
-      match List.assoc_opt "title" fields with
+      match assoc_ "title" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "text" "title"
     in
     let body =
-      match List.assoc_opt "body" fields with
+      match assoc_ "body" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "text" "body"
     in
@@ -191,8 +207,18 @@ let make_image ~url () : image =
 let image_of_yojson (x : Yojson.Safe.t) : image =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let url =
-      match List.assoc_opt "url" fields with
+      match assoc_ "url" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "image" "url"
     in

--- a/atdml/tests/named-snapshots/attr
+++ b/atdml/tests/named-snapshots/attr
@@ -111,6 +111,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -131,13 +137,23 @@ let make_point ~x ~y () : point =
 let point_of_yojson (x : Yojson.Safe.t) : point =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let x =
-      match List.assoc_opt "x" fields with
+      match assoc_ "x" with
       | Some v -> Atdml_runtime.float_of_yojson v
       | None -> Atdml_runtime.missing_field "point" "x"
     in
     let y =
-      match List.assoc_opt "y" fields with
+      match assoc_ "y" with
       | Some v -> Atdml_runtime.float_of_yojson v
       | None -> Atdml_runtime.missing_field "point" "y"
     in

--- a/atdml/tests/named-snapshots/builtin_types
+++ b/atdml/tests/named-snapshots/builtin_types
@@ -101,6 +101,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -129,58 +135,68 @@ let make_all_types ~a_unit ~a_bool ~a_int ~a_float ~a_string ~a_list ~a_option ~
 let all_types_of_yojson (x : Yojson.Safe.t) : all_types =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let a_unit =
-      match List.assoc_opt "a_unit" fields with
+      match assoc_ "a_unit" with
       | Some v -> Atdml_runtime.unit_of_yojson v
       | None -> Atdml_runtime.missing_field "all_types" "a_unit"
     in
     let a_bool =
-      match List.assoc_opt "a_bool" fields with
+      match assoc_ "a_bool" with
       | Some v -> Atdml_runtime.bool_of_yojson v
       | None -> Atdml_runtime.missing_field "all_types" "a_bool"
     in
     let a_int =
-      match List.assoc_opt "a_int" fields with
+      match assoc_ "a_int" with
       | Some v -> Atdml_runtime.int_of_yojson v
       | None -> Atdml_runtime.missing_field "all_types" "a_int"
     in
     let a_float =
-      match List.assoc_opt "a_float" fields with
+      match assoc_ "a_float" with
       | Some v -> Atdml_runtime.float_of_yojson v
       | None -> Atdml_runtime.missing_field "all_types" "a_float"
     in
     let a_string =
-      match List.assoc_opt "a_string" fields with
+      match assoc_ "a_string" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "all_types" "a_string"
     in
     let a_list =
-      match List.assoc_opt "a_list" fields with
+      match assoc_ "a_list" with
       | Some v -> (Atdml_runtime.list_of_yojson Atdml_runtime.int_of_yojson) v
       | None -> Atdml_runtime.missing_field "all_types" "a_list"
     in
     let a_option =
-      match List.assoc_opt "a_option" fields with
+      match assoc_ "a_option" with
       | Some v -> (Atdml_runtime.option_of_yojson Atdml_runtime.string_of_yojson) v
       | None -> Atdml_runtime.missing_field "all_types" "a_option"
     in
     let a_nullable =
-      match List.assoc_opt "a_nullable" fields with
+      match assoc_ "a_nullable" with
       | Some v -> (Atdml_runtime.nullable_of_yojson Atdml_runtime.bool_of_yojson) v
       | None -> Atdml_runtime.missing_field "all_types" "a_nullable"
     in
     let a_abstract =
-      match List.assoc_opt "a_abstract" fields with
+      match assoc_ "a_abstract" with
       | Some v -> (fun x -> x) v
       | None -> Atdml_runtime.missing_field "all_types" "a_abstract"
     in
     let a_tuple =
-      match List.assoc_opt "a_tuple" fields with
+      match assoc_ "a_tuple" with
       | Some v -> (fun x -> match x with | `List lst when List.length lst = 3 -> (Atdml_runtime.int_of_yojson (List.nth lst 0), Atdml_runtime.string_of_yojson (List.nth lst 1), Atdml_runtime.bool_of_yojson (List.nth lst 2)) | _ -> Atdml_runtime.bad_type "tuple" x) v
       | None -> Atdml_runtime.missing_field "all_types" "a_tuple"
     in
     let a_nested =
-      match List.assoc_opt "a_nested" fields with
+      match assoc_ "a_nested" with
       | Some v -> (Atdml_runtime.option_of_yojson (fun x -> match x with | `List lst when List.length lst = 1 -> ((Atdml_runtime.list_of_yojson Atdml_runtime.float_of_yojson) (List.nth lst 0)) | _ -> Atdml_runtime.bad_type "tuple" x)) v
       | None -> Atdml_runtime.missing_field "all_types" "a_nested"
     in

--- a/atdml/tests/named-snapshots/classic_sum_types
+++ b/atdml/tests/named-snapshots/classic_sum_types
@@ -106,6 +106,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/color_enum
+++ b/atdml/tests/named-snapshots/color_enum
@@ -105,6 +105,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/doc
+++ b/atdml/tests/named-snapshots/doc
@@ -177,6 +177,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -203,18 +209,28 @@ let make_node ~value ~left ~right () : node =
 let rec node_of_yojson (x : Yojson.Safe.t) : node =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let value =
-      match List.assoc_opt "value" fields with
+      match assoc_ "value" with
       | Some v -> Atdml_runtime.int_of_yojson v
       | None -> Atdml_runtime.missing_field "node" "value"
     in
     let left =
-      match List.assoc_opt "left" fields with
+      match assoc_ "left" with
       | Some v -> tree_of_yojson v
       | None -> Atdml_runtime.missing_field "node" "left"
     in
     let right =
-      match List.assoc_opt "right" fields with
+      match assoc_ "right" with
       | Some v -> tree_of_yojson v
       | None -> Atdml_runtime.missing_field "node" "right"
     in
@@ -285,18 +301,28 @@ let make_person ~name ~age ?email () : person =
 let person_of_yojson (x : Yojson.Safe.t) : person =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let name =
-      match List.assoc_opt "name" fields with
+      match assoc_ "name" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "person" "name"
     in
     let age =
-      match List.assoc_opt "age" fields with
+      match assoc_ "age" with
       | Some v -> Atdml_runtime.int_of_yojson v
       | None -> Atdml_runtime.missing_field "person" "age"
     in
     let email =
-      match List.assoc_opt "email" fields with
+      match assoc_ "email" with
       | None | Some `Null -> None
       | Some v -> Some (Atdml_runtime.string_of_yojson v)
     in

--- a/atdml/tests/named-snapshots/json_repr_object
+++ b/atdml/tests/named-snapshots/json_repr_object
@@ -122,6 +122,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -185,13 +191,23 @@ let make_record ~counts ~tags () : record =
 let record_of_yojson (x : Yojson.Safe.t) : record =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let counts =
-      match List.assoc_opt "counts" fields with
+      match assoc_ "counts" with
       | Some v -> string_map_of_yojson v
       | None -> Atdml_runtime.missing_field "record" "counts"
     in
     let tags =
-      match List.assoc_opt "tags" fields with
+      match assoc_ "tags" with
       | Some v -> nested_of_yojson v
       | None -> Atdml_runtime.missing_field "record" "tags"
     in

--- a/atdml/tests/named-snapshots/keyword_field_and_variant_names
+++ b/atdml/tests/named-snapshots/keyword_field_and_variant_names
@@ -111,6 +111,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -161,23 +167,33 @@ let make_record_with_keyword_fields ~method_ ~object_ ?begin_ ?(end_ = []) () : 
 let record_with_keyword_fields_of_yojson (x : Yojson.Safe.t) : record_with_keyword_fields =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let method_ =
-      match List.assoc_opt "method" fields with
+      match assoc_ "method" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "record_with_keyword_fields" "method"
     in
     let object_ =
-      match List.assoc_opt "object" fields with
+      match assoc_ "object" with
       | Some v -> Atdml_runtime.int_of_yojson v
       | None -> Atdml_runtime.missing_field "record_with_keyword_fields" "object"
     in
     let begin_ =
-      match List.assoc_opt "begin" fields with
+      match assoc_ "begin" with
       | None | Some `Null -> None
       | Some v -> Some (Atdml_runtime.bool_of_yojson v)
     in
     let end_ =
-      match List.assoc_opt "end" fields with
+      match assoc_ "end" with
       | None -> []
       | Some v -> (Atdml_runtime.list_of_yojson Atdml_runtime.string_of_yojson) v
     in

--- a/atdml/tests/named-snapshots/mutually_recursive_types
+++ b/atdml/tests/named-snapshots/mutually_recursive_types
@@ -109,6 +109,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -132,13 +138,23 @@ let make_node ~value ~children () : node =
 let rec node_of_yojson (x : Yojson.Safe.t) : node =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let value =
-      match List.assoc_opt "value" fields with
+      match assoc_ "value" with
       | Some v -> Atdml_runtime.int_of_yojson v
       | None -> Atdml_runtime.missing_field "node" "value"
     in
     let children =
-      match List.assoc_opt "children" fields with
+      match assoc_ "children" with
       | Some v -> (fun x -> match x with | `List lst when List.length lst = 2 -> (tree_of_yojson (List.nth lst 0), tree_of_yojson (List.nth lst 1)) | _ -> Atdml_runtime.bad_type "tuple" x) v
       | None -> Atdml_runtime.missing_field "node" "children"
     in

--- a/atdml/tests/named-snapshots/parametric_types
+++ b/atdml/tests/named-snapshots/parametric_types
@@ -177,6 +177,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/polymorphic_variants
+++ b/atdml/tests/named-snapshots/polymorphic_variants
@@ -106,6 +106,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/records
+++ b/atdml/tests/named-snapshots/records
@@ -99,6 +99,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -125,48 +131,58 @@ let make_person ~name ~age ~lol ?email ?(score = 0.) ?(active = false) ?(tags = 
 let person_of_yojson (x : Yojson.Safe.t) : person =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let name =
-      match List.assoc_opt "name" fields with
+      match assoc_ "name" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "person" "name"
     in
     let age =
-      match List.assoc_opt "age" fields with
+      match assoc_ "age" with
       | Some v -> Atdml_runtime.int_of_yojson v
       | None -> Atdml_runtime.missing_field "person" "age"
     in
     let lol =
-      match List.assoc_opt "lol" fields with
+      match assoc_ "lol" with
       | Some v -> (Atdml_runtime.nullable_of_yojson Atdml_runtime.int_of_yojson) v
       | None -> Atdml_runtime.missing_field "person" "lol"
     in
     let email =
-      match List.assoc_opt "email" fields with
+      match assoc_ "email" with
       | None | Some `Null -> None
       | Some v -> Some (Atdml_runtime.string_of_yojson v)
     in
     let score =
-      match List.assoc_opt "score" fields with
+      match assoc_ "score" with
       | None -> 0.
       | Some v -> Atdml_runtime.float_of_yojson v
     in
     let active =
-      match List.assoc_opt "active" fields with
+      match assoc_ "active" with
       | None -> false
       | Some v -> Atdml_runtime.bool_of_yojson v
     in
     let tags =
-      match List.assoc_opt "tags" fields with
+      match assoc_ "tags" with
       | None -> []
       | Some v -> (Atdml_runtime.list_of_yojson Atdml_runtime.string_of_yojson) v
     in
     let level =
-      match List.assoc_opt "level" fields with
+      match assoc_ "level" with
       | None -> 1
       | Some v -> Atdml_runtime.int_of_yojson v
     in
     let address =
-      match List.assoc_opt "addr" fields with
+      match assoc_ "addr" with
       | Some v -> Atdml_runtime.string_of_yojson v
       | None -> Atdml_runtime.missing_field "person" "addr"
     in

--- a/atdml/tests/named-snapshots/type_aliases
+++ b/atdml/tests/named-snapshots/type_aliases
@@ -154,6 +154,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -263,23 +269,33 @@ let make_all ~id ~score ~tags ~name () : all =
 let all_of_yojson (x : Yojson.Safe.t) : all =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let id =
-      match List.assoc_opt "id" fields with
+      match assoc_ "id" with
       | Some v -> id_of_yojson v
       | None -> Atdml_runtime.missing_field "all" "id"
     in
     let score =
-      match List.assoc_opt "score" fields with
+      match assoc_ "score" with
       | Some v -> score_of_yojson v
       | None -> Atdml_runtime.missing_field "all" "score"
     in
     let tags =
-      match List.assoc_opt "tags" fields with
+      match assoc_ "tags" with
       | Some v -> tag_list_of_yojson v
       | None -> Atdml_runtime.missing_field "all" "tags"
     in
     let name =
-      match List.assoc_opt "name" fields with
+      match assoc_ "name" with
       | Some v -> opt_name_of_yojson v
       | None -> Atdml_runtime.missing_field "all" "name"
     in

--- a/atdml/tests/named-snapshots/type_name_json
+++ b/atdml/tests/named-snapshots/type_name_json
@@ -87,6 +87,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/type_name_module
+++ b/atdml/tests/named-snapshots/type_name_module
@@ -132,6 +132,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/type_name_t
+++ b/atdml/tests/named-snapshots/type_name_t
@@ -87,6 +87,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/type_name_yojson
+++ b/atdml/tests/named-snapshots/type_name_yojson
@@ -87,6 +87,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x

--- a/atdml/tests/named-snapshots/wrap
+++ b/atdml/tests/named-snapshots/wrap
@@ -122,6 +122,12 @@ module Atdml_runtime = struct
     | None -> `Null
     | Some x -> f x
 
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
   let assoc_of_yojson f = function
     | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
     | x -> bad_type "object" x
@@ -185,13 +191,23 @@ let make_record ~id ~label () : record =
 let record_of_yojson (x : Yojson.Safe.t) : record =
   match x with
   | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
     let id =
-      match List.assoc_opt "id" fields with
+      match assoc_ "id" with
       | Some v -> uid_of_yojson v
       | None -> Atdml_runtime.missing_field "record" "id"
     in
     let label =
-      match List.assoc_opt "label" fields with
+      match assoc_ "label" with
       | Some v -> tag_of_yojson v
       | None -> Atdml_runtime.missing_field "record" "label"
     in


### PR DESCRIPTION
This is an optimization for which we have no benchmarks so it may be a little off. A hash table is used when reading a JSON object with more than 5 bindings. This number should be adjusted once we have benchmarks. Further optimizations are possible too but the current performance should be good enough for typical uses of JSON regardless.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
