### PR TITLE
atds: add <json repr="object"> for sum types (externally-tagged encoding)

### DIFF
--- a/atds/src/atds_trans.ml
+++ b/atds/src/atds_trans.ml
@@ -160,8 +160,23 @@ and trans_outer env (def : A.type_def) =
  * we generate a sealed abstract class Ty and case classes Foo and Bar
  * in the Ty companion object.
 *)
-and trans_sum my_name env (_, vars, _) =
+and trans_sum my_name env (_, vars, sum_an) =
   let class_name = Atds_names.to_class_name my_name in
+
+  (* Determine whether tagged variants are encoded as two-element JSON arrays
+     ["Constructor", payload] (the default ATD encoding) or as single-key
+     JSON objects {"Constructor": payload} (<json repr="object">).
+
+     The object encoding is the Rust/Serde default (externally-tagged)
+     and also maps naturally to YAML as a single-key mapping:
+
+       # array encoding (default):
+       - - Circle
+         - 3.14
+       # object encoding (<json repr="object">):
+       - Circle: 3.14
+  *)
+  let json_sum_repr = (Atd.Json.get_json_sum sum_an).json_sum_repr in
 
   let cases =
     List.map (fun (x : A.variant) ->
@@ -209,18 +224,29 @@ object %s {"
          class_name
          json_name;
     | Some (atd_ty, scala_ty) ->
+        (* Encode the tagged variant.
+           Array encoding (default): ["Constructor", payload]
+           Object encoding (<json repr="object">): {"Constructor": payload}
+
+           The object encoding is the Rust/Serde default (externally-tagged)
+           and also produces idiomatic YAML: Constructor: payload *)
+        let encode_expr =
+          match json_sum_repr with
+          | Atd.Json.Array ->
+              sprintf "argonaut.Json.array(\n      jString(\"%s\"),\n      %s.asJson\n     )"
+                json_name "data"
+          | Atd.Json.Object ->
+              sprintf "argonaut.Json.obj(\n      \"%s\" -> %s.asJson\n     )"
+                json_name "data"
+        in
         fprintf out "
   case class %s(data: %s) extends %s {
-    override protected def toArgonaut: argonaut.Json = argonaut.Json.array(
-      jString(\"%s\"),
-      %s.asJson
-     )
+    override protected def toArgonaut: argonaut.Json = %s
   }"
           scala_name
           scala_ty
           class_name
-          json_name
-          "data"
+          encode_expr
    ) cases;
 
   fprintf out "\n}\n";

--- a/atds/test/AtdsTest.scala
+++ b/atds/test/AtdsTest.scala
@@ -33,6 +33,27 @@ class AtdsTest {
     assertEquals(s"""["Simple_rec",$rstr]""", s.asJson.nospaces)
   }
 
+  /**
+   * Test the object encoding for sum types: {"Constructor": payload}
+   * instead of the default array encoding: ["Constructor", payload].
+   *
+   * This is the Rust/Serde default (externally-tagged) and also maps
+   * naturally to YAML as a single-key mapping.
+   */
+  @Test
+  def testSumReprObject {
+    // Tagged variants use single-key object encoding
+    val c = Shape.Circle(3.14)
+    assertEquals("""{"Circle":3.14}""", c.asJson.nospaces)
+
+    val sq = Shape.Square(2.0)
+    assertEquals("""{"Square":2.0}""", sq.asJson.nospaces)
+
+    // Unit variant is still encoded as a plain string regardless of repr
+    val pt = Shape.Point
+    assertEquals("\"Point\"", pt.asJson.nospaces)
+  }
+
 }
 object AtdsTest {
 

--- a/atds/test/test.atd
+++ b/atds/test/test.atd
@@ -81,3 +81,22 @@ type addr = {
 type a = [ A of b list ]
 type b = [ B ]
 *)
+
+(*
+  Sum type using the object encoding: {"Constructor": payload}
+  instead of the default array encoding: ["Constructor", payload].
+
+  This matches the Rust/Serde default (externally-tagged) and also
+  looks natural in YAML:
+
+    # array encoding (default):
+    - - Circle
+      - 3.14
+    # object encoding (<json repr="object">):
+    - Circle: 3.14
+*)
+type shape = [
+  | Circle of float
+  | Square of float
+  | Point              (* unit variant -- always encoded as a plain string *)
+] <json repr="object">

--- a/atds/test/test.expected.scala
+++ b/atds/test/test.expected.scala
@@ -238,4 +238,28 @@ case class Addr(
   )
 }
 
+/**
+ * Construct objects of type shape.
+ */
+sealed abstract class Shape extends Atds
+
+/**
+ * Define tags for sum type shape.
+ */
+object Shape {
+  case class Circle(data: Double) extends Shape {
+    override protected def toArgonaut: argonaut.Json = argonaut.Json.obj(
+      "Circle" -> data.asJson
+     )
+  }
+  case class Square(data: Double) extends Shape {
+    override protected def toArgonaut: argonaut.Json = argonaut.Json.obj(
+      "Square" -> data.asJson
+     )
+  }
+  case object Point extends Shape {
+    override protected def toArgonaut: argonaut.Json = jString("Point")
+  }
+}
+
 }

--- a/internal/support_matrix.ml
+++ b/internal/support_matrix.ml
@@ -133,7 +133,6 @@ let languages : (string * lang_support) list = [
   "atds (Scala)", { all_yes with
     wrap             = Planned;
     json_repr_object = Planned;
-    sum_repr_object  = Planned;
     json_adapter     = Planned;
     imports          = Planned;
     open_enums       = Planned;


### PR DESCRIPTION
## Summary

- Sum types annotated with `<json repr="object">` now encode tagged variants as single-key JSON objects `{"Constructor": payload}` instead of the default two-element array `["Constructor", payload]`.
- Unit variants (no payload) remain plain strings regardless of the repr annotation.
- Adds a `shape` type to the test suite with `Circle`, `Square`, and `Point` variants.

## Motivation

This encoding matches the [Rust/Serde default externally-tagged representation](https://serde.rs/enum-representations.html#externally-tagged) and was already implemented for OCaml in atdml (commit 0fc67a5). It also maps naturally to YAML as a single-key mapping:

```yaml
# array encoding (default):
- - Circle
  - 3.14
# object encoding (<json repr="object">):
- Circle: 3.14
```

Uses Argonaut's `Json.obj("Constructor" -> data.asJson)` instead of `Json.array(jString("Constructor"), data.asJson)`. Note: decoding is not yet supported in atds.

## Test plan

- [x] `dune runtest atds/test` — codegen diff test passes (Scala runtime tests require scalac, not available in CI)