### PR TITLE
Upgrade OCaml to 5.3 (from 4.13) as the latest supported version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
 jobs:
   build_latest_ocaml:
     docker:
-      - image: ocaml/opam:ubuntu-24.04-ocaml-5.5
+      - image: ocaml/opam:ubuntu-24.04-ocaml-5.3
     working_directory: ~/atd
     steps:
       - build


### PR DESCRIPTION
That's a very simple change. Let's see if it works.

`odoc` depends on ocaml < 5.4 which prevents us from using ocaml 5.5... unless we don't build the with-doc dependencies as part of CI. For the sake of simplicity, let's use ocaml 5.3.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
