### PR TITLE
atdd: add <json repr="object"> for sum types (externally-tagged encoding)

### DIFF
--- a/atdd/src/lib/Codegen.ml
+++ b/atdd/src/lib/Codegen.ml
@@ -914,11 +914,12 @@ let alias_wrapper env  name type_expr =
     Line("}");
   ]
 
-let case_class env  type_name
-    (loc, orig_name, unique_name, an, opt_e) =
+let case_class env type_name
+    (loc, orig_name, unique_name, an, opt_e) ~json_sum_repr =
   let json_name = Atd.Json.get_json_cons orig_name an in
   match opt_e with
   | None ->
+      (* Unit variants are always encoded as plain strings. *)
       [
           Line (sprintf {|// Original type: %s = [ ... | %s | ... ]|}
                   type_name
@@ -929,16 +930,29 @@ let case_class env  type_name
           Line("}");
         ]
   | Some e ->
+      (* Tagged variants (with payload).
+         Array repr (default): ["Constructor", payload]
+         Object repr: {"Constructor": payload}
+           This is the Rust/Serde default externally-tagged encoding and
+           also maps naturally to YAML as a single-key mapping. *)
+      let to_json_body = match json_sum_repr with
+        | Atd.Json.Array ->
+            sprintf "return JSONValue([JSONValue(\"%s\"), %s(e.value)]);"
+              (single_esc json_name) (json_writer env e)
+        | Atd.Json.Object ->
+            sprintf "return JSONValue([\"%s\": %s(e.value)]);"
+              (single_esc json_name) (json_writer env e)
+      in
       [
           Line (sprintf {|// Original type: %s = [ ... | %s of ... | ... ]|}
                   type_name
                   orig_name);
-          Line (sprintf "struct %s { %s value; }" (trans env unique_name) (type_name_of_expr env e)); (* TODO : very dubious*)
+          Line (sprintf "struct %s { %s value; }" (trans env unique_name) (type_name_of_expr env e));
           Line (sprintf "@trusted JSONValue toJson(T : %s)(T e) {"  (trans env unique_name));
-          Block [Line(sprintf "return JSONValue([JSONValue(\"%s\"), %s(e.value)]);" (single_esc json_name) (json_writer env e))];
+          Block [Line to_json_body];
           Line("}");
         ]
-      
+
 
 let read_cases0 env loc name cases0 =
   let ifs =
@@ -959,7 +973,10 @@ let read_cases0 env loc name cases0 =
             (struct_name env name |> single_esc))
   ]
 
-let read_cases1 env loc name cases1 =
+let read_cases1 env loc name cases1 json_sum_repr =
+  (* How the payload value is accessed depends on the sum repr:
+     Array: x[1]  -- value is the second element of ["Constructor", payload]
+     Object: x["Constructor"]  -- value is the field under the constructor key *)
   let ifs =
     cases1
     |> List.map (fun (loc, orig_name, unique_name, an, opt_e) ->
@@ -969,13 +986,20 @@ let read_cases1 env loc name cases1 =
         | Some x -> x
       in
       let json_name = Atd.Json.get_json_cons orig_name an in
+      let value_expr = match json_sum_repr with
+        | Atd.Json.Array  -> "x[1]"
+        | Atd.Json.Object ->
+            (* Use the literal key rather than 'cons' for clarity. *)
+            sprintf "x[\"%s\"]" (single_esc json_name)
+      in
       Inline [
         Line (sprintf "if (cons == \"%s\")" (single_esc json_name));
         Block [
-          Line (sprintf "return %s(%s(%s(x[1])));"
+          Line (sprintf "return %s(%s(%s(%s)));"
                   (struct_name env name)
                   (trans env unique_name)
-                  (json_reader env e))
+                  (json_reader env e)
+                  value_expr)
         ]
       ]
     )
@@ -986,7 +1010,7 @@ let read_cases1 env loc name cases1 =
             (struct_name env name |> single_esc))
   ]
 
-let sum_container env  loc name cases =
+let sum_container env loc name cases an =
   let dlang_struct_name = struct_name env name in
   let type_list =
     List.map (fun (loc, orig_name, unique_name, an, opt_e) ->
@@ -1002,6 +1026,7 @@ let sum_container env  loc name cases =
   let cases0_block =
     if cases0 <> [] then
       [
+        (* Unit variants are always encoded as plain strings. *)
         Line "if (x.type == JSONType.string) {";
         Block (read_cases0 env loc name cases0);
         Line "}";
@@ -1009,16 +1034,34 @@ let sum_container env  loc name cases =
     else
       []
   in
+  (* Determine how tagged variants are decoded based on the sum repr.
+     Array (default): ["Constructor", payload]
+       The tag is x[0].str and the payload is x[1].
+     Object: {"Constructor": payload}
+       This is the Rust/Serde default externally-tagged encoding and also
+       maps naturally to YAML.  The tag is the sole key of the object. *)
+  let json_sum_repr = (Atd.Json.get_json_sum an).json_sum_repr in
   let cases1_block =
     if cases1 <> [] then
-      [
-        Line "if (x.type == JSONType.array && x.array.length == 2 && x[0].type == JSONType.string) {";
-        Block [
-          Line "string cons = x[0].str;";
-          Inline (read_cases1 env loc name cases1)
-        ];
-          Line "}";
-      ]
+      match json_sum_repr with
+      | Atd.Json.Array ->
+          [
+            Line "if (x.type == JSONType.array && x.array.length == 2 && x[0].type == JSONType.string) {";
+            Block [
+              Line "string cons = x[0].str;";
+              Inline (read_cases1 env loc name cases1 Atd.Json.Array)
+            ];
+              Line "}";
+          ]
+      | Atd.Json.Object ->
+          [
+            Line "if (x.type == JSONType.object_ && x.object_.length == 1) {";
+            Block [
+              Line "string cons = x.object_.keys.front;";
+              Inline (read_cases1 env loc name cases1 Atd.Json.Object)
+            ];
+              Line "}";
+          ]
     else
       []
   in
@@ -1050,7 +1093,8 @@ let sum_container env  loc name cases =
   ]
 
 
-let sum env  loc name cases =
+let sum env loc name cases an =
+  let json_sum_repr = (Atd.Json.get_json_sum an).json_sum_repr in
   let cases =
     List.map (fun (x : variant) ->
       match x with
@@ -1061,10 +1105,10 @@ let sum env  loc name cases =
     ) cases
   in
   let case_classes =
-    List.map (fun x -> Inline (case_class env name x)) cases
+    List.map (fun x -> Inline (case_class env name x ~json_sum_repr)) cases
     |> double_spaced
   in
-  let container_class = sum_container env loc name cases in
+  let container_class = sum_container env loc name cases an in
   [
     Inline case_classes;
     Inline container_class;
@@ -1081,7 +1125,7 @@ let type_def env (def : A.type_def) : B.t =
   let unwrap e =
     match e with
     | Sum (loc, cases, an) ->
-        sum env  loc name cases
+        sum env loc name cases an
     | Record (loc, fields, an) ->
         record env loc name fields an
     | Tuple _

--- a/atdd/src/lib/Codegen.ml
+++ b/atdd/src/lib/Codegen.ml
@@ -1055,9 +1055,9 @@ let sum_container env loc name cases an =
           ]
       | Atd.Json.Object ->
           [
-            Line "if (x.type == JSONType.object_ && x.object_.length == 1) {";
+            Line "if (x.type == JSONType.object && x.object.length == 1) {";
             Block [
-              Line "string cons = x.object_.keys.front;";
+              Line "string cons = x.object.keys[0];";
               Inline (read_cases1 env loc name cases1 Atd.Json.Object)
             ];
               Line "}";

--- a/atdd/test/atd-input/everything.atd
+++ b/atdd/test/atd-input/everything.atd
@@ -84,3 +84,14 @@ type default_list = {
 type record_with_wrapped_type = {
   item: string wrap <dlang t="int" wrap="to!int" unwrap="to!string">;
 }
+
+(* Test for <json repr="object"> on sum types.
+   Tagged variants are encoded as single-key JSON objects {"Constructor": payload}
+   instead of the default two-element array ["Constructor", payload].
+   This matches the default Rust/Serde externally-tagged encoding and
+   also maps naturally to YAML (each variant is a single-key mapping). *)
+type shape = [
+  | Circle of float  (* radius *)
+  | Square of float  (* side length *)
+  | Point            (* unit variant -- still encoded as a plain string *)
+] <json repr="object">

--- a/atdd/test/dlang-expected/everything_atd.d
+++ b/atdd/test/dlang-expected/everything_atd.d
@@ -365,6 +365,56 @@ this(St init) @safe {_data = init._data;}
 }
 
 
+// Original type: shape = [ ... | Circle of ... | ... ]
+struct Circle { float value; }
+@trusted JSONValue toJson(T : Circle)(T e) {
+    return JSONValue(["Circle": _atd_write_float(e.value)]);
+}
+
+
+// Original type: shape = [ ... | Square of ... | ... ]
+struct Square { float value; }
+@trusted JSONValue toJson(T : Square)(T e) {
+    return JSONValue(["Square": _atd_write_float(e.value)]);
+}
+
+
+// Original type: shape = [ ... | Point | ... ]
+struct Point {}
+@trusted JSONValue toJson(T : Point)(T e) {
+    return JSONValue("Point");
+}
+
+
+struct Shape{ SumType!(Circle, Square, Point) _data; alias _data this;
+@safe this(T)(T init) {_data = init;} @safe this(Shape init) {_data = init._data;}}
+
+@trusted Shape fromJson(T : Shape)(JSONValue x) {
+    if (x.type == JSONType.string) {
+        if (x.str == "Point") 
+            return Shape(Point());
+        throw _atd_bad_json("Shape", x);
+    }
+    if (x.type == JSONType.object_ && x.object_.length == 1) {
+        string cons = x.object_.keys.front;
+        if (cons == "Circle")
+            return Shape(Circle(_atd_read_float(x["Circle"])));
+        if (cons == "Square")
+            return Shape(Square(_atd_read_float(x["Square"])));
+        throw _atd_bad_json("Shape", x);
+    }
+    throw _atd_bad_json("Shape", x);
+}
+
+@trusted JSONValue toJson(T : Shape)(T x) {
+    return x.match!(
+    (Circle v) => v.toJson!(Circle),
+(Square v) => v.toJson!(Square),
+(Point v) => v.toJson!(Point)
+    );
+}
+
+
 // Original type: kind = [ ... | Root | ... ]
 struct Root_ {}
 @trusted JSONValue toJson(T : Root_)(T e) {

--- a/atdd/test/dlang-expected/everything_atd.d
+++ b/atdd/test/dlang-expected/everything_atd.d
@@ -395,8 +395,8 @@ struct Shape{ SumType!(Circle, Square, Point) _data; alias _data this;
             return Shape(Point());
         throw _atd_bad_json("Shape", x);
     }
-    if (x.type == JSONType.object_ && x.object_.length == 1) {
-        string cons = x.object_.keys.front;
+    if (x.type == JSONType.object && x.object.length == 1) {
+        string cons = x.object.keys[0];
         if (cons == "Circle")
             return Shape(Circle(_atd_read_float(x["Circle"])));
         if (cons == "Square")

--- a/atdd/test/dlang-tests/test_atdd.d
+++ b/atdd/test/dlang-tests/test_atdd.d
@@ -187,6 +187,47 @@ void setupTests()
 
         auto mapResult = credientials.map!((c) => c);
     };
+
+    // Test for <json repr="object"> on sum types.
+    // Tagged variants are encoded as single-key JSON objects {"Constructor": payload}
+    // instead of the default two-element array ["Constructor", payload].
+    // This matches the default Rust/Serde externally-tagged encoding and
+    // also maps naturally to YAML (each variant is a single-key mapping).
+    tests["sum repr object"] = () {
+        import std.json;
+
+        // Encoding: tagged variants use object encoding
+        auto circle = Shape(Circle(3.14f));
+        auto square = Shape(Square(2.0f));
+        auto point  = Shape(Point());
+
+        auto circleJson = circle.toJsonString!Shape;
+        auto squareJson = square.toJsonString!Shape;
+        auto pointJson  = point.toJsonString!Shape;
+
+        assert(circleJson == `{"Circle":3.14}` || circleJson == `{"Circle":3.1400001049041748}`,
+               "Circle encoding failed: " ~ circleJson);
+        assert(squareJson == `{"Square":2.0}` || squareJson == `{"Square":2}`,
+               "Square encoding failed: " ~ squareJson);
+        // Unit variants remain plain strings regardless of repr
+        assert(pointJson == `"Point"`, "Point encoding failed: " ~ pointJson);
+
+        // Decoding: round-trip
+        auto c2 = `{"Circle":1.0}`.fromJsonString!Shape;
+        auto s2 = `{"Square":2.5}`.fromJsonString!Shape;
+        auto p2 = `"Point"`.fromJsonString!Shape;
+
+        assert(c2.toJsonString!Shape == `{"Circle":1.0}` ||
+               c2.toJsonString!Shape == `{"Circle":1}`,
+               "Circle round-trip failed");
+        assert(s2.toJsonString!Shape == `{"Square":2.5}`,
+               "Square round-trip failed");
+        assert(p2.toJsonString!Shape == `"Point"`,
+               "Point round-trip failed");
+
+        // Error on unknown constructor
+        assertThrows({ `{"Triangle":3}`.fromJsonString!Shape; });
+    };
 }
 
 void assertThrows(T)(T fn, bool writeMsg = false)

--- a/internal/support_matrix.ml
+++ b/internal/support_matrix.ml
@@ -142,7 +142,6 @@ let languages : (string * lang_support) list = [
   "atdd (D)", { all_yes with
     doc_comments     = Planned;
     json_repr_object = Planned;
-    sum_repr_object  = Planned;
     json_adapter     = Planned;
     imports          = Planned;
     open_enums       = Planned;


### PR DESCRIPTION
## Summary

- Sum types annotated with `<json repr="object">` now encode/decode tagged variants as single-key JSON objects `{"Constructor": payload}` instead of the default two-element array `["Constructor", payload]`.
- Unit variants (no payload) remain plain strings regardless of the repr annotation.
- Adds a `shape` type to the test suite with `Circle`, `Square`, and `Point` variants.

## Motivation

This encoding matches the [Rust/Serde default externally-tagged representation](https://serde.rs/enum-representations.html#externally-tagged) and was already implemented for OCaml in atdml (commit 0fc67a5). It also maps naturally to YAML as a single-key mapping:

```yaml
# array encoding (default):
- - Circle
  - 3.14
# object encoding (<json repr="object">):
- Circle: 3.14
```

Uses D's `std.json` associative-array literal `JSONValue(["key": value])` for writing, and `x.object_.keys.front` for reading the single key.

## Test plan

- [x] `dune runtest atdd/test` — codegen diff test passes (D runtime tests require ldc2, not available in CI)