### PR TITLE
atdj: add <json repr="object"> for sum types (externally-tagged encoding)

### DIFF
--- a/atdj/src/atdj_helper.ml
+++ b/atdj/src/atdj_helper.ml
@@ -30,12 +30,25 @@ let output_util env =
   let out = Atdj_trans.open_class env "Util" in
   fprintf out "\
 class Util {
-  // Extract the tag of sum-typed value
+  // Extract the tag of a sum-typed value.
+  // Handles three encodings:
+  //   - String: unit variant e.g. \"Foo\"
+  //   - JSONArray: two-element array e.g. [\"Foo\", payload]
+  //       (the default ATD encoding for tagged variants)
+  //   - JSONObject: single-key object e.g. {\"Foo\": payload}
+  //       (<json repr=\"object\">, the Rust/Serde default externally-tagged
+  //       encoding; also maps naturally to YAML as a single-key mapping)
   static String extractTag(Object value) throws JSONException {
     if (value instanceof String)
       return (String)value;
     else if (value instanceof JSONArray)
       return ((JSONArray)value).getString(0);
+    else if (value instanceof JSONObject) {
+      JSONObject obj = (JSONObject)value;
+      if (obj.length() != 1)
+        throw new JSONException(\"Expected single-key object for sum type\");
+      return obj.keys().next();
+    }
     else throw new JSONException(\"Cannot extract type\");
   }
 

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -327,8 +327,23 @@ and trans_outer env (def : A.type_def) =
  * we generate a class Ty implemented in Ty.java and an enum TyEnum defined
  * in a separate file TyTag.java.
 *)
-and trans_sum my_name env (_, vars, _) =
+and trans_sum my_name env (_, vars, sum_an) =
   let class_name = Atdj_names.to_class_name my_name in
+
+  (* Determine whether tagged variants are encoded as two-element JSON arrays
+     ["Constructor", payload] (the default ATD encoding) or as single-key JSON
+     objects {"Constructor": payload} (<json repr="object">).
+
+     The object encoding is the default for Rust/Serde (externally-tagged)
+     and also maps naturally to YAML as a single-key mapping:
+
+       # array encoding (default):
+       - - Circle
+         - 3.14
+       # object encoding (<json repr="object">):
+       - Circle: 3.14
+  *)
+  let json_sum_repr = (Atd.Json.get_json_sum sum_an).json_sum_repr in
 
   let cases =
     List.map (fun (x : A.variant) ->
@@ -401,7 +416,16 @@ public class %s {
                enum_name
 
          | Some (atd_ty, java_ty) ->
-             let src = sprintf "((JSONArray)o).%s(1)" (get env atd_ty false) in
+             (* Extract the payload from the tagged variant.
+                Array encoding: ["Constructor", payload] → index 1 in JSONArray
+                Object encoding: {"Constructor": payload} → key "Constructor" in JSONObject *)
+             let src =
+               match json_sum_repr with
+               | Atd.Json.Array ->
+                   sprintf "((JSONArray)o).%s(1)" (get env atd_ty false)
+               | Atd.Json.Object ->
+                   sprintf "((JSONObject)o).%s(\"%s\")" (get env atd_ty false) json_name
+             in
              let set_value =
                assign env
                  (Some ("field_" ^ field_name)) src
@@ -485,14 +509,31 @@ public class %s {
                json_name (* TODO: java-string-escape *)
 
          | Some (atd_ty, _) ->
-             fprintf out "
+             (* Encode the tagged variant.
+                Array encoding (default): ["Constructor", payload]
+                Object encoding (<json repr="object">): {"Constructor": payload}
+
+                The object encoding is the Rust/Serde default (externally-tagged)
+                and also produces idiomatic YAML: Constructor: payload *)
+             (match json_sum_repr with
+              | Atd.Json.Array ->
+                  fprintf out "
       case %s:
          _out.append(\"[\\\"%s\\\",\");
 %s         _out.append(\"]\");
          break;"
-               enum_name
-               json_name
-               (to_string env ("field_" ^ field_name) atd_ty "         ")
+                    enum_name
+                    json_name
+                    (to_string env ("field_" ^ field_name) atd_ty "         ")
+              | Atd.Json.Object ->
+                  fprintf out "
+      case %s:
+         _out.append(\"{\\\"%s\\\":\");
+%s         _out.append(\"}\");
+         break;"
+                    enum_name
+                    json_name
+                    (to_string env ("field_" ^ field_name) atd_ty "         "))
        ) l
     ) cases;
 

--- a/atdj/test/AtdjTest.java
+++ b/atdj/test/AtdjTest.java
@@ -83,6 +83,43 @@ public class AtdjTest {
     assertEquals(false, v.l.get(1));
   }
 
+  /**
+   * Test the object encoding for sum types: {"Constructor": payload}
+   * instead of the default array encoding: ["Constructor", payload].
+   *
+   * This is the Rust/Serde default (externally-tagged) and also maps
+   * naturally to YAML as a single-key mapping.
+   */
+  @Test
+  public void testSumReprObject() throws JSONException {
+    // Encode a Circle: should produce {"Circle": 3.14}
+    Shape circle = new Shape();
+    circle.setCircle(3.14);
+    assertEquals("{\"Circle\":3.14}", circle.toJson());
+
+    // Encode a Square: should produce {"Square": 2.0}
+    Shape square = new Shape();
+    square.setSquare(2.0);
+    assertEquals("{\"Square\":2.0}", square.toJson());
+
+    // Unit variant is still encoded as a plain string regardless of repr
+    Shape point = new Shape();
+    point.setPoint();
+    assertEquals("\"Point\"", point.toJson());
+
+    // Decode: {"Circle": 1.0} -> Circle(1.0)
+    Shape decoded = new Shape(new org.json.JSONObject("{\"Circle\": 1.0}"));
+    assertEquals(Shape.Tag.CIRCLE, decoded.tag());
+    assertEquals(1.0, decoded.getCircle(), 1e-9);
+
+    // Round-trip
+    Shape orig = new Shape();
+    orig.setSquare(5.5);
+    Shape rt = new Shape(new org.json.JSONObject(orig.toJson()));
+    assertEquals(Shape.Tag.SQUARE, rt.tag());
+    assertEquals(5.5, rt.getSquare(), 1e-9);
+  }
+
   public static void main(String[] args) {
     org.junit.runner.JUnitCore.main("AtdjTest");
   }

--- a/atdj/test/com/mylife/test/dune
+++ b/atdj/test/com/mylife/test/dune
@@ -8,6 +8,7 @@
   E.java
   RecordWithDefaults.java
   SampleSum.java
+  Shape.java
   SimpleRecord.java
   Util.java
   package.html)

--- a/atdj/test/dune
+++ b/atdj/test/dune
@@ -38,6 +38,11 @@
 (rule
  (alias runtest)
  (package atdj)
+ (action (diff expected/Shape.java com/mylife/test/Shape.java)))
+
+(rule
+ (alias runtest)
+ (package atdj)
  (action (diff expected/SimpleRecord.java com/mylife/test/SimpleRecord.java)))
 
 (rule

--- a/atdj/test/expected/Shape.java
+++ b/atdj/test/expected/Shape.java
@@ -1,0 +1,104 @@
+// Automatically generated; do not edit
+package com.mylife.test;
+import org.json.*;
+
+/**
+ * Construct objects of type shape.
+ */
+
+public class Shape {
+  Tag t = null;
+
+  public Shape() {
+  }
+
+  public Tag tag() {
+    return t;
+  }
+
+  /**
+   * Define tags for sum type shape.
+   */
+  public enum Tag {
+    CIRCLE, SQUARE, POINT
+  }
+
+  public Shape(Object o) throws JSONException {
+    String tag = Util.extractTag(o);
+    if (tag.equals("Circle")) {
+      field_circle = ((JSONObject)o).getDouble("Circle");
+
+      t = Tag.CIRCLE;
+    }
+    else if (tag.equals("Square")) {
+      field_square = ((JSONObject)o).getDouble("Square");
+
+      t = Tag.SQUARE;
+    }
+    else if (tag.equals("Point"))
+      t = Tag.POINT;
+    else
+      throw new JSONException("Invalid tag: " + tag);
+  }
+
+  Double field_circle = null;
+  public void setCircle(Double x) {
+    /* TODO: clear previously-set field in order to avoid memory leak */
+    t = Tag.CIRCLE;
+    field_circle = x;
+  }
+  public Double getCircle() {
+    if (t == Tag.CIRCLE)
+      return field_circle;
+    else
+      return null;
+  }
+
+  Double field_square = null;
+  public void setSquare(Double x) {
+    /* TODO: clear previously-set field in order to avoid memory leak */
+    t = Tag.SQUARE;
+    field_square = x;
+  }
+  public Double getSquare() {
+    if (t == Tag.SQUARE)
+      return field_square;
+    else
+      return null;
+  }
+
+  public void setPoint() {
+    /* TODO: clear previously-set field and avoid memory leak */
+    t = Tag.POINT;
+  }
+
+  public void toJsonBuffer(StringBuilder _out) throws JSONException {
+    if (t == null)
+      throw new JSONException("Uninitialized Shape");
+    else {
+      switch(t) {
+      case CIRCLE:
+         _out.append("{\"Circle\":");
+         _out.append(String.valueOf(field_circle));
+         _out.append("}");
+         break;
+      case SQUARE:
+         _out.append("{\"Square\":");
+         _out.append(String.valueOf(field_square));
+         _out.append("}");
+         break;
+      case POINT:
+        _out.append("\"Point\"");
+        break;
+      default:
+        break; /* unused; keeps compiler happy */
+      }
+    }
+  }
+
+  public String toJson() throws JSONException {
+    StringBuilder out = new StringBuilder(128);
+    toJsonBuffer(out);
+    return out.toString();
+  }
+}

--- a/atdj/test/expected/Util.java
+++ b/atdj/test/expected/Util.java
@@ -3,12 +3,25 @@ package com.mylife.test;
 import org.json.*;
 
 class Util {
-  // Extract the tag of sum-typed value
+  // Extract the tag of a sum-typed value.
+  // Handles three encodings:
+  //   - String: unit variant e.g. "Foo"
+  //   - JSONArray: two-element array e.g. ["Foo", payload]
+  //       (the default ATD encoding for tagged variants)
+  //   - JSONObject: single-key object e.g. {"Foo": payload}
+  //       (<json repr="object">, the Rust/Serde default externally-tagged
+  //       encoding; also maps naturally to YAML as a single-key mapping)
   static String extractTag(Object value) throws JSONException {
     if (value instanceof String)
       return (String)value;
     else if (value instanceof JSONArray)
       return ((JSONArray)value).getString(0);
+    else if (value instanceof JSONObject) {
+      JSONObject obj = (JSONObject)value;
+      if (obj.length() != 1)
+        throw new JSONException("Expected single-key object for sum type");
+      return obj.keys().next();
+    }
     else throw new JSONException("Cannot extract type");
   }
 

--- a/atdj/test/test.atd
+++ b/atdj/test/test.atd
@@ -47,3 +47,22 @@ type simple_record = { ?o : bool option }
 (* https://github.com/esperco/atdj/issues/2 *)
 type a = [ A of b list ]
 type b = [ B ]
+
+(*
+  Sum type using the object encoding: {"Constructor": payload}
+  instead of the default array encoding: ["Constructor", payload].
+
+  This matches the Rust/Serde default (externally-tagged) and also
+  looks natural in YAML:
+
+    # array encoding (default):
+    - - Circle
+      - 3.14
+    # object encoding (<json repr="object">):
+    - Circle: 3.14
+*)
+type shape = [
+  | Circle of float
+  | Square of float
+  | Point              (* unit variant -- always encoded as a plain string *)
+] <json repr="object">

--- a/internal/support_matrix.ml
+++ b/internal/support_matrix.ml
@@ -124,7 +124,6 @@ let languages : (string * lang_support) list = [
   "atdj (Java)", { all_yes with
     wrap             = Planned;
     json_repr_object = Planned;
-    sum_repr_object  = Planned;
     json_adapter     = Planned;
     imports          = Planned;
     open_enums       = Planned;


### PR DESCRIPTION
## Summary

- Sum types annotated with `<json repr="object">` now encode/decode tagged variants as single-key JSON objects `{"Constructor": payload}` instead of the default two-element array `["Constructor", payload]`.
- Unit variants (no payload) remain plain strings regardless of the repr annotation.
- Updates `Util.extractTag()` to also handle `JSONObject` values (in addition to `String` and `JSONArray`).
- Adds a `shape` type to the test suite with `Circle`, `Square`, and `Point` variants.

## Motivation

This encoding matches the [Rust/Serde default externally-tagged representation](https://serde.rs/enum-representations.html#externally-tagged) and was already implemented for OCaml in atdml (commit 0fc67a5). It also maps naturally to YAML as a single-key mapping:

```yaml
# array encoding (default):
- - Circle
  - 3.14
# object encoding (<json repr="object">):
- Circle: 3.14
```

Decoding uses `((JSONObject)o).getDouble("Circle")` (key-based access) instead of `((JSONArray)o).getDouble(1)` (index-based). Encoding wraps the payload with `{\"Circle\":` … `}` instead of `[\"Circle\",` … `]`.

## Test plan

- [x] `dune runtest atdj/test` — codegen diff test passes (Java runtime tests require javac, not available in CI)