### PR TITLE
atdml: replace --no-yojson/--no-jsonlike with --mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,11 +42,13 @@ unreleased
 
 * atdml: Generate `foo_of_jsonlike` reader functions that accept an
   `Atd_jsonlike.AST.t` value and return a typed OCaml value, with error
-  messages that include the original source location. New CLI flags:
-  - `--no-jsonlike`: suppress generation of `of_jsonlike` readers
-    (reduces generated code and removes the `atd-jsonlike` runtime dependency)
-  - `--no-yojson`: suppress generation of Yojson-based readers/writers
-    (for users who only need the jsonlike path)
+  messages that include the original source location.
+  - Default output is Yojson-based readers/writers only (no `atd-jsonlike`
+    dependency unless explicitly requested).
+  - New `--mode MODE` option (repeatable) selects what to generate.
+    `MODE` is a mode name or comma-separated list of mode names.
+    Valid modes: `yojson`, `jsonlike`, `all` (= yojson + jsonlike).
+    Example: `atdml --mode yojson,jsonlike foo.atd`
   - JSON adapters (`<json adapter.ocaml="M">`) are supported for the jsonlike
     path: if the adapter module `M` provides `normalize_jsonlike`, it is called
     before deserialization by `foo_of_jsonlike`. Inline adapters

--- a/atd-yamlx/examples/dune
+++ b/atd-yamlx/examples/dune
@@ -4,7 +4,7 @@
 (rule
  (targets app_config.ml app_config.mli)
  (deps    app_config.atd)
- (action  (run %{bin:atdml} --mode all %{deps})))
+ (action  (run %{bin:atdml} --mode jsonlike %{deps})))
 
 ; This has more dependencies than the bare atd-yamlx library.
 ; It's fine because this executable is not declared as part of the atd-yamlx

--- a/atd-yamlx/examples/dune
+++ b/atd-yamlx/examples/dune
@@ -1,5 +1,5 @@
 ; Generate app_config.ml + app_config.mli from app_config.atd using atdml.
-; --mode all ensures both yojson and jsonlike readers are generated,
+; --mode jsonlike ensures jsonlike readers are generated,
 ; since main.ml uses app_config_of_jsonlike.
 (rule
  (targets app_config.ml app_config.mli)

--- a/atd-yamlx/examples/dune
+++ b/atd-yamlx/examples/dune
@@ -1,8 +1,10 @@
 ; Generate app_config.ml + app_config.mli from app_config.atd using atdml.
+; --mode all ensures both yojson and jsonlike readers are generated,
+; since main.ml uses app_config_of_jsonlike.
 (rule
  (targets app_config.ml app_config.mli)
  (deps    app_config.atd)
- (action  (run %{bin:atdml} %{deps})))
+ (action  (run %{bin:atdml} --mode all %{deps})))
 
 ; This has more dependencies than the bare atd-yamlx library.
 ; It's fine because this executable is not declared as part of the atd-yamlx
@@ -10,3 +12,9 @@
 (executable
  (name main)
  (libraries atd-yamlx atd-jsonlike yamlx yojson))
+
+; Run the example as part of 'dune runtest atd-yamlx'.
+(rule
+ (alias runtest)
+ (deps config.yaml)
+ (action (run %{exe:main.exe})))

--- a/atdml/src/bin/Atdml_main.ml
+++ b/atdml/src/bin/Atdml_main.ml
@@ -46,6 +46,35 @@ let version_term =
   in
   Arg.value (Arg.flag info)
 
+(*
+   Parse the list of strings collected from all '--mode' occurrences into
+   a (yojson, jsonlike) pair.
+
+   Each string may be a single mode name or a comma-separated list:
+     --mode yojson
+     --mode jsonlike,yojson
+     --mode all
+
+   If '--mode' is never supplied the default is [yojson] (no jsonlike).
+   The special mode 'all' expands to every available mode.
+*)
+let parse_mode_strings = function
+  | [] -> (true, false)   (* default: yojson only *)
+  | mode_strings ->
+      let tokens =
+        List.concat_map (String.split_on_char ',') mode_strings
+        |> List.map String.trim
+        |> List.filter (fun s -> s <> "")
+      in
+      List.fold_left (fun (y, j) token ->
+        match token with
+        | "yojson"   -> (true, j)
+        | "jsonlike" -> (y, true)
+        | "all"      -> (true, true)
+        | other ->
+            error (sprintf "unknown mode %S; valid modes: yojson, jsonlike, all" other)
+      ) (false, false) tokens
+
 let doc =
   "Simplified OCaml JSON serializers using the Yojson AST"
 
@@ -67,6 +96,8 @@ let man = [
   `S Manpage.s_examples;
   `P "Generate 'foo.ml' and 'foo.mli' from 'foo.atd':";
   `Pre "atdml foo.atd";
+  `P "Also generate Atd_jsonlike-based readers:";
+  `Pre "atdml --mode yojson,jsonlike foo.atd";
   `P "Generate a self-contained snippet from stdin:";
   `Pre "atdml < foo.atd";
   `P "Sample ATD file 'foo.atd':";
@@ -124,37 +155,35 @@ end
   `P "atdgen, atdpy, atdts"
 ]
 
-let no_yojson_term =
+let mode_term =
   let info =
-    Arg.info ["no-yojson"]
-      ~doc:"Do not generate Yojson-based readers, writers, and I/O functions. \
-            Use this when the generated code should not depend on yojson."
+    Arg.info ["mode"]
+      ~docv:"MODE"
+      ~doc:"Select which readers/writers to generate. \
+            $(docv) is a mode name or a comma-separated list of mode names. \
+            This option may be repeated. \
+            Valid modes: \
+            $(b,yojson) (Yojson.Safe.t-based readers and writers), \
+            $(b,jsonlike) (Atd_jsonlike.AST.t-based readers), \
+            $(b,all) (all of the above). \
+            Default when the option is absent: $(b,yojson)."
   in
-  Arg.value (Arg.flag info)
-
-let no_jsonlike_term =
-  let info =
-    Arg.info ["no-jsonlike"]
-      ~doc:"Do not generate Atd_jsonlike-based readers. \
-            Use this to reduce the amount of generated code and avoid a \
-            dependency on the atd-jsonlike library."
-  in
-  Arg.value (Arg.flag info)
+  Arg.value (Arg.opt_all Arg.string [] info)
 
 let cmdline_term run =
-  let combine input_files version no_yojson no_jsonlike =
+  let combine input_files version mode_strings =
+    let (yojson, jsonlike) = parse_mode_strings mode_strings in
     run {
       input_files;
       version;
-      yojson = not no_yojson;
-      jsonlike = not no_jsonlike;
+      yojson;
+      jsonlike;
     }
   in
   Term.(const combine
         $ input_files_term
         $ version_term
-        $ no_yojson_term
-        $ no_jsonlike_term
+        $ mode_term
        )
 
 let parse_command_line_and_run run =

--- a/atdml/tests/test.ml
+++ b/atdml/tests/test.ml
@@ -22,7 +22,7 @@ let run_codegen ~test_name ~file_name atd_src =
   Testo.with_temp_dir ~chdir:true (fun _dir ->
     let atd_file = file_name ^ ".atd" in
     Testo.write_text_file (Fpath.v atd_file) atd_src;
-    Standard_tests.Util.run_command [atdml; atd_file];
+    Standard_tests.Util.run_command [atdml; "--mode"; "all"; atd_file];
     let mli = Testo.read_text_file (Fpath.v (file_name ^ ".mli")) in
     let ml = Testo.read_text_file (Fpath.v (file_name ^ ".ml"))  in
     (mli, ml)
@@ -109,7 +109,7 @@ let build_and_run ?(test_jsonlike = true) ?(extra_sources = []) ?(extra_atd_file
       List.concat (List.map (fun (atd_fname, atd_src) ->
         let base = Filename.chop_suffix atd_fname ".atd" in
         Testo.write_text_file (Fpath.v atd_fname) atd_src;
-        Standard_tests.Util.run_command [atdml; atd_fname];
+        Standard_tests.Util.run_command [atdml; "--mode"; "all"; atd_fname];
         [ base ^ ".mli"; base ^ ".ml" ]
       ) extra_atd_files)
     in


### PR DESCRIPTION

## Summary

- Default output is now **yojson only** — no `atd-jsonlike` dependency unless explicitly requested.
- `--no-yojson` and `--no-jsonlike` are replaced by a single repeatable `--mode` option.

## New `--mode` option

`--mode MODE` may be given multiple times. Each `MODE` is a mode name or a comma-separated list:

| Mode | What is generated |
|---|---|
| `yojson` | Yojson.Safe.t-based readers and writers (default) |
| `jsonlike` | Atd_jsonlike.AST.t-based readers |
| `all` | Everything above |

Examples:
```
atdml foo.atd                          # yojson only (default)
atdml --mode jsonlike foo.atd          # jsonlike only
atdml --mode yojson,jsonlike foo.atd   # both
atdml --mode all foo.atd               # both (shorthand)
```

## Notes

- Tests pass `--mode all` so existing snapshots (which include jsonlike output) remain valid.
- The standard JSON test suite is unaffected — it only uses yojson functions and works with the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)