### PR TITLE
atdpy: add <json repr="object"> for sum types (externally-tagged encoding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tmp
 # Where we install binaries and other things locally to make them easily
 # available for testing (used by atdml)
 local/
+
+# Local Claude Code settings
+/.claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-#
-# Makefile for developer's convenience.
+
+## Makefile for developer's convenience.
 # Build logic is implemented with dune.
 #
 

--- a/atd-jsonlike.opam
+++ b/atd-jsonlike.opam
@@ -91,6 +91,8 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "3.18"}
   "ocaml" {>= "4.08"}
+  "re" {>= "1.9.0"}
+  "testo" {>= "0.3.0" & with-test}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/atdpy/src/lib/Codegen.ml
+++ b/atdpy/src/lib/Codegen.ml
@@ -1103,7 +1103,7 @@ let alias_wrapper env ~class_decorators ~class_doc name type_expr =
     ]
   ]
 
-let case_class env ~class_decorators type_name
+let case_class env ~class_decorators ~json_sum_repr type_name
     (loc, orig_name, unique_name, an, opt_e) =
   let json_name = Atd.Json.get_json_cons orig_name an in
   let case_doc = trans_case_doc_to_docstring loc an in
@@ -1130,6 +1130,8 @@ let case_class env ~class_decorators type_name
           Line "@staticmethod";
           Line "def to_json() -> Any:";
           Block [
+            (* Unit variants (no payload) are always encoded as a plain string,
+               regardless of the sum repr. *)
             Line (sprintf "return '%s'" (single_esc json_name))
           ];
           Line "";
@@ -1140,6 +1142,24 @@ let case_class env ~class_decorators type_name
         ]
       ]
   | Some e ->
+      (* Tagged variants (with payload).
+         The encoding depends on the sum-level <json repr="..."> annotation:
+         - Array (default): ["Constructor", payload]
+             e.g. ["Circle", 3.14]
+         - Object: {"Constructor": payload}
+             e.g. {"Circle": 3.14}
+             This is the default Rust/Serde externally-tagged encoding.
+             It also reads naturally in YAML as a single-key mapping. *)
+      let to_json_line = match json_sum_repr with
+        | Atd.Json.Array ->
+            sprintf "return ['%s', %s(self.value)]"
+              (single_esc json_name)
+              (json_writer env e)
+        | Atd.Json.Object ->
+            sprintf "return {'%s': %s(self.value)}"
+              (single_esc json_name)
+              (json_writer env e)
+      in
       [
         Inline class_decorators;
         Line (sprintf "class %s:" (trans env unique_name));
@@ -1162,9 +1182,7 @@ let case_class env ~class_decorators type_name
           Line "";
           Line "def to_json(self) -> Any:";
           Block [
-            Line (sprintf "return ['%s', %s(self.value)]"
-                    (single_esc json_name)
-                    (json_writer env e))
+            Line to_json_line
           ];
           Line "";
           Line "def to_json_string(self, **kw: Any) -> str:";
@@ -1193,7 +1211,15 @@ let read_cases0 env loc name cases0 =
             (class_name env name |> single_esc))
   ]
 
-let read_cases1 env loc name cases1 =
+let read_cases1 env loc name cases1 json_sum_repr =
+  (* How we read the payload value depends on the sum repr:
+     - Array: the value is x[1]  (e.g. ["Circle", 3.14])
+     - Object: the value is x[cons]  (e.g. {"Circle": 3.14}, where
+       'cons' holds the single key extracted from the dict) *)
+  let value_expr = match json_sum_repr with
+    | Atd.Json.Array -> "x[1]"
+    | Atd.Json.Object -> "x[cons]"
+  in
   let ifs =
     cases1
     |> List.map (fun (loc, orig_name, unique_name, an, opt_e) ->
@@ -1206,9 +1232,10 @@ let read_cases1 env loc name cases1 =
       Inline [
         Line (sprintf "if cons == '%s':" (single_esc json_name));
         Block [
-          Line (sprintf "return cls(%s(%s(x[1])))"
+          Line (sprintf "return cls(%s(%s(%s)))"
                   (trans env unique_name)
-                  (json_reader env e))
+                  (json_reader env e)
+                  value_expr)
         ]
       ]
     )
@@ -1235,21 +1262,39 @@ let sum_container env ~class_decorators ~class_doc loc name cases an =
   let cases0_block =
     if cases0 <> [] then
       [
+        (* Unit variants are always encoded as plain strings regardless of
+           the sum repr annotation. *)
         Line "if isinstance(x, str):";
         Block (read_cases0 env loc name cases0)
       ]
     else
       []
   in
+  (* Determine how tagged variants (those with a payload) are encoded.
+     The <json repr="object"> annotation selects the Rust/Serde-style
+     externally-tagged object encoding {"Constructor": payload}, which is
+     also clean in YAML.  The default is the two-element array encoding
+     ["Constructor", payload]. *)
+  let json_sum_repr = (Atd.Json.get_json_sum an).json_sum_repr in
   let cases1_block =
     if cases1 <> [] then
-      [
-        Line "if isinstance(x, List) and len(x) == 2:";
-        Block [
-          Line "cons = x[0]";
-          Inline (read_cases1 env loc name cases1)
-        ]
-      ]
+      match json_sum_repr with
+      | Atd.Json.Array ->
+          [
+            Line "if isinstance(x, List) and len(x) == 2:";
+            Block [
+              Line "cons = x[0]";
+              Inline (read_cases1 env loc name cases1 Atd.Json.Array)
+            ]
+          ]
+      | Atd.Json.Object ->
+          [
+            Line "if isinstance(x, dict) and len(x) == 1:";
+            Block [
+              Line "cons = next(iter(x))";
+              Inline (read_cases1 env loc name cases1 Atd.Json.Object)
+            ]
+          ]
     else
       []
   in
@@ -1306,6 +1351,7 @@ let sum_container env ~class_decorators ~class_doc loc name cases an =
   ]
 
 let sum env ~class_decorators ~class_doc loc name cases an =
+  let json_sum_repr = (Atd.Json.get_json_sum an).json_sum_repr in
   let cases =
     List.map (fun (x : variant) ->
       match x with
@@ -1316,7 +1362,7 @@ let sum env ~class_decorators ~class_doc loc name cases an =
     ) cases
   in
   let case_classes =
-    List.map (fun x -> Inline (case_class env ~class_decorators name x)) cases
+    List.map (fun x -> Inline (case_class env ~class_decorators ~json_sum_repr name x)) cases
     |> double_spaced
   in
   let container_class =

--- a/atdpy/test/atd-input/everything.atd
+++ b/atdpy/test/atd-input/everything.atd
@@ -86,6 +86,17 @@ first line of the preformatted block
 
 type alias = int list
 
+(* Test for <json repr="object"> on sum types.
+   Tagged variants are encoded as single-key JSON objects {"Constructor": payload}
+   instead of the default two-element array ["Constructor", payload].
+   This matches the default Rust/Serde externally-tagged encoding and
+   also maps naturally to YAML (each variant is a single-key mapping). *)
+type shape = [
+  | Circle of float  (* radius *)
+  | Square of float  (* side length *)
+  | Point            (* unit variant -- still encoded as a plain string *)
+] <json repr="object">
+
 type pair <doc text="Def-level doc"> =
   (string * int) <doc text="Type-level doc">
 

--- a/atdpy/test/python-expected/everything.py
+++ b/atdpy/test/python-expected/everything.py
@@ -341,6 +341,100 @@ class Tagged:
 
 
 @dataclass
+class Circle:
+    """Original type: shape = [ ... | Circle of ... | ... ]
+    """
+
+    value: float
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Circle'
+
+    def to_json(self) -> Any:
+        return {'Circle': _atd_write_float(self.value)}
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Square:
+    """Original type: shape = [ ... | Square of ... | ... ]
+    """
+
+    value: float
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Square'
+
+    def to_json(self) -> Any:
+        return {'Square': _atd_write_float(self.value)}
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Point:
+    """Original type: shape = [ ... | Point | ... ]
+    """
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Point'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'Point'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Shape:
+    """Original type: shape = [ ... ]
+    """
+
+    value: Union[Circle, Square, Point]
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return self.value.kind
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Shape':
+        if isinstance(x, str):
+            if x == 'Point':
+                return cls(Point())
+            _atd_bad_json('Shape', x)
+        if isinstance(x, dict) and len(x) == 1:
+            cons = next(iter(x))
+            if cons == 'Circle':
+                return cls(Circle(_atd_read_float(x[cons])))
+            if cons == 'Square':
+                return cls(Square(_atd_read_float(x[cons])))
+            _atd_bad_json('Shape', x)
+        _atd_bad_json('Shape', x)
+
+    def to_json(self) -> Any:
+        return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Shape':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class Root_:
     """Original type: kind = [ ... | Root | ... ]
     """

--- a/atdpy/test/python-tests/test_atdpy.py
+++ b/atdpy/test/python-tests/test_atdpy.py
@@ -289,5 +289,40 @@ def test_imported_types() -> None:
     assert b_obj.priority.value == 5
 
 
+def test_sum_repr_object() -> None:
+    """
+    Test sum types with <json repr="object">.
+
+    With this annotation, tagged variants (those carrying a payload) are
+    encoded as single-key JSON objects {"Constructor": payload} instead
+    of the default two-element array ["Constructor", payload].
+    This matches the default Rust/Serde externally-tagged encoding and
+    is also natural YAML syntax (a single-key mapping).
+    Unit variants (no payload) remain plain strings regardless.
+    """
+    # Encoding
+    assert e.Shape(e.Circle(3.14)).to_json() == {'Circle': 3.14}
+    assert e.Shape(e.Square(2.0)).to_json() == {'Square': 2.0}
+    # unit variant: always a plain string, regardless of repr
+    assert e.Shape(e.Point()).to_json() == 'Point'
+
+    # Round-trip via JSON string
+    for json_str, expected_kind in [
+        ('{"Circle": 1.0}', 'Circle'),
+        ('{"Square": 2.5}', 'Square'),
+        ('"Point"', 'Point'),
+    ]:
+        obj = e.Shape.from_json_string(json_str)
+        assert obj.kind == expected_kind
+        assert obj.to_json_string() == json_str
+
+    # Error on unknown constructor
+    try:
+        e.Shape.from_json_string('{"Triangle": 3}')
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+
 # print updated json
 test_everything_to_json()

--- a/internal/support_matrix.ml
+++ b/internal/support_matrix.ml
@@ -110,7 +110,6 @@ let languages : (string * lang_support) list = [
   };
   "atdpy (Python)", { all_yes with
     wrap            = Planned;
-    sum_repr_object = Planned;
     json_adapter    = Planned;
     open_enums      = Planned;
     binary_serialization = No;


### PR DESCRIPTION
## Summary

- Sum types annotated with `<json repr="object">` now encode tagged variants as single-key JSON objects `{"Constructor": payload}` instead of the default two-element array `["Constructor", payload]`.
- Unit variants (no payload) remain plain strings regardless of the repr annotation.
- Adds a `shape` type to the test suite with `Circle`, `Square`, and `Point` variants to exercise both tagged and unit cases.

## Motivation

This encoding matches the [Rust/Serde default externally-tagged representation](https://serde.rs/enum-representations.html#externally-tagged) and was already implemented for OCaml in atdml (commit 0fc67a5). It also maps naturally to YAML as a single-key mapping, which is more readable than a two-element sequence:

```yaml
# array encoding (default):
- - Circle
  - 3.14
# object encoding (<json repr="object">):
- Circle: 3.14
```

## Test plan

- [x] `dune runtest atdpy/test` — codegen diff test and Python unit tests pass