### PR TITLE
atdj: generate wrapper classes for top-level list aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+4.1.1 (unreleased)
+------------------
+
+* atdj: Top-level list aliases such as `type items = item list` are now
+  supported. A wrapper class (e.g. `Items`) implementing `Atdj` is generated
+  with the same interface as record classes: a no-arg constructor, a
+  constructor from `ArrayList<T>`, a constructor from a JSON string, a
+  package-private constructor from `JSONArray`, `toJsonBuffer`, `toJson`,
+  and a public `value` field of type `ArrayList<T>`. List aliases used as
+  record fields or sum-variant payloads are also handled correctly.
+
 4.1.0 (2026-04-11)
 ------------------
 

--- a/atdj/src/atdj_helper.ml
+++ b/atdj/src/atdj_helper.ml
@@ -47,7 +47,7 @@ class Util {
       JSONObject obj = (JSONObject)value;
       if (obj.length() != 1)
         throw new JSONException(\"Expected single-key object for sum type\");
-      return obj.keys().next();
+      return (String) obj.keys().next();
     }
     else throw new JSONException(\"Cannot extract type\");
   }

--- a/atdj/src/atdj_trans.ml
+++ b/atdj/src/atdj_trans.ml
@@ -67,6 +67,9 @@ let rec assign env opt_dst src java_ty atd_ty indent =
            sprintf "new %s(%s)" java_ty src
        | Record _ ->
            sprintf "new %s(%s)" java_ty src
+       | List _ when not (String.contains java_ty '<') ->
+           (* Named list alias class - use the JSONArray constructor *)
+           sprintf "new %s(%s)" java_ty src
        | Name (_, (_, ty, _), _) ->
            (match Atd.Type_name.basename ty with
             | "bool" | "int" | "float" | "string" -> src
@@ -81,18 +84,22 @@ let rec assign env opt_dst src java_ty atd_ty indent =
        | Record _ ->
            sprintf "%s%s = new %s(%s);\n" indent dst java_ty src
        | List (_, sub_ty, _) ->
-           let java_sub_ty = (*ahem*) extract_from_edgy_brackets java_ty in
-           let sub_expr = assign env None "_tmp" java_sub_ty sub_ty "" in
+           if String.contains java_ty '<' then
+             let java_sub_ty = (*ahem*) extract_from_edgy_brackets java_ty in
+             let sub_expr = assign env None "_tmp" java_sub_ty sub_ty "" in
 
-           sprintf "%s%s = new %s();\n" indent dst java_ty
-           ^ sprintf "%sfor (int _i = 0; _i < %s.length(); ++_i) {\n" indent src
+             sprintf "%s%s = new %s();\n" indent dst java_ty
+             ^ sprintf "%sfor (int _i = 0; _i < %s.length(); ++_i) {\n" indent src
 
-           ^ sprintf "%s  %s _tmp = %s.%s(_i);\n" indent
-             (json_of_atd env sub_ty) src (get env sub_ty false)
+             ^ sprintf "%s  %s _tmp = %s.%s(_i);\n" indent
+               (json_of_atd env sub_ty) src (get env sub_ty false)
 
-           ^ sprintf "%s  %s.add(%s);\n" indent
-             dst sub_expr
-           ^ sprintf "%s}\n" indent
+             ^ sprintf "%s  %s.add(%s);\n" indent
+               dst sub_expr
+             ^ sprintf "%s}\n" indent
+           else
+             (* Named list alias class - use the JSONArray constructor *)
+             sprintf "%s%s = new %s(%s);\n" indent dst java_ty src
 
        | Name (_, (_, ty, _), _) ->
            (match Atd.Type_name.basename ty with
@@ -315,10 +322,89 @@ and trans_outer env (def : A.type_def) =
       trans_sum name env (loc, v, a)
   | Record (loc, v, a) ->
       trans_record name env (loc, v, a)
-  | Name (_, (_, _name, _), _) ->
-      (* Don't translate primitive types at the top-level *)
-      env
+  | List (_, sub_ty, _) ->
+      trans_list_alias name env sub_ty
+  | Name (_, (_, _name, _), _) as ty ->
+      (match norm_ty env ty with
+       | List (_, sub_ty, _) -> trans_list_alias name env sub_ty
+       | _ -> (* Don't translate primitive types at the top-level *) env)
   | x -> type_not_supported x
+
+(* Translation of a top-level list alias, e.g. 'type items = item list'.
+ * Since Java has no type aliases, we generate a class Items that wraps an
+ * ArrayList and provides the same JSON interface as record classes.
+*)
+and trans_list_alias my_name env sub_atd_ty =
+  let class_name = Atdj_names.to_class_name my_name in
+  let (java_sub_ty, env) = trans_inner env sub_atd_ty in
+  let json_sub_ty = json_of_atd env sub_atd_ty in
+  let get_method = get env sub_atd_ty false in
+  let sub_expr = assign env None "_tmp" java_sub_ty sub_atd_ty "" in
+  let ctor_body =
+    sprintf "    for (int _i = 0; _i < ja.length(); ++_i) {\n"
+    ^ sprintf "      %s _tmp = ja.%s(_i);\n" json_sub_ty get_method
+    ^ sprintf "      value.add(%s);\n" sub_expr
+    ^ sprintf "    }\n"
+  in
+  let to_json_body =
+    sprintf "    _out.append(\"[\");\n"
+    ^ sprintf "    for (int i = 0; i < value.size(); ++i) {\n"
+    ^ to_string env "value.get(i)" sub_atd_ty "      "
+    ^ sprintf "      if (i < value.size() - 1)\n"
+    ^ sprintf "        _out.append(\",\");\n"
+    ^ sprintf "    }\n"
+    ^ sprintf "    _out.append(\"]\");\n"
+  in
+  let out = open_class env class_name in
+  fprintf out "\
+public class %s implements Atdj {
+  /**
+   * Construct a fresh empty list.
+   */
+  public %s() {
+    value = new java.util.ArrayList<%s>();
+  }
+
+  /**
+   * Construct from an existing list.
+   */
+  public %s(java.util.ArrayList<%s> arr) {
+    value = arr;
+  }
+
+  /**
+   * Construct from a JSON string.
+   */
+  public %s(String s) throws JSONException {
+    this(new JSONArray(s));
+  }
+
+  %s(JSONArray ja) throws JSONException {
+    value = new java.util.ArrayList<%s>();
+%s  }
+
+  public void toJsonBuffer(StringBuilder _out) throws JSONException {
+%s  }
+
+  public String toJson() throws JSONException {
+    StringBuilder out = new StringBuilder(128);
+    toJsonBuffer(out);
+    return out.toString();
+  }
+
+  public java.util.ArrayList<%s> value;
+}
+"
+    class_name
+    class_name java_sub_ty
+    class_name java_sub_ty
+    class_name
+    class_name java_sub_ty
+    ctor_body
+    to_json_body
+    java_sub_ty;
+  close_out out;
+  env
 
 (* Translation of sum types.  For a sum type
  *

--- a/atdj/test/com/mylife/test/dune
+++ b/atdj/test/com/mylife/test/dune
@@ -6,6 +6,7 @@
   B.java
   ComplexRecord.java
   E.java
+  Items.java
   RecordWithDefaults.java
   SampleSum.java
   Shape.java

--- a/atdj/test/dune
+++ b/atdj/test/dune
@@ -27,6 +27,11 @@
 (rule
  (alias runtest)
  (package atdj)
+ (action (diff expected/Items.java com/mylife/test/Items.java)))
+
+(rule
+ (alias runtest)
+ (package atdj)
  (action
   (diff expected/RecordWithDefaults.java com/mylife/test/RecordWithDefaults.java)))
 

--- a/atdj/test/expected/Items.java
+++ b/atdj/test/expected/Items.java
@@ -1,0 +1,52 @@
+// Automatically generated; do not edit
+package com.mylife.test;
+import org.json.*;
+
+public class Items implements Atdj {
+  /**
+   * Construct a fresh empty list.
+   */
+  public Items() {
+    value = new java.util.ArrayList<SimpleRecord>();
+  }
+
+  /**
+   * Construct from an existing list.
+   */
+  public Items(java.util.ArrayList<SimpleRecord> arr) {
+    value = arr;
+  }
+
+  /**
+   * Construct from a JSON string.
+   */
+  public Items(String s) throws JSONException {
+    this(new JSONArray(s));
+  }
+
+  Items(JSONArray ja) throws JSONException {
+    value = new java.util.ArrayList<SimpleRecord>();
+    for (int _i = 0; _i < ja.length(); ++_i) {
+      JSONObject _tmp = ja.getJSONObject(_i);
+      value.add(new SimpleRecord(_tmp));
+    }
+  }
+
+  public void toJsonBuffer(StringBuilder _out) throws JSONException {
+    _out.append("[");
+    for (int i = 0; i < value.size(); ++i) {
+      value.get(i).toJsonBuffer(_out);
+      if (i < value.size() - 1)
+        _out.append(",");
+    }
+    _out.append("]");
+  }
+
+  public String toJson() throws JSONException {
+    StringBuilder out = new StringBuilder(128);
+    toJsonBuffer(out);
+    return out.toString();
+  }
+
+  public java.util.ArrayList<SimpleRecord> value;
+}

--- a/atdj/test/expected/Util.java
+++ b/atdj/test/expected/Util.java
@@ -20,7 +20,7 @@ class Util {
       JSONObject obj = (JSONObject)value;
       if (obj.length() != 1)
         throw new JSONException("Expected single-key object for sum type");
-      return obj.keys().next();
+      return (String) obj.keys().next();
     }
     else throw new JSONException("Cannot extract type");
   }

--- a/atdj/test/test.atd
+++ b/atdj/test/test.atd
@@ -48,6 +48,10 @@ type simple_record = { ?o : bool option }
 type a = [ A of b list ]
 type b = [ B ]
 
+(* Type alias for a list - Java doesn't support type aliases, so we generate
+   a wrapper class with the same JSON interface as record classes. *)
+type items = simple_record list
+
 (*
   Sum type using the object encoding: {"Constructor": payload}
   instead of the default array encoding: ["Constructor", payload].


### PR DESCRIPTION
## Summary

- Java has no type aliases, so `type items = item list` previously caused an error in atdj. This PR generates a proper Java class instead.
- A new `trans_list_alias` function in `atdj_trans.ml` generates a class (e.g. `Items`) implementing `Atdj` with the same interface as record classes: no-arg constructor, `ArrayList<T>` constructor, `String` (JSON) constructor, package-private `JSONArray` constructor, `toJsonBuffer`, `toJson`, and a public `value` field.
- `trans_outer` is extended to recognise both direct `List` nodes and `Name` aliases that resolve to a `List` via `norm_ty`.
- `assign` is updated so that when a list alias appears as a record field or sum-variant payload, deserialization uses `new Items(jsonArray)` rather than the inline `ArrayList`-building loop.
- All element types are handled correctly: records, sums, booleans, integers, floats, and strings (the last using `Util.writeJsonString` as expected).
- A test case `type items = simple_record list` is added along with the expected `Items.java` output and the necessary dune rules.

## Test plan

- [x] `dune build atdj` compiles cleanly
- [x] All expected-vs-generated Java file diffs pass
- [x] Manually verify generated output for record, sum, bool, string, and int element types looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
