### PR TITLE
atdts: add <json repr="object"> for sum types (externally-tagged encoding)

### DIFF
--- a/atdts/src/lib/Codegen.ml
+++ b/atdts/src/lib/Codegen.ml
@@ -920,10 +920,11 @@ let make_type_def env (def : A.type_def) : B.t =
   | Wrap (loc, e, an) -> assert false
   | Tvar _ -> assert false
 
-let read_case env loc orig_name an opt_e =
+let read_case env loc orig_name an opt_e ~json_sum_repr =
   let json_name = Atd.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
+      (* Unit variants are always plain strings, regardless of sum repr. *)
       [
         Line (sprintf "case '%s':" (single_esc json_name));
         Block [
@@ -931,19 +932,32 @@ let read_case env loc orig_name an opt_e =
         ]
       ]
   | Some e ->
+      (* Tagged variants (with payload).
+         Array repr: the payload is at x[1] in the two-element array.
+         Object repr: the payload is the value under the constructor's key
+           e.g. {"Circle": 3.14} -> x['Circle']
+         The object encoding matches the Rust/Serde default externally-tagged
+         format and is also natural YAML syntax. *)
+      let value_expr = match json_sum_repr with
+        | Atd.Json.Array ->
+            sprintf "%s(x[1], x)" (json_reader env e)
+        | Atd.Json.Object ->
+            sprintf "%s(x['%s'], x)" (json_reader env e) (single_esc json_name)
+      in
       [
         Line (sprintf "case '%s':" (single_esc json_name));
         Block [
-          Line (sprintf "return { kind: '%s', value: %s(x[1], x) }"
+          Line (sprintf "return { kind: '%s', value: %s }"
                   (single_esc orig_name)
-                  (json_reader env e))
+                  value_expr)
         ]
       ]
 
-let write_case env loc orig_name an opt_e =
+let write_case env loc orig_name an opt_e ~json_sum_repr =
   let json_name = Atd.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
+      (* Unit variants are always plain strings, regardless of sum repr. *)
       [
         Line (sprintf "case '%s':" (single_esc orig_name));
         Block [
@@ -951,12 +965,25 @@ let write_case env loc orig_name an opt_e =
         ]
       ]
   | Some e ->
+      (* Tagged variants (with payload).
+         Array repr (default): ["Constructor", payload]
+         Object repr: {"Constructor": payload}
+           This is the Rust/Serde externally-tagged default encoding,
+           and also reads naturally as a YAML single-key mapping. *)
+      let return_expr = match json_sum_repr with
+        | Atd.Json.Array ->
+            sprintf "return ['%s', %s(x.value, x)]"
+              (single_esc json_name)
+              (json_writer env e)
+        | Atd.Json.Object ->
+            sprintf "return { '%s': %s(x.value, x) }"
+              (single_esc json_name)
+              (json_writer env e)
+      in
       [
         Line (sprintf "case '%s':" (single_esc orig_name));
         Block [
-          Line (sprintf "return ['%s', %s(x.value, x)]"
-                  (single_esc json_name)
-                  (json_writer env e))
+          Line return_expr
         ]
       ]
 
@@ -967,13 +994,15 @@ let read_root_expr env ~ts_type_name e =
       let cases0, cases1 =
         List.partition (fun (loc, orig_name, an, opt_e) -> opt_e = None) cases
       in
+      (* Determine the encoding for tagged (payload-carrying) variants. *)
+      let json_sum_repr = (Atd.Json.get_json_sum an).json_sum_repr in
       let part0 =
         [
           Line "switch (x) {";
           Block (
             List.map
               (fun (loc, orig_name, an, opt_e) ->
-                 read_case env loc orig_name an opt_e
+                 read_case env loc orig_name an opt_e ~json_sum_repr
               ) cases0
             |> List.flatten
           );
@@ -988,14 +1017,18 @@ let read_root_expr env ~ts_type_name e =
           Line "}";
         ]
       in
+      (* Build the block that reads tagged variants, switching on encoding. *)
       let part1 =
-        [
+        match json_sum_repr with
+        | Atd.Json.Array ->
+          (* Default: ["Constructor", payload] *)
+          [
           Line "_atd_check_json_tuple(2, x, context)";
           Line "switch (x[0]) {";
           Block (
             List.map
               (fun (loc, orig_name, an, opt_e) ->
-                 read_case env loc orig_name an opt_e
+                 read_case env loc orig_name an opt_e ~json_sum_repr
               ) cases1
             |> List.flatten
           );
@@ -1008,7 +1041,31 @@ let read_root_expr env ~ts_type_name e =
             ]
           ];
           Line "}";
-        ]
+          ]
+        | Atd.Json.Object ->
+          (* Object encoding: {"Constructor": payload}
+             This is the Rust/Serde default externally-tagged encoding
+             and reads naturally as a YAML single-key mapping. *)
+          [
+          Line "const key = Object.keys(x)[0];";
+          Line "switch (key) {";
+          Block (
+            List.map
+              (fun (loc, orig_name, an, opt_e) ->
+                 read_case env loc orig_name an opt_e ~json_sum_repr
+              ) cases1
+            |> List.flatten
+          );
+          Block [
+            Line "default:";
+            Block [
+              Line (sprintf "_atd_bad_json('%s', x, context)"
+                      (single_esc ts_type_name));
+              Line impossible
+            ]
+          ];
+          Line "}";
+          ]
       in
       (match cases0, cases1 with
        | _, [] -> (* pure enum *)
@@ -1090,10 +1147,11 @@ let write_root_expr env ~ts_type_name e =
   match e with
   | Sum (loc, variants, an) ->
       let cases = flatten_variants variants in
+      let json_sum_repr = (Atd.Json.get_json_sum an).json_sum_repr in
       [
         Line "switch (x.kind) {";
         Block (List.map (fun (loc, orig_name, an, opt_e) ->
-          Inline (write_case env loc orig_name an opt_e)
+          Inline (write_case env loc orig_name an opt_e ~json_sum_repr)
         ) cases);
         Line "}";
       ]

--- a/atdts/test/gen-expect-tests/everything.atd
+++ b/atdts/test/gen-expect-tests/everything.atd
@@ -56,6 +56,17 @@ type root = {
 
 type alias = int list
 
+(* Test for <json repr="object"> on sum types.
+   Tagged variants are encoded as single-key JSON objects {"Constructor": payload}
+   instead of the default two-element array ["Constructor", payload].
+   This matches the default Rust/Serde externally-tagged encoding and
+   also maps naturally to YAML (each variant is a single-key mapping). *)
+type shape = [
+  | Circle of float  (* radius *)
+  | Square of float  (* side length *)
+  | Point            (* unit variant -- still encoded as a plain string *)
+] <json repr="object">
+
 type pair = (string * int)
 
 type foo = {

--- a/atdts/test/gen-expect-tests/everything.ts.expected
+++ b/atdts/test/gen-expect-tests/everything.ts.expected
@@ -58,6 +58,11 @@ export type Root = {
 
 export type Alias = number /*int*/[]
 
+export type Shape =
+| { kind: 'Circle'; value: number }
+| { kind: 'Square'; value: number }
+| { kind: 'Point' }
+
 export type Pair = [string, number /*int*/]
 
 export type Foo = {
@@ -208,6 +213,41 @@ export function writeAlias(x: Alias, context: any = x): any {
 
 export function readAlias(x: any, context: any = x): Alias {
   return _atd_read_array(_atd_read_int)(x, context);
+}
+
+export function writeShape(x: Shape, context: any = x): any {
+  switch (x.kind) {
+    case 'Circle':
+      return { 'Circle': _atd_write_float(x.value, x) }
+    case 'Square':
+      return { 'Square': _atd_write_float(x.value, x) }
+    case 'Point':
+      return 'Point'
+  }
+}
+
+export function readShape(x: any, context: any = x): Shape {
+  if (typeof x === 'string') {
+    switch (x) {
+      case 'Point':
+        return { kind: 'Point' }
+      default:
+        _atd_bad_json('Shape', x, context)
+        throw new Error('impossible')
+    }
+  }
+  else {
+    const key = Object.keys(x)[0];
+    switch (key) {
+      case 'Circle':
+        return { kind: 'Circle', value: _atd_read_float(x['Circle'], x) }
+      case 'Square':
+        return { kind: 'Square', value: _atd_read_float(x['Square'], x) }
+      default:
+        _atd_bad_json('Shape', x, context)
+        throw new Error('impossible')
+    }
+  }
 }
 
 export function writePair(x: Pair, context: any = x): any {

--- a/atdts/test/ts-tests/test_atdts.ts
+++ b/atdts/test/ts-tests/test_atdts.ts
@@ -248,5 +248,41 @@ function test_import_alias() {
   assert(ext_types.writeTag(obj2.tag) === "renamed", "tag round-trip failed")
 }
 
+function test_sum_repr_object() {
+  // With <json repr="object">, tagged variants (those carrying a payload)
+  // are encoded as single-key JSON objects {"Constructor": payload} instead
+  // of the default two-element array ["Constructor", payload].
+  // This matches the default Rust/Serde externally-tagged encoding and is
+  // also natural YAML syntax (a single-key mapping per variant).
+  // Unit variants (no payload) remain plain strings in all cases.
+
+  // Encoding
+  const circle: API.Shape = { kind: 'Circle', value: 3.14 }
+  const square: API.Shape = { kind: 'Square', value: 2.0 }
+  const point: API.Shape = { kind: 'Point' }
+
+  assert(JSON.stringify(API.writeShape(circle)) === '{"Circle":3.14}',
+    'Circle encoding failed')
+  assert(JSON.stringify(API.writeShape(square)) === '{"Square":2}',
+    'Square encoding failed')
+  assert(JSON.stringify(API.writeShape(point)) === '"Point"',
+    'Point (unit variant) should be a plain string')
+
+  // Round-trip decoding
+  const c2 = API.readShape(JSON.parse('{"Circle":1.0}'))
+  assert(c2.kind === 'Circle', 'Circle decode: wrong kind')
+  assert((c2 as {kind: 'Circle'; value: number}).value === 1.0, 'Circle decode: wrong value')
+
+  const p2 = API.readShape(JSON.parse('"Point"'))
+  assert(p2.kind === 'Point', 'Point decode: wrong kind')
+
+  // Error on unknown constructor
+  let threw = false
+  try { API.readShape(JSON.parse('{"Triangle":3}')) }
+  catch (_) { threw = true }
+  assert(threw, 'Expected error for unknown constructor')
+}
+
 test_everything()
 test_import_alias()
+test_sum_repr_object()

--- a/internal/support_matrix.ml
+++ b/internal/support_matrix.ml
@@ -116,7 +116,6 @@ let languages : (string * lang_support) list = [
     binary_serialization = No;
   };
   "atdts (TypeScript)", { all_yes with
-    sum_repr_object = Planned;
     json_adapter    = Planned;
     open_enums      = Planned;
     binary_serialization = No;


### PR DESCRIPTION
## Summary

- Sum types annotated with `<json repr="object">` now encode/decode tagged variants as single-key JSON objects `{"Constructor": payload}` instead of the default two-element array `["Constructor", payload]`.
- Unit variants (no payload) remain plain strings regardless of the repr annotation.
- Adds a `shape` type to the test suite with `Circle`, `Square`, and `Point` variants.

## Motivation

This encoding matches the [Rust/Serde default externally-tagged representation](https://serde.rs/enum-representations.html#externally-tagged) and was already implemented for OCaml in atdml (commit 0fc67a5). It also maps naturally to YAML as a single-key mapping:

```yaml
# array encoding (default):
- - Circle
  - 3.14
# object encoding (<json repr="object">):
- Circle: 3.14
```

## Test plan

- [x] `dune runtest atdts/test` — codegen diff test and TypeScript unit tests pass