### PR TITLE
atdcpp: add <json repr="object"> for sum types (externally-tagged encoding)

### DIFF
--- a/atdcpp/src/lib/Codegen.ml
+++ b/atdcpp/src/lib/Codegen.ml
@@ -1143,7 +1143,8 @@ let alias_wrapper env  name type_expr codegen_type =
   | _ -> []
 
 
-let case_class env  type_name (loc, orig_name, unique_name, an, opt_e) case_classes =
+let case_class env type_name (loc, orig_name, unique_name, an, opt_e)
+    case_classes ~json_sum_repr =
   let json_name = Atd.Json.get_json_cons orig_name an in
   match case_classes with
   | Declaration -> (match opt_e with
@@ -1171,6 +1172,7 @@ let case_class env  type_name (loc, orig_name, unique_name, an, opt_e) case_clas
         ])
   | Definition -> (match opt_e with
     | None ->
+        (* Unit variants are always encoded as plain strings. *)
         [
             Line (sprintf "void %s::to_json(const %s &e, rapidjson::Writer<rapidjson::StringBuffer> &writer){" (trans env orig_name) (trans env orig_name));
             Block [
@@ -1179,14 +1181,30 @@ let case_class env  type_name (loc, orig_name, unique_name, an, opt_e) case_clas
             Line (sprintf "};");
         ]
     | Some e ->
+        (* Tagged variants (with payload).
+           Array repr (default): ["Constructor", payload]
+           Object repr: {"Constructor": payload}
+             This is the Rust/Serde default externally-tagged encoding
+             and also maps naturally to YAML as a single-key mapping. *)
+        let body = match json_sum_repr with
+          | Atd.Json.Array ->
+              [
+                Line (sprintf "writer.StartArray();");
+                Line (sprintf "writer.String(\"%s\");" (single_esc json_name));
+                Line (sprintf "%se.value, writer);" (json_writer env e));
+                Line (sprintf "writer.EndArray();");
+              ]
+          | Atd.Json.Object ->
+              [
+                Line (sprintf "writer.StartObject();");
+                Line (sprintf "writer.Key(\"%s\");" (single_esc json_name));
+                Line (sprintf "%se.value, writer);" (json_writer env e));
+                Line (sprintf "writer.EndObject();");
+              ]
+        in
         [
             Line (sprintf "void %s::to_json(const %s &e, rapidjson::Writer<rapidjson::StringBuffer> &writer){" (trans env orig_name) (trans env orig_name));
-            Block [
-              Line (sprintf "writer.StartArray();");
-              Line (sprintf "writer.String(\"%s\");" (single_esc json_name));
-              Line (sprintf "%se.value, writer);" (json_writer env e));
-              Line (sprintf "writer.EndArray();");
-            ];
+            Block body;
             Line("}");
         ])
   | _ -> []
@@ -1212,7 +1230,11 @@ let read_cases0 env loc name cases0 sum_repr =
             (struct_name env name |> single_esc))
   ]
 
-let read_cases1 env loc name cases1 =
+let read_cases1 env loc name cases1 json_sum_repr =
+  (* How the payload value is accessed depends on the sum repr:
+     Array: x[1]  -- value is second element of ["Constructor", payload]
+     Object: x["Constructor"]  -- value is the field under the constructor key
+       (cons is the variable holding the key name) *)
   let ifs =
     cases1
     |> List.map (fun (loc, orig_name, unique_name, an, opt_e) ->
@@ -1222,12 +1244,20 @@ let read_cases1 env loc name cases1 =
         | Some x -> x
       in
       let json_name = Atd.Json.get_json_cons orig_name an in
+      let value_expr = match json_sum_repr with
+        | Atd.Json.Array ->
+            sprintf "%sx[1])}" (json_reader env e)
+        | Atd.Json.Object ->
+            (* Use the literal key rather than the 'cons' variable for
+               clarity, even though both would work after the if-guard. *)
+            sprintf "%sx[\"%s\"])}" (json_reader env e) (single_esc json_name)
+      in
       Inline [
         Line (sprintf "if (cons == \"%s\")" (single_esc json_name));
         Block [
-          Line (sprintf "return Types::%s({%sx[1])});"
+          Line (sprintf "return Types::%s({%s);"
                   (trans env orig_name)
-                  (json_reader env e))
+                  value_expr)
         ]
       ]
     )
@@ -1238,7 +1268,7 @@ let read_cases1 env loc name cases1 =
             (struct_name env name |> single_esc))
   ]
 
-let sum_container env  loc name cases codegen_type =
+let sum_container env loc name cases codegen_type ~json_sum_repr =
   let cpp_struct_name = struct_name env name in
   let cases0, cases1 =
     List.partition (fun (loc, orig_name, unique_name, an, opt_e) ->
@@ -1248,6 +1278,7 @@ let sum_container env  loc name cases codegen_type =
   let cases0_block =
     if cases0 <> [] then
       [
+        (* Unit variants are always encoded as plain strings. *)
         Line "if (x.IsString()) {";
         Block (read_cases0 env loc name cases0 Cpp_annot.Variant);
         Line "}";
@@ -1255,16 +1286,34 @@ let sum_container env  loc name cases codegen_type =
     else
       []
   in
+  (* Determine how tagged variants are decoded based on the sum repr.
+     Array (default): ["Constructor", payload]
+       The tag is x[0].GetString() and the payload is x[1].
+     Object: {"Constructor": payload}
+       This is the Rust/Serde default externally-tagged encoding and also
+       maps naturally to YAML.  The tag is the sole member name, obtained
+       via MemberBegin()->name. *)
   let cases1_block =
     if cases1 <> [] then
-      [
-        Line "if (x.IsArray() && x.Size() == 2 && x[0].IsString()) {";
-        Block [
-          Line "std::string cons = x[0].GetString();";
-          Inline (read_cases1 env loc name cases1)
-        ];
-          Line "}";
-      ]
+      match json_sum_repr with
+      | Atd.Json.Array ->
+          [
+            Line "if (x.IsArray() && x.Size() == 2 && x[0].IsString()) {";
+            Block [
+              Line "std::string cons = x[0].GetString();";
+              Inline (read_cases1 env loc name cases1 Atd.Json.Array)
+            ];
+              Line "}";
+          ]
+      | Atd.Json.Object ->
+          [
+            Line "if (x.IsObject() && x.MemberCount() == 1) {";
+            Block [
+              Line "std::string cons = x.MemberBegin()->name.GetString();";
+              Inline (read_cases1 env loc name cases1 Atd.Json.Object)
+            ];
+              Line "}";
+          ]
     else
       []
   in
@@ -1318,7 +1367,8 @@ let sum_container env  loc name cases codegen_type =
   ]
   | _ -> []
   
-let sum env loc name cases codegen_type =
+let sum env loc name cases an codegen_type =
+  let json_sum_repr = (Atd.Json.get_json_sum an).json_sum_repr in
   let cases =
     List.map (fun (x : variant) ->
       match x with
@@ -1328,10 +1378,10 @@ let sum env loc name cases codegen_type =
       | Inherit _ -> assert false
     ) cases
   in
-  let case_classes = 
-    List.map (fun x -> Inline (case_class env name x codegen_type)) cases
+  let case_classes =
+    List.map (fun x -> Inline (case_class env name x codegen_type ~json_sum_repr)) cases
   in
-  let container_class = sum_container env loc name cases codegen_type in
+  let container_class = sum_container env loc name cases codegen_type ~json_sum_repr in
   match codegen_type with
   | Declaration -> 
     [
@@ -1494,7 +1544,7 @@ let type_def env (def : A.type_def) codegen_type : B.t =
     match e with
     | Sum (loc, cases, an) ->
       (match (Cpp_annot.get_cpp_sumtype_repr an) with
-      | Variant -> sum env loc name cases codegen_type
+      | Variant -> sum env loc name cases an codegen_type
       | Enum -> enum env loc name cases codegen_type)
     | Record (loc, fields, an) ->
         record env loc name fields an codegen_type

--- a/atdcpp/test/atd-input/everything.atd
+++ b/atdcpp/test/atd-input/everything.atd
@@ -133,3 +133,14 @@ type null_opt = {
 
 type empty_record = {
 }
+
+(* Test for <json repr="object"> on sum types.
+   Tagged variants are encoded as single-key JSON objects {"Constructor": payload}
+   instead of the default two-element array ["Constructor", payload].
+   This matches the default Rust/Serde externally-tagged encoding and
+   also maps naturally to YAML (each variant is a single-key mapping). *)
+type shape = [
+  | Circle of float  (* radius *)
+  | Square of float  (* side length *)
+  | Point            (* unit variant -- still encoded as a plain string *)
+] <json repr="object">

--- a/atdcpp/test/cpp-expected/everything_atd.cpp
+++ b/atdcpp/test/cpp-expected/everything_atd.cpp
@@ -602,6 +602,75 @@ namespace St {
 }
 
 
+namespace Shape::Types {
+
+
+    void Circle::to_json(const Circle &e, rapidjson::Writer<rapidjson::StringBuffer> &writer){
+        writer.StartObject();
+        writer.Key("Circle");
+        _atd_write_float(e.value, writer);
+        writer.EndObject();
+    }
+
+
+    void Square::to_json(const Square &e, rapidjson::Writer<rapidjson::StringBuffer> &writer){
+        writer.StartObject();
+        writer.Key("Square");
+        _atd_write_float(e.value, writer);
+        writer.EndObject();
+    }
+
+
+    void Point::to_json(const Point &e, rapidjson::Writer<rapidjson::StringBuffer> &writer){
+        writer.String("Point");
+    };
+
+
+}
+
+
+namespace Shape {
+    typedefs::Shape from_json(const rapidjson::Value &x) {
+        if (x.IsString()) {
+            if (std::string_view(x.GetString()) == "Point") 
+                return Types::Point();
+            throw _atd_bad_json("Shape", x);
+        }
+        if (x.IsObject() && x.MemberCount() == 1) {
+            std::string cons = x.MemberBegin()->name.GetString();
+            if (cons == "Circle")
+                return Types::Circle({_atd_read_float(x["Circle"])});
+            if (cons == "Square")
+                return Types::Square({_atd_read_float(x["Square"])});
+            throw _atd_bad_json("Shape", x);
+        }
+        throw _atd_bad_json("Shape", x);
+    }
+    typedefs::Shape from_json_string(const std::string &s) {
+        rapidjson::Document doc;
+        doc.Parse(s.c_str());
+        if (doc.HasParseError()) {
+            throw AtdException("Failed to parse JSON");
+        }
+        return from_json(doc);
+    }
+    void to_json(const typedefs::Shape &x, rapidjson::Writer<rapidjson::StringBuffer> &writer) {
+        std::visit([&writer](auto &&arg) {
+            using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, Types::Circle>) Types::Circle::to_json(arg, writer);
+                if constexpr (std::is_same_v<T, Types::Square>) Types::Square::to_json(arg, writer);
+                if constexpr (std::is_same_v<T, Types::Point>) Types::Point::to_json(arg, writer);
+        }, x);
+    }
+    std::string to_json_string(const typedefs::Shape &x) {
+        rapidjson::StringBuffer buffer;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+        to_json(x, writer);
+        return buffer.GetString();
+    }
+}
+
+
 namespace Kind::Types {
 
 

--- a/atdcpp/test/cpp-expected/everything_atd.hpp
+++ b/atdcpp/test/cpp-expected/everything_atd.hpp
@@ -33,6 +33,11 @@ struct RecursiveRecord2;
 struct RecursiveClass;
 struct ThreeLevelNestedListRecord;
 struct StructWithRecursiveVariant;
+namespace Shape::Types {
+    struct Circle;
+    struct Square;
+    struct Point;
+}
 namespace Kind::Types {
     struct Root;
     struct Thing;
@@ -75,6 +80,7 @@ namespace typedefs {
     typedef Credentials Credentials;
 
     typedef std::variant<RecursiveVariant::Types::Integer, RecursiveVariant::Types::Rec> RecursiveVariant;
+    typedef std::variant<Shape::Types::Circle, Shape::Types::Square, Shape::Types::Point> Shape;
     typedef std::variant<Kind::Types::Root, Kind::Types::Thing, Kind::Types::WOW, Kind::Types::Amaze> Kind;
     typedef std::variant<Frozen::Types::A, Frozen::Types::B> Frozen;
 
@@ -167,6 +173,33 @@ namespace St {
     typedefs::St from_json_string(const std::string &s);
     void to_json(const typedefs::St &t, rapidjson::Writer<rapidjson::StringBuffer> &writer);
     std::string to_json_string(const typedefs::St &t);
+}
+
+
+namespace Shape {
+    namespace Types {
+        // Original type: shape = [ ... | Circle of ... | ... ]
+        struct Circle
+        {
+            double value;
+            static void to_json(const Circle &e, rapidjson::Writer<rapidjson::StringBuffer> &writer);
+        };
+        // Original type: shape = [ ... | Square of ... | ... ]
+        struct Square
+        {
+            double value;
+            static void to_json(const Square &e, rapidjson::Writer<rapidjson::StringBuffer> &writer);
+        };
+        // Original type: shape = [ ... | Point | ... ]
+        struct Point {
+            static void to_json(const Point &e, rapidjson::Writer<rapidjson::StringBuffer> &writer);
+        };
+    }
+
+    typedefs::Shape from_json(const rapidjson::Value &x);
+    typedefs::Shape from_json_string(const std::string &s);
+    void to_json(const typedefs::Shape &x, rapidjson::Writer<rapidjson::StringBuffer> &writer);
+    std::string to_json_string(const typedefs::Shape &x);
 }
 
 

--- a/atdcpp/test/cpp-tests/test_atdd.cpp
+++ b/atdcpp/test/cpp-tests/test_atdd.cpp
@@ -138,6 +138,44 @@ int main() {
         }
     };
 
+    // Test for <json repr="object"> on sum types.
+    // Tagged variants are encoded as single-key JSON objects {"Constructor": payload}
+    // instead of the default two-element array ["Constructor", payload].
+    // This matches the default Rust/Serde externally-tagged encoding and
+    // also maps naturally to YAML (each variant is a single-key mapping).
+    tests["sum repr object"] = []() {
+        // Encoding: tagged variants use {"Constructor": payload}
+        typedefs::Shape circle = Shape::Types::Circle{3.14};
+        typedefs::Shape square = Shape::Types::Square{2.0};
+        typedefs::Shape point  = Shape::Types::Point{};
+
+        auto circle_json = Shape::to_json_string(circle);
+        auto square_json = Shape::to_json_string(square);
+        auto point_json  = Shape::to_json_string(point);
+
+        if (circle_json != R"({"Circle":3.14})")
+            throw std::runtime_error("Circle encoding failed: " + circle_json);
+        if (square_json != R"({"Square":2.0})")
+            throw std::runtime_error("Square encoding failed: " + square_json);
+        // Unit variants remain plain strings regardless of repr
+        if (point_json != R"("Point")")
+            throw std::runtime_error("Point encoding failed: " + point_json);
+
+        // Decoding: round-trip
+        auto c2 = Shape::from_json_string(circle_json);
+        auto s2 = Shape::from_json_string(square_json);
+        auto p2 = Shape::from_json_string(point_json);
+
+        if (Shape::to_json_string(c2) != circle_json)
+            throw std::runtime_error("Circle round-trip failed");
+        if (Shape::to_json_string(s2) != square_json)
+            throw std::runtime_error("Square round-trip failed");
+        if (Shape::to_json_string(p2) != point_json)
+            throw std::runtime_error("Point round-trip failed");
+
+        std::cout << "Test passed: sum repr object" << std::endl;
+    };
+
     tests["empty record"] = []() {
         typedefs::EmptyRecord emptyRecord;
         std::string json = "{}";

--- a/internal/support_matrix.ml
+++ b/internal/support_matrix.ml
@@ -151,7 +151,6 @@ let languages : (string * lang_support) list = [
   "atdcpp (C++)", { all_yes with
     doc_comments     = Planned;
     json_repr_object = Planned;
-    sum_repr_object  = Planned;
     json_adapter     = Planned;
     imports          = Planned;
     open_enums       = Planned;


### PR DESCRIPTION
## Summary

- Sum types annotated with `<json repr="object">` now encode/decode tagged variants as single-key JSON objects `{"Constructor": payload}` instead of the default two-element array `["Constructor", payload]`.
- Unit variants (no payload) remain plain strings regardless of the repr annotation.
- Adds a `shape` type to the test suite with `Circle`, `Square`, and `Point` variants.

## Motivation

This encoding matches the [Rust/Serde default externally-tagged representation](https://serde.rs/enum-representations.html#externally-tagged) and was already implemented for OCaml in atdml (commit 0fc67a5). It also maps naturally to YAML as a single-key mapping:

```yaml
# array encoding (default):
- - Circle
  - 3.14
# object encoding (<json repr="object">):
- Circle: 3.14
```

Uses RapidJSON's `StartObject`/`Key`/`EndObject` API for writing, and `IsObject()`/`MemberBegin()->name` for reading — symmetric with the existing `StartArray`/`String`/`EndArray` path.

## Test plan

- [x] `dune runtest atdcpp/test` — codegen diff test passes (C++ runtime tests require g++ and RapidJSON, not available in CI)