### PR TITLE
Add OCaml-to-jsonlike serializers and jsonlike-to-YAML converter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,19 @@
   and a public `value` field of type `ArrayList<T>`. List aliases used as
   record fields or sum-variant payloads are also handled correctly.
 
+* atdml: Generate `jsonlike_of_foo` serializer functions and `Foo.to_jsonlike`
+  submodule bindings, completing the OCaml ↔ `Atd_jsonlike.AST.t` round-trip.
+  JSON adapters are also supported: if the adapter module `M` provides
+  `restore_jsonlike`, it is called after serialization by `jsonlike_of_foo`.
+
+* atd-jsonlike: Add `Pos.zero` and `Loc.zero` — zero-position / zero-location
+  constants useful for constructing `AST.t` nodes programmatically when source
+  location information is not available.
+
+* atd-yamlx: Add `to_yamlx_value : Atd_jsonlike.AST.t -> YAMLx.value`, the
+  reverse of `of_yamlx_value`. Enables programmatic construction of YAML
+  documents from ATD-typed OCaml values via `jsonlike_of_foo`.
+
 4.1.0 (2026-04-11)
 ------------------
 

--- a/atd-jsonlike/src/Loc.ml
+++ b/atd-jsonlike/src/Loc.ml
@@ -4,6 +4,8 @@ type t = {
   file: string option;
 }
 
+let zero = { start = Pos.zero; end_ = Pos.zero; file = None }
+
 let equal a b =
   Pos.equal a.start b.start
   && Pos.equal a.end_ b.end_

--- a/atd-jsonlike/src/Loc.mli
+++ b/atd-jsonlike/src/Loc.mli
@@ -14,5 +14,8 @@ type t = {
         system. *)
 }
 
+val zero : t
+(** A zero-length location at the beginning of the input with no file. *)
+
 val equal : t -> t -> bool
 val compare : t -> t -> int

--- a/atd-jsonlike/src/Pos.ml
+++ b/atd-jsonlike/src/Pos.ml
@@ -3,6 +3,8 @@ type t = {
   column: int;
 }
 
+let zero = { row = 0; column = 0 }
+
 let equal a b = a.row = b.row && a.column = b.column
 
 let compare a b =

--- a/atd-jsonlike/src/Pos.mli
+++ b/atd-jsonlike/src/Pos.mli
@@ -14,5 +14,8 @@ type t = {
     (** position within the line, starting from 0 *)
 }
 
+val zero : t
+(** Position at the start of an input: row 0, column 0. *)
+
 val equal : t -> t -> bool
 val compare : t -> t -> int

--- a/atd-yamlx.opam
+++ b/atd-yamlx.opam
@@ -93,7 +93,7 @@ depends: [
   "dune" {>= "3.18"}
   "ocaml" {>= "4.14"}
   "atd-jsonlike" {= version}
-  "yamlx" {>= "0.1.0"}
+  "yamlx" {>= "0.2.0"}
   "testo" {>= "0.3.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/atd-yamlx/src/Atd_yamlx.ml
+++ b/atd-yamlx/src/Atd_yamlx.ml
@@ -30,7 +30,7 @@ let key_to_string ?file (key : YAMLx.value) : string =
   | String (_, s) -> s
   | Null loc | Bool (loc, _) | Int (loc, _) | Float (loc, _)
   | Seq (loc, _) | Map (loc, _) ->
-      let loc_str = YAMLx.default_format_loc ?file loc in
+      let loc_str = YAMLx.format_loc ?file loc in
       invalid_arg
         (loc_str ^ "map key must be a string; \
          pre-process the YAML document to convert non-string keys if needed")
@@ -60,3 +60,28 @@ let of_yamlx_value ?file v =
   match of_yamlx_value_exn ?file v with
   | result              -> Ok result
   | exception Invalid_argument msg -> Error ("invalid argument: " ^ msg)
+
+(* ===== Jsonlike → YAML conversion ===== *)
+
+let rec to_yamlx_value (node : AST.t) : YAMLx.value =
+  let loc = YAMLx.zero_loc in
+  match node with
+  | AST.Null _ -> YAMLx.Null loc
+  | AST.Bool (_, b) -> YAMLx.Bool (loc, b)
+  | AST.Number (_, n) ->
+      (match n.Number.int with
+       | Some i -> YAMLx.Int (loc, Int64.of_int i)
+       | None ->
+           match n.Number.float with
+           | Some f -> YAMLx.Float (loc, f)
+           | None ->
+               match n.Number.literal with
+               | Some s -> YAMLx.String (loc, s)
+               | None -> YAMLx.Int (loc, 0L))
+  | AST.String (_, s) -> YAMLx.String (loc, s)
+  | AST.Array (_, items) -> YAMLx.Seq (loc, List.map to_yamlx_value items)
+  | AST.Object (_, pairs) ->
+      YAMLx.Map (loc,
+        List.map (fun (_, k, v) ->
+          (loc, YAMLx.String (loc, k), to_yamlx_value v))
+          pairs)

--- a/atd-yamlx/src/Atd_yamlx.mli
+++ b/atd-yamlx/src/Atd_yamlx.mli
@@ -57,3 +57,24 @@ val of_yamlx_value :
     [Error] when a YAML map has a non-string key.  The error message includes
     the source location of the offending key. *)
 val of_yamlx_value_exn : ?file:string -> YAMLx.value -> Atd_jsonlike.AST.t
+
+(** Convert an [Atd_jsonlike.AST.t] to a [YAMLx.value].
+
+    This is the reverse of {!of_yamlx_value_exn}.  Source locations in the
+    input are ignored; the resulting [YAMLx.value] nodes all carry
+    {!YAMLx.zero_loc}.
+
+    {1 Jsonlike–YAML type correspondence}
+
+    | Jsonlike (atd-jsonlike)   | YAML (yamlx)                      |
+    |---------------------------|-----------------------------------|
+    | [Null]                    | [Null]                            |
+    | [Bool]                    | [Bool]                            |
+    | [Number] (int available)  | [Int] (int64)                     |
+    | [Number] (float only)     | [Float]                           |
+    | [Number] (literal only)   | [String] (verbatim literal)       |
+    | [String]                  | [String]                          |
+    | [Array]                   | [Seq]                             |
+    | [Object]                  | [Map] (string keys)               |
+*)
+val to_yamlx_value : Atd_jsonlike.AST.t -> YAMLx.value

--- a/atd-yamlx/tests/test.ml
+++ b/atd-yamlx/tests/test.ml
@@ -74,6 +74,58 @@ tags: []
   in
   Testo.check ast_t expected result
 
+(* Round-trip: parse YAML → jsonlike → YAMLx.value → compare against original. *)
+let test_to_yamlx_value () =
+  let yaml_str = {|
+answer: 42
+flag: true
+greeting: "hello"
+nothing: null
+scores:
+  - 1
+  - 2
+  - 3
+|} in
+  match YAMLx.Values.of_yaml yaml_str with
+  | Error msg -> failwith ("YAMLx parse error: " ^ msg)
+  | Ok [orig_val] ->
+      let jsonlike = Atd_yamlx.of_yamlx_value_exn orig_val in
+      let round_tripped = Atd_yamlx.to_yamlx_value jsonlike in
+      (* Re-convert back to jsonlike and compare (ignoring locations) *)
+      let jsonlike2 = Atd_yamlx.of_yamlx_value_exn round_tripped in
+      if not (AST.equal jsonlike jsonlike2) then
+        failwith (Printf.sprintf
+          "Round-trip mismatch!\nOriginal:\n%s\nRound-tripped:\n%s\n"
+          (AST.show jsonlike) (AST.show jsonlike2))
+  | Ok _ -> failwith "expected exactly one YAML document"
+
+(* to_yamlx_value handles all scalar types correctly. *)
+let test_to_yamlx_value_scalars () =
+  let no_loc = Loc.{ start = Pos.{row=0;column=0}; end_ = Pos.{row=0;column=0}; file=None } in
+  let check node expected_yaml_str =
+    let yaml_val = Atd_yamlx.to_yamlx_value node in
+    let yaml_str = YAMLx.Values.to_yaml [yaml_val] in
+    let reparsed =
+      match YAMLx.Values.of_yaml yaml_str with
+      | Ok [v] -> v
+      | _ -> failwith ("Could not reparse: " ^ yaml_str)
+    in
+    let jsonlike2 = Atd_yamlx.of_yamlx_value_exn reparsed in
+    if not (AST.equal node jsonlike2) then
+      failwith (Printf.sprintf "Expected YAML %s but round-trip gave: %s"
+        expected_yaml_str (AST.show jsonlike2))
+  in
+  check (AST.Null no_loc) "null";
+  check (AST.Bool (no_loc, true)) "true";
+  check (AST.Bool (no_loc, false)) "false";
+  check (AST.Number (no_loc, Number.of_int 42)) "42";
+  check (AST.Number (no_loc, Number.of_float 3.14)) "3.14";
+  check (AST.String (no_loc, "hello")) "\"hello\"";
+  check (AST.Array (no_loc, [
+    AST.Number (no_loc, Number.of_int 1);
+    AST.Number (no_loc, Number.of_int 2);
+  ])) "[1, 2]"
+
 (* A non-string map key should return an Error. *)
 let test_non_string_key_error () =
   let yaml_str = {|
@@ -95,6 +147,8 @@ let tests _env = [
   Testo.create "basic document: scalars, bool, null, sequence" test_basic_document;
   Testo.create "nested maps, float, empty sequence"            test_nested;
   Testo.create "non-string map key returns Error"              test_non_string_key_error;
+  Testo.create "to_yamlx_value: round-trip via YAML"           test_to_yamlx_value;
+  Testo.create "to_yamlx_value: scalar types"                  test_to_yamlx_value_scalars;
 ]
 
 let () =

--- a/atdml/src/lib/Codegen.ml
+++ b/atdml/src/lib/Codegen.ml
@@ -253,6 +253,21 @@ let normalize_jsonlike_of_adapter (adapter : Atd.Json.json_adapter) =
       else
         None
 
+(* Derive the restore_jsonlike expression from a module-based adapter.
+   Module-based adapters have restore = "M.restore"; we produce
+   "M.restore_jsonlike". Inline adapters are not supported for jsonlike. *)
+let restore_jsonlike_of_adapter (adapter : Atd.Json.json_adapter) =
+  match adapter.ocaml_adapter with
+  | None -> None
+  | Some a ->
+      let suffix = ".restore" in
+      let n = a.restore in
+      let slen = String.length suffix and nlen = String.length n in
+      if nlen > slen && String.sub n (nlen - slen) slen = suffix then
+        Some (String.sub n 0 (nlen - slen) ^ ".restore_jsonlike")
+      else
+        None
+
 (* ============ Doc comment helpers ============ *)
 
 (* Escape special characters for OCaml's ocamldoc format *)
@@ -338,6 +353,7 @@ let get_ocaml_name default_name an =
 let of_yojson_name name = name ^ "_of_yojson"
 let yojson_of_name name = "yojson_of_" ^ name
 let of_jsonlike_name name = name ^ "_of_jsonlike"
+let jsonlike_of_name name = "jsonlike_of_" ^ name
 let of_json_name name = name ^ "_of_json"
 let json_of_name name = "json_of_" ^ name
 let create_name name = "create_" ^ name
@@ -679,6 +695,62 @@ let rec writer_expr env (e : type_expr) : string =
       | Some f -> sprintf "(fun x -> %s ((%s) x))" inner f)
   | Sum _ | Record _ -> failwith "inline types are not supported"
 
+(* Produce a jsonlike writer expression for a type, analogous to writer_expr
+   but targeting Atd_jsonlike.AST.t instead of Yojson.Safe.t. *)
+let rec jsonlike_writer_expr env (e : type_expr) : string =
+  match e with
+  | Name (_, (_, TN ["unit"], []), _) -> "Atdml_runtime.Jsonlike.jsonlike_of_unit"
+  | Name (_, (_, TN ["bool"], []), _) -> "Atdml_runtime.Jsonlike.jsonlike_of_bool"
+  | Name (_, (_, TN ["int"], []), _) -> "Atdml_runtime.Jsonlike.jsonlike_of_int"
+  | Name (_, (_, TN ["float"], []), _) -> "Atdml_runtime.Jsonlike.jsonlike_of_float"
+  | Name (_, (_, TN ["string"], []), _) -> "Atdml_runtime.Jsonlike.jsonlike_of_string"
+  | Name (_, (_, TN ["abstract"], []), _) ->
+      "(fun _ -> failwith \"abstract type is not supported in jsonlike mode\")"
+  | Name (_, (_, TN [name], []), _) -> jsonlike_of_name (env.tr name)
+  | Name (_, (_, TN [name], params), _) ->
+      let writers = List.map (jsonlike_writer_expr env) params in
+      sprintf "(%s %s)" (jsonlike_of_name (env.tr name)) (String.concat " " writers)
+  | Name (loc, (_, name, params), _) ->
+      let (import_opt, base_name) = Atd.Imports.resolve env.imports loc name in
+      (match import_opt with
+       | None -> assert false
+       | Some (import, _) ->
+           let ocaml_mod = env.ocaml_mod_of_import import in
+           let fn = sprintf "%s.%s" ocaml_mod (jsonlike_of_name base_name) in
+           (match params with
+            | [] -> fn
+            | _ ->
+                let writers = List.map (jsonlike_writer_expr env) params in
+                sprintf "(%s %s)" fn (String.concat " " writers)))
+  | List (_, Tuple (_, [(_, Name (_, (_, TN ["string"], []), _), _); (_, val_e, _)], _), an)
+    when Atd.Json.get_json_list an = Atd.Json.Object ->
+      sprintf "(Atdml_runtime.Jsonlike.jsonlike_of_assoc %s)" (jsonlike_writer_expr env val_e)
+  | List (_, e, _) ->
+      sprintf "(Atdml_runtime.Jsonlike.jsonlike_of_list %s)" (jsonlike_writer_expr env e)
+  | Option (_, e, _) ->
+      sprintf "(Atdml_runtime.Jsonlike.jsonlike_of_option %s)" (jsonlike_writer_expr env e)
+  | Nullable (_, e, _) ->
+      sprintf "(Atdml_runtime.Jsonlike.jsonlike_of_nullable %s)" (jsonlike_writer_expr env e)
+  | Tuple (_, cells, _) ->
+      let vars = List.mapi (fun i _ -> sprintf "x%d" i) cells in
+      let writes =
+        List.mapi (fun i (_, e, _) ->
+          sprintf "%s %s" (jsonlike_writer_expr env e) (List.nth vars i)
+        ) cells
+      in
+      sprintf "(fun (%s) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [%s]))"
+        (String.concat ", " vars)
+        (String.concat "; " writes)
+  | Tvar (_, v) -> "jsonlike_of_" ^ v
+  | Shared (loc, _, _) -> not_implemented loc "shared"
+  | Wrap (_, inner_e, an) ->
+      let inner = jsonlike_writer_expr env inner_e in
+      let (_, _, unwrap_fn) = get_ocaml_wrap an in
+      (match unwrap_fn with
+      | None -> inner
+      | Some f -> sprintf "(fun x -> %s ((%s) x))" inner f)
+  | Sum _ | Record _ -> failwith "inline types are not supported"
+
 (* ============ Flatten variants ============ *)
 
 let flatten_variants variants =
@@ -836,6 +908,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end|} in
   [B.Line (preamble
     ^ (if yojson then yojson_ext else "")
@@ -1382,6 +1471,114 @@ let gen_yojson_of env ({A.name; param=params; annot=an; value=e; _} : A.type_def
       B.Block [B.Line (sprintf "fun %sx ->" extra_params); body];
     ]
 
+(* ============ jsonlike writer (jsonlike_of_foo) ============ *)
+
+let gen_jsonlike_of_field env pftr (_, (fname, kind, an), e) : B.node =
+  let json_name = Atd.Json.get_json_fname fname an in
+  let ofname = pftr fname in
+  match kind with
+  | Required | With_default ->
+      B.Line (sprintf "[(Atd_jsonlike.Loc.zero, \"%s\", %s x.%s)];" json_name (jsonlike_writer_expr env e) ofname)
+  | Optional ->
+      let inner_e =
+        match e with
+        | Option (_, ie, _) -> ie
+        | _ -> e
+      in
+      B.Line
+        (sprintf
+           "(match x.%s with None -> [] | Some v -> [(Atd_jsonlike.Loc.zero, \"%s\", %s v)]);"
+           ofname json_name (jsonlike_writer_expr env inner_e))
+
+let gen_jsonlike_of env ({A.name; param=params; annot=an; value=e; _} : A.type_def) : B.t =
+  let name = Atd.Type_name.basename name in
+  let ocaml_name = env.tr name in
+  let param_strs = List.map (fun v -> "jsonlike_of_" ^ v) params in
+  let extra_params =
+    if param_strs = [] then ""
+    else String.concat " " param_strs ^ " "
+  in
+  let arg_type = full_type_name ocaml_name params in
+  let loc = "Atd_jsonlike.Loc.zero" in
+  let body =
+    match e with
+    | Sum (_, variants, sum_an) ->
+        let is_poly =
+          match get_ocaml_repr sum_an with
+          | Some "poly" -> true
+          | _ -> false
+        in
+        let tick = if is_poly then "`" else "" in
+        let flat = flatten_variants variants in
+        let vtr =
+          make_local_env
+            (List.map (fun (_, orig_name, an, _) -> get_ocaml_name orig_name an) flat)
+        in
+        let sum = Atd.Json.get_json_sum sum_an in
+        let gen_case (_, orig_name, an, opt_e) =
+          let json_name = Atd.Json.get_json_cons orig_name an in
+          let cons_name = vtr (get_ocaml_name orig_name an) in
+          match opt_e with
+          | None ->
+              B.Line
+                (sprintf "| %s%s -> Atd_jsonlike.AST.String (%s, \"%s\")"
+                   tick cons_name loc json_name)
+          | Some e ->
+              let rhs = match sum.json_sum_repr with
+                | Atd.Json.Array ->
+                    sprintf "Atd_jsonlike.AST.Array (%s, [Atd_jsonlike.AST.String (%s, \"%s\"); %s v])"
+                      loc loc json_name (jsonlike_writer_expr env e)
+                | Atd.Json.Object ->
+                    sprintf "Atd_jsonlike.AST.Object (%s, [(%s, \"%s\", %s v)])"
+                      loc loc json_name (jsonlike_writer_expr env e)
+              in
+              B.Line (sprintf "| %s%s v -> %s" tick cons_name rhs)
+        in
+        let restore = restore_jsonlike_of_adapter sum.json_sum_adapter in
+        apply_restore restore
+          (B.Block
+            (B.Line "match x with"
+             :: List.map gen_case flat))
+    | Record (_, fields, rec_an) ->
+        let prefix = get_field_prefix rec_an in
+        let fields =
+          List.filter_map (fun (f : field) -> match f with
+            | Field x -> Some x
+            | Inherit _ -> assert false)
+            fields
+        in
+        let fnames = List.map (fun (_, (fname, _, _), _) -> fname) fields in
+        let (_, pftr) = make_prefixed_trs prefix fnames in
+        let restore =
+          restore_jsonlike_of_adapter (Atd.Json.get_json_record rec_an).json_record_adapter
+        in
+        apply_restore restore
+          (B.Block
+            [
+              B.Line (sprintf "Atd_jsonlike.AST.Object (%s, List.concat [" loc);
+              B.Block (List.map (gen_jsonlike_of_field env pftr) fields);
+              B.Line "])";
+            ])
+    | e ->
+        B.Block [B.Line (sprintf "%s x" (jsonlike_writer_expr env e))]
+  in
+  if params = [] then
+    [
+      B.Line (sprintf "let %s (x : %s) : Atd_jsonlike.AST.t ="
+                (jsonlike_of_name ocaml_name) arg_type);
+      body;
+    ]
+  else
+    let quant = String.concat " " (List.map (fun v -> "'" ^ v) params) in
+    let param_types =
+      String.concat " " (List.map (fun v -> sprintf "('%s -> Atd_jsonlike.AST.t) ->" v) params)
+    in
+    let full_type = sprintf "%s %s -> Atd_jsonlike.AST.t" param_types arg_type in
+    [
+      B.Line (sprintf "let %s : %s. %s =" (jsonlike_of_name ocaml_name) quant full_type);
+      B.Block [B.Line (sprintf "fun %sx ->" extra_params); body];
+    ]
+
 (* ============ Top-level I/O functions (all types, with converter args for parametric) ============ *)
 
 let gen_io_funs env ({A.name; param=params; _} : A.type_def) : B.t =
@@ -1438,7 +1635,10 @@ let gen_submodule_ml ~yojson ~jsonlike env ({A.name; param=params; annot=def_an;
   let bindings =
     create_binding
     @ (if yojson then [B.Line (sprintf "let of_yojson = %s" (of_yojson_name ocaml_name))] else [])
-    @ (if jsonlike then [B.Line (sprintf "let of_jsonlike = %s" (of_jsonlike_name ocaml_name))] else [])
+    @ (if jsonlike then [
+        B.Line (sprintf "let of_jsonlike = %s" (of_jsonlike_name ocaml_name));
+        B.Line (sprintf "let to_jsonlike = %s" (jsonlike_of_name ocaml_name));
+      ] else [])
     @ (if yojson then [
         B.Line (sprintf "let to_yojson = %s" (yojson_of_name ocaml_name));
         B.Line (sprintf "let of_json = %s" (of_json_name ocaml_name));
@@ -1487,6 +1687,23 @@ let gen_yojson_of_sig env ({A.name; param=params; _} : A.type_def) : B.t =
         B.Block
           (List.map (fun s -> B.Line s) param_sigs
            @ [B.Line (sprintf "%s ->" arg_type); B.Line "Yojson.Safe.t"]);
+      ]
+
+let gen_jsonlike_of_sig env ({A.name; param=params; _} : A.type_def) : B.t =
+  let name = Atd.Type_name.basename name in
+  let ocaml_name = env.tr name in
+  match params with
+  | [] ->
+      [B.Line (sprintf "val %s : %s -> Atd_jsonlike.AST.t"
+                 (jsonlike_of_name ocaml_name) ocaml_name)]
+  | _ ->
+      let param_sigs = List.map (fun v -> sprintf "('%s -> Atd_jsonlike.AST.t) ->" v) params in
+      let arg_type = full_type_name ocaml_name params in
+      [
+        B.Line (sprintf "val %s :" (jsonlike_of_name ocaml_name));
+        B.Block
+          (List.map (fun s -> B.Line s) param_sigs
+           @ [B.Line (sprintf "%s ->" arg_type); B.Line "Atd_jsonlike.AST.t"]);
       ]
 
 let gen_make_sig env ({A.name; param=params; value=e; _} : A.type_def) : B.t =
@@ -1650,6 +1867,20 @@ let gen_submodule_mli ~yojson ~jsonlike env ({A.name; param=params; annot=def_an
              @ [B.Line "Atd_jsonlike.AST.t ->"; B.Line t_type]);
         ]
   in
+  let to_jsonlike_sig =
+    match params with
+    | [] -> [B.Line (sprintf "val to_jsonlike : %s -> Atd_jsonlike.AST.t" t_type)]
+    | _ ->
+        let param_sigs =
+          List.map (fun v -> sprintf "('%s -> Atd_jsonlike.AST.t) ->" v) params
+        in
+        [
+          B.Line "val to_jsonlike :";
+          B.Block
+            (List.map (fun s -> B.Line s) param_sigs
+             @ [B.Line (sprintf "%s ->" t_type); B.Line "Atd_jsonlike.AST.t"]);
+        ]
+  in
   let to_yojson_sig =
     match params with
     | [] -> [B.Line (sprintf "val to_yojson : %s -> Yojson.Safe.t" t_type)]
@@ -1697,7 +1928,7 @@ let gen_submodule_mli ~yojson ~jsonlike env ({A.name; param=params; annot=def_an
     @ attr_lines
     @ create_sig
     @ (if yojson then of_yojson_sig else [])
-    @ (if jsonlike then of_jsonlike_sig else [])
+    @ (if jsonlike then of_jsonlike_sig @ to_jsonlike_sig else [])
     @ (if yojson then to_yojson_sig @ of_json_sig @ to_json_sig else [])
   in
   [
@@ -1789,6 +2020,7 @@ let make_ml ~yojson ~jsonlike ~imports ~env ~atd_filename ~module_doc (items : A
     let of_yojsons = if yojson then emit_fun_group ~is_recursive (gen_reader env yojson_mode) defs else [] in
     let of_jsonlikes = if jsonlike then emit_fun_group ~is_recursive (gen_reader env jsonlike_mode) defs else [] in
     let yojson_ofs = if yojson then emit_fun_group ~is_recursive (gen_yojson_of env) defs else [] in
+    let jsonlike_ofs = if jsonlike then emit_fun_group ~is_recursive (gen_jsonlike_of env) defs else [] in
     let ios =
       if yojson then concat_map (fun def -> gen_io_funs env def @ [B.Line ""]) defs
       else []
@@ -1796,7 +2028,7 @@ let make_ml ~yojson ~jsonlike ~imports ~env ~atd_filename ~module_doc (items : A
     let submods =
       concat_map (fun def -> gen_submodule_ml ~yojson ~jsonlike env def @ [B.Line ""]) defs
     in
-    types @ creates @ of_yojsons @ of_jsonlikes @ yojson_ofs @ ios @ submods
+    types @ creates @ of_yojsons @ of_jsonlikes @ yojson_ofs @ jsonlike_ofs @ ios @ submods
   in
   let aliases = module_alias_decls imports in
   header
@@ -1829,6 +2061,7 @@ let make_mli ~yojson ~jsonlike ~env ~atd_filename ~module_doc (items : A.type_de
         @ gen_alias_create_sigs env def
         @ (if yojson then gen_reader_sig env yojson_mode def else [])
         @ (if jsonlike then gen_reader_sig env jsonlike_mode def else [])
+        @ (if jsonlike then gen_jsonlike_of_sig env def else [])
         @ (if yojson then gen_yojson_of_sig env def @ gen_io_sigs env def else [])
         @ [B.Line ""]
       ) defs

--- a/atdml/src/lib/Codegen.ml
+++ b/atdml/src/lib/Codegen.ml
@@ -1635,12 +1635,10 @@ let gen_submodule_ml ~yojson ~jsonlike env ({A.name; param=params; annot=def_an;
   let bindings =
     create_binding
     @ (if yojson then [B.Line (sprintf "let of_yojson = %s" (of_yojson_name ocaml_name))] else [])
-    @ (if jsonlike then [
-        B.Line (sprintf "let of_jsonlike = %s" (of_jsonlike_name ocaml_name));
-        B.Line (sprintf "let to_jsonlike = %s" (jsonlike_of_name ocaml_name));
-      ] else [])
+    @ (if yojson then [B.Line (sprintf "let to_yojson = %s" (yojson_of_name ocaml_name))] else [])
+    @ (if jsonlike then [B.Line (sprintf "let of_jsonlike = %s" (of_jsonlike_name ocaml_name))] else [])
+    @ (if jsonlike then [B.Line (sprintf "let to_jsonlike = %s" (jsonlike_of_name ocaml_name))] else [])
     @ (if yojson then [
-        B.Line (sprintf "let to_yojson = %s" (yojson_of_name ocaml_name));
         B.Line (sprintf "let of_json = %s" (of_json_name ocaml_name));
         B.Line (sprintf "let to_json = %s" (json_of_name ocaml_name));
       ] else [])
@@ -1928,8 +1926,10 @@ let gen_submodule_mli ~yojson ~jsonlike env ({A.name; param=params; annot=def_an
     @ attr_lines
     @ create_sig
     @ (if yojson then of_yojson_sig else [])
-    @ (if jsonlike then of_jsonlike_sig @ to_jsonlike_sig else [])
-    @ (if yojson then to_yojson_sig @ of_json_sig @ to_json_sig else [])
+    @ (if yojson then to_yojson_sig else [])
+    @ (if jsonlike then of_jsonlike_sig else [])
+    @ (if jsonlike then to_jsonlike_sig else [])
+    @ (if yojson then of_json_sig @ to_json_sig else [])
   in
   [
     B.Line (sprintf "module %s : sig" (module_name ocaml_name));
@@ -2018,8 +2018,8 @@ let make_ml ~yojson ~jsonlike ~imports ~env ~atd_filename ~module_doc (items : A
       ) defs
     in
     let of_yojsons = if yojson then emit_fun_group ~is_recursive (gen_reader env yojson_mode) defs else [] in
-    let of_jsonlikes = if jsonlike then emit_fun_group ~is_recursive (gen_reader env jsonlike_mode) defs else [] in
     let yojson_ofs = if yojson then emit_fun_group ~is_recursive (gen_yojson_of env) defs else [] in
+    let of_jsonlikes = if jsonlike then emit_fun_group ~is_recursive (gen_reader env jsonlike_mode) defs else [] in
     let jsonlike_ofs = if jsonlike then emit_fun_group ~is_recursive (gen_jsonlike_of env) defs else [] in
     let ios =
       if yojson then concat_map (fun def -> gen_io_funs env def @ [B.Line ""]) defs
@@ -2028,7 +2028,7 @@ let make_ml ~yojson ~jsonlike ~imports ~env ~atd_filename ~module_doc (items : A
     let submods =
       concat_map (fun def -> gen_submodule_ml ~yojson ~jsonlike env def @ [B.Line ""]) defs
     in
-    types @ creates @ of_yojsons @ of_jsonlikes @ yojson_ofs @ jsonlike_ofs @ ios @ submods
+    types @ creates @ of_yojsons @ yojson_ofs @ of_jsonlikes @ jsonlike_ofs @ ios @ submods
   in
   let aliases = module_alias_decls imports in
   header
@@ -2060,9 +2060,10 @@ let make_mli ~yojson ~jsonlike ~env ~atd_filename ~module_doc (items : A.type_de
         gen_make_sig env def
         @ gen_alias_create_sigs env def
         @ (if yojson then gen_reader_sig env yojson_mode def else [])
+        @ (if yojson then gen_yojson_of_sig env def else [])
         @ (if jsonlike then gen_reader_sig env jsonlike_mode def else [])
         @ (if jsonlike then gen_jsonlike_of_sig env def else [])
-        @ (if yojson then gen_yojson_of_sig env def @ gen_io_sigs env def else [])
+        @ (if yojson then gen_io_sigs env def else [])
         @ [B.Line ""]
       ) defs
     in

--- a/atdml/src/lib/Codegen.mli
+++ b/atdml/src/lib/Codegen.mli
@@ -17,7 +17,7 @@ val run_file : yojson:bool -> jsonlike:bool -> string -> unit
     removing the [.atd] extension and lowercasing.
     [~yojson] controls whether [Yojson.Safe.t]-based readers/writers are
     generated (default [true]).
-    [~jsonlike] controls whether [Atd_jsonlike.AST.t]-based readers are
+    [~jsonlike] controls whether [Atd_jsonlike.AST.t]-based readers and writers are
     generated (default [true]). *)
 
 val run_stdin : yojson:bool -> jsonlike:bool -> unit -> unit

--- a/atdml/tests/named-snapshots/adapter
+++ b/atdml/tests/named-snapshots/adapter
@@ -7,9 +7,9 @@ type text = {
 
 val create_text : title:string -> body:string -> unit -> text
 val text_of_yojson : Yojson.Safe.t -> text
+val yojson_of_text : text -> Yojson.Safe.t
 val text_of_jsonlike : Atd_jsonlike.AST.t -> text
 val jsonlike_of_text : text -> Atd_jsonlike.AST.t
-val yojson_of_text : text -> Yojson.Safe.t
 val text_of_json : string -> text
 val json_of_text : text -> string
 
@@ -17,9 +17,9 @@ module Text : sig
   type nonrec t = text
   val create : title:string -> body:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -30,9 +30,9 @@ type image = {
 
 val create_image : url:string -> unit -> image
 val image_of_yojson : Yojson.Safe.t -> image
+val yojson_of_image : image -> Yojson.Safe.t
 val image_of_jsonlike : Atd_jsonlike.AST.t -> image
 val jsonlike_of_image : image -> Atd_jsonlike.AST.t
-val yojson_of_image : image -> Yojson.Safe.t
 val image_of_json : string -> image
 val json_of_image : image -> string
 
@@ -40,9 +40,9 @@ module Image : sig
   type nonrec t = image
   val create : url:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -52,18 +52,18 @@ type document =
   | Text of text
 
 val document_of_yojson : Yojson.Safe.t -> document
+val yojson_of_document : document -> Yojson.Safe.t
 val document_of_jsonlike : Atd_jsonlike.AST.t -> document
 val jsonlike_of_document : document -> Atd_jsonlike.AST.t
-val yojson_of_document : document -> Yojson.Safe.t
 val document_of_json : string -> document
 val json_of_document : document -> string
 
 module Document : sig
   type nonrec t = document
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -265,6 +265,12 @@ let text_of_yojson (x : Yojson.Safe.t) : text =
     { title; body }
   | _ -> Atdml_runtime.Yojson.bad_type "text" x
 
+let yojson_of_text (x : text) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("title", Atdml_runtime.Yojson.yojson_of_string x.title)];
+    [("body", Atdml_runtime.Yojson.yojson_of_string x.body)];
+  ])
+
 let text_of_jsonlike (x : Atd_jsonlike.AST.t) : text =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -292,12 +298,6 @@ let text_of_jsonlike (x : Atd_jsonlike.AST.t) : text =
     { title; body }
   | _ -> Atdml_runtime.Jsonlike.bad_type "text" x
 
-let yojson_of_text (x : text) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("title", Atdml_runtime.Yojson.yojson_of_string x.title)];
-    [("body", Atdml_runtime.Yojson.yojson_of_string x.body)];
-  ])
-
 let jsonlike_of_text (x : text) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "title", Atdml_runtime.Jsonlike.jsonlike_of_string x.title)];
@@ -314,9 +314,9 @@ module Text = struct
   type nonrec t = text
   let create = create_text
   let of_yojson = text_of_yojson
+  let to_yojson = yojson_of_text
   let of_jsonlike = text_of_jsonlike
   let to_jsonlike = jsonlike_of_text
-  let to_yojson = yojson_of_text
   let of_json = text_of_json
   let to_json = json_of_text
 end
@@ -349,6 +349,11 @@ let image_of_yojson (x : Yojson.Safe.t) : image =
     { url }
   | _ -> Atdml_runtime.Yojson.bad_type "image" x
 
+let yojson_of_image (x : image) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("url", Atdml_runtime.Yojson.yojson_of_string x.url)];
+  ])
+
 let image_of_jsonlike (x : Atd_jsonlike.AST.t) : image =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -371,11 +376,6 @@ let image_of_jsonlike (x : Atd_jsonlike.AST.t) : image =
     { url }
   | _ -> Atdml_runtime.Jsonlike.bad_type "image" x
 
-let yojson_of_image (x : image) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("url", Atdml_runtime.Yojson.yojson_of_string x.url)];
-  ])
-
 let jsonlike_of_image (x : image) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "url", Atdml_runtime.Jsonlike.jsonlike_of_string x.url)];
@@ -391,9 +391,9 @@ module Image = struct
   type nonrec t = image
   let create = create_image
   let of_yojson = image_of_yojson
+  let to_yojson = yojson_of_image
   let of_jsonlike = image_of_jsonlike
   let to_jsonlike = jsonlike_of_image
-  let to_yojson = yojson_of_image
   let of_json = image_of_json
   let to_json = json_of_image
 end
@@ -409,19 +409,19 @@ let document_of_yojson (x : Yojson.Safe.t) : document =
   | `List [`String "Text"; v] -> Text (text_of_yojson v)
   | _ -> Atdml_runtime.Yojson.bad_sum "document" x
 
-let document_of_jsonlike (x : Atd_jsonlike.AST.t) : document =
-  let x = My_adapter.normalize_jsonlike x in
-  match x with
-  | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Image"); v]) -> Image (image_of_jsonlike v)
-  | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Text"); v]) -> Text (text_of_jsonlike v)
-  | _ -> Atdml_runtime.Jsonlike.bad_sum "document" x
-
 let yojson_of_document (x : document) : Yojson.Safe.t =
   let atdml_result_ =
     match x with
     | Image v -> `List [`String "Image"; yojson_of_image v]
     | Text v -> `List [`String "Text"; yojson_of_text v]
   in My_adapter.restore atdml_result_
+
+let document_of_jsonlike (x : Atd_jsonlike.AST.t) : document =
+  let x = My_adapter.normalize_jsonlike x in
+  match x with
+  | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Image"); v]) -> Image (image_of_jsonlike v)
+  | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Text"); v]) -> Text (text_of_jsonlike v)
+  | _ -> Atdml_runtime.Jsonlike.bad_sum "document" x
 
 let jsonlike_of_document (x : document) : Atd_jsonlike.AST.t =
   let atdml_result_ =
@@ -439,9 +439,9 @@ let json_of_document x =
 module Document = struct
   type nonrec t = document
   let of_yojson = document_of_yojson
+  let to_yojson = yojson_of_document
   let of_jsonlike = document_of_jsonlike
   let to_jsonlike = jsonlike_of_document
-  let to_yojson = yojson_of_document
   let of_json = document_of_json
   let to_json = json_of_document
 end

--- a/atdml/tests/named-snapshots/adapter
+++ b/atdml/tests/named-snapshots/adapter
@@ -8,6 +8,7 @@ type text = {
 val create_text : title:string -> body:string -> unit -> text
 val text_of_yojson : Yojson.Safe.t -> text
 val text_of_jsonlike : Atd_jsonlike.AST.t -> text
+val jsonlike_of_text : text -> Atd_jsonlike.AST.t
 val yojson_of_text : text -> Yojson.Safe.t
 val text_of_json : string -> text
 val json_of_text : text -> string
@@ -17,6 +18,7 @@ module Text : sig
   val create : title:string -> body:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -29,6 +31,7 @@ type image = {
 val create_image : url:string -> unit -> image
 val image_of_yojson : Yojson.Safe.t -> image
 val image_of_jsonlike : Atd_jsonlike.AST.t -> image
+val jsonlike_of_image : image -> Atd_jsonlike.AST.t
 val yojson_of_image : image -> Yojson.Safe.t
 val image_of_json : string -> image
 val json_of_image : image -> string
@@ -38,6 +41,7 @@ module Image : sig
   val create : url:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -49,6 +53,7 @@ type document =
 
 val document_of_yojson : Yojson.Safe.t -> document
 val document_of_jsonlike : Atd_jsonlike.AST.t -> document
+val jsonlike_of_document : document -> Atd_jsonlike.AST.t
 val yojson_of_document : document -> Yojson.Safe.t
 val document_of_json : string -> document
 val json_of_document : document -> string
@@ -57,6 +62,7 @@ module Document : sig
   type nonrec t = document
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -205,6 +211,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -275,6 +298,12 @@ let yojson_of_text (x : text) : Yojson.Safe.t =
     [("body", Atdml_runtime.Yojson.yojson_of_string x.body)];
   ])
 
+let jsonlike_of_text (x : text) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "title", Atdml_runtime.Jsonlike.jsonlike_of_string x.title)];
+    [(Atd_jsonlike.Loc.zero, "body", Atdml_runtime.Jsonlike.jsonlike_of_string x.body)];
+  ])
+
 let text_of_json s =
   text_of_yojson (Yojson.Safe.from_string s)
 
@@ -286,6 +315,7 @@ module Text = struct
   let create = create_text
   let of_yojson = text_of_yojson
   let of_jsonlike = text_of_jsonlike
+  let to_jsonlike = jsonlike_of_text
   let to_yojson = yojson_of_text
   let of_json = text_of_json
   let to_json = json_of_text
@@ -346,6 +376,11 @@ let yojson_of_image (x : image) : Yojson.Safe.t =
     [("url", Atdml_runtime.Yojson.yojson_of_string x.url)];
   ])
 
+let jsonlike_of_image (x : image) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "url", Atdml_runtime.Jsonlike.jsonlike_of_string x.url)];
+  ])
+
 let image_of_json s =
   image_of_yojson (Yojson.Safe.from_string s)
 
@@ -357,6 +392,7 @@ module Image = struct
   let create = create_image
   let of_yojson = image_of_yojson
   let of_jsonlike = image_of_jsonlike
+  let to_jsonlike = jsonlike_of_image
   let to_yojson = yojson_of_image
   let of_json = image_of_json
   let to_json = json_of_image
@@ -387,6 +423,13 @@ let yojson_of_document (x : document) : Yojson.Safe.t =
     | Text v -> `List [`String "Text"; yojson_of_text v]
   in My_adapter.restore atdml_result_
 
+let jsonlike_of_document (x : document) : Atd_jsonlike.AST.t =
+  let atdml_result_ =
+    match x with
+    | Image v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Image"); jsonlike_of_image v])
+    | Text v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Text"); jsonlike_of_text v])
+  in My_adapter.restore_jsonlike atdml_result_
+
 let document_of_json s =
   document_of_yojson (Yojson.Safe.from_string s)
 
@@ -397,6 +440,7 @@ module Document = struct
   type nonrec t = document
   let of_yojson = document_of_yojson
   let of_jsonlike = document_of_jsonlike
+  let to_jsonlike = jsonlike_of_document
   let to_yojson = yojson_of_document
   let of_json = document_of_json
   let to_json = json_of_document

--- a/atdml/tests/named-snapshots/attr
+++ b/atdml/tests/named-snapshots/attr
@@ -8,9 +8,9 @@ type point = {
 
 val create_point : x:float -> y:float -> unit -> point
 val point_of_yojson : Yojson.Safe.t -> point
+val yojson_of_point : point -> Yojson.Safe.t
 val point_of_jsonlike : Atd_jsonlike.AST.t -> point
 val jsonlike_of_point : point -> Atd_jsonlike.AST.t
-val yojson_of_point : point -> Yojson.Safe.t
 val point_of_json : string -> point
 val json_of_point : point -> string
 
@@ -19,9 +19,9 @@ module Point : sig
   [@@deriving show]
   val create : x:float -> y:float -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -30,9 +30,9 @@ type points = point list
 [@@deriving show]
 
 val points_of_yojson : Yojson.Safe.t -> points
+val yojson_of_points : points -> Yojson.Safe.t
 val points_of_jsonlike : Atd_jsonlike.AST.t -> points
 val jsonlike_of_points : points -> Atd_jsonlike.AST.t
-val yojson_of_points : points -> Yojson.Safe.t
 val points_of_json : string -> points
 val json_of_points : points -> string
 
@@ -40,9 +40,9 @@ module Points : sig
   type nonrec t = points
   [@@deriving show]
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -245,6 +245,12 @@ let point_of_yojson (x : Yojson.Safe.t) : point =
     { x; y }
   | _ -> Atdml_runtime.Yojson.bad_type "point" x
 
+let yojson_of_point (x : point) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("x", Atdml_runtime.Yojson.yojson_of_float x.x)];
+    [("y", Atdml_runtime.Yojson.yojson_of_float x.y)];
+  ])
+
 let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -272,12 +278,6 @@ let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
     { x; y }
   | _ -> Atdml_runtime.Jsonlike.bad_type "point" x
 
-let yojson_of_point (x : point) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("x", Atdml_runtime.Yojson.yojson_of_float x.x)];
-    [("y", Atdml_runtime.Yojson.yojson_of_float x.y)];
-  ])
-
 let jsonlike_of_point (x : point) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "x", Atdml_runtime.Jsonlike.jsonlike_of_float x.x)];
@@ -295,9 +295,9 @@ module Point = struct
   [@@deriving show]
   let create = create_point
   let of_yojson = point_of_yojson
+  let to_yojson = yojson_of_point
   let of_jsonlike = point_of_jsonlike
   let to_jsonlike = jsonlike_of_point
-  let to_yojson = yojson_of_point
   let of_json = point_of_json
   let to_json = json_of_point
 end
@@ -308,11 +308,11 @@ type points = point list
 let points_of_yojson (x : Yojson.Safe.t) : points =
   (Atdml_runtime.Yojson.list_of_yojson point_of_yojson) x
 
-let points_of_jsonlike (x : Atd_jsonlike.AST.t) : points =
-  (Atdml_runtime.Jsonlike.list_of_jsonlike point_of_jsonlike) x
-
 let yojson_of_points (x : points) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_point) x
+
+let points_of_jsonlike (x : Atd_jsonlike.AST.t) : points =
+  (Atdml_runtime.Jsonlike.list_of_jsonlike point_of_jsonlike) x
 
 let jsonlike_of_points (x : points) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_point) x
@@ -327,9 +327,9 @@ module Points = struct
   type nonrec t = points
   [@@deriving show]
   let of_yojson = points_of_yojson
+  let to_yojson = yojson_of_points
   let of_jsonlike = points_of_jsonlike
   let to_jsonlike = jsonlike_of_points
-  let to_yojson = yojson_of_points
   let of_json = points_of_json
   let to_json = json_of_points
 end

--- a/atdml/tests/named-snapshots/attr
+++ b/atdml/tests/named-snapshots/attr
@@ -9,6 +9,7 @@ type point = {
 val create_point : x:float -> y:float -> unit -> point
 val point_of_yojson : Yojson.Safe.t -> point
 val point_of_jsonlike : Atd_jsonlike.AST.t -> point
+val jsonlike_of_point : point -> Atd_jsonlike.AST.t
 val yojson_of_point : point -> Yojson.Safe.t
 val point_of_json : string -> point
 val json_of_point : point -> string
@@ -19,6 +20,7 @@ module Point : sig
   val create : x:float -> y:float -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -29,6 +31,7 @@ type points = point list
 
 val points_of_yojson : Yojson.Safe.t -> points
 val points_of_jsonlike : Atd_jsonlike.AST.t -> points
+val jsonlike_of_points : points -> Atd_jsonlike.AST.t
 val yojson_of_points : points -> Yojson.Safe.t
 val points_of_json : string -> points
 val json_of_points : points -> string
@@ -38,6 +41,7 @@ module Points : sig
   [@@deriving show]
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -186,6 +190,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -257,6 +278,12 @@ let yojson_of_point (x : point) : Yojson.Safe.t =
     [("y", Atdml_runtime.Yojson.yojson_of_float x.y)];
   ])
 
+let jsonlike_of_point (x : point) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "x", Atdml_runtime.Jsonlike.jsonlike_of_float x.x)];
+    [(Atd_jsonlike.Loc.zero, "y", Atdml_runtime.Jsonlike.jsonlike_of_float x.y)];
+  ])
+
 let point_of_json s =
   point_of_yojson (Yojson.Safe.from_string s)
 
@@ -269,6 +296,7 @@ module Point = struct
   let create = create_point
   let of_yojson = point_of_yojson
   let of_jsonlike = point_of_jsonlike
+  let to_jsonlike = jsonlike_of_point
   let to_yojson = yojson_of_point
   let of_json = point_of_json
   let to_json = json_of_point
@@ -286,6 +314,9 @@ let points_of_jsonlike (x : Atd_jsonlike.AST.t) : points =
 let yojson_of_points (x : points) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_point) x
 
+let jsonlike_of_points (x : points) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_point) x
+
 let points_of_json s =
   points_of_yojson (Yojson.Safe.from_string s)
 
@@ -297,6 +328,7 @@ module Points = struct
   [@@deriving show]
   let of_yojson = points_of_yojson
   let of_jsonlike = points_of_jsonlike
+  let to_jsonlike = jsonlike_of_points
   let to_yojson = yojson_of_points
   let of_json = points_of_json
   let to_json = json_of_points

--- a/atdml/tests/named-snapshots/builtin_types
+++ b/atdml/tests/named-snapshots/builtin_types
@@ -17,6 +17,7 @@ type all_types = {
 val create_all_types : a_unit:unit -> a_bool:bool -> a_int:int -> a_float:float -> a_string:string -> a_list:int list -> a_option:string option -> a_nullable:bool option -> a_abstract:Yojson.Safe.t -> a_tuple:(int * string * bool) -> a_nested:(float list) option -> unit -> all_types
 val all_types_of_yojson : Yojson.Safe.t -> all_types
 val all_types_of_jsonlike : Atd_jsonlike.AST.t -> all_types
+val jsonlike_of_all_types : all_types -> Atd_jsonlike.AST.t
 val yojson_of_all_types : all_types -> Yojson.Safe.t
 val all_types_of_json : string -> all_types
 val json_of_all_types : all_types -> string
@@ -26,6 +27,7 @@ module All_types : sig
   val create : a_unit:unit -> a_bool:bool -> a_int:int -> a_float:float -> a_string:string -> a_list:int list -> a_option:string option -> a_nullable:bool option -> a_abstract:Yojson.Safe.t -> a_tuple:(int * string * bool) -> a_nested:(float list) option -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -174,6 +176,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -352,6 +371,21 @@ let yojson_of_all_types (x : all_types) : Yojson.Safe.t =
     [("a_nested", (Atdml_runtime.Yojson.yojson_of_option (fun (x0) -> `List [(Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_float) x0])) x.a_nested)];
   ])
 
+let jsonlike_of_all_types (x : all_types) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "a_unit", Atdml_runtime.Jsonlike.jsonlike_of_unit x.a_unit)];
+    [(Atd_jsonlike.Loc.zero, "a_bool", Atdml_runtime.Jsonlike.jsonlike_of_bool x.a_bool)];
+    [(Atd_jsonlike.Loc.zero, "a_int", Atdml_runtime.Jsonlike.jsonlike_of_int x.a_int)];
+    [(Atd_jsonlike.Loc.zero, "a_float", Atdml_runtime.Jsonlike.jsonlike_of_float x.a_float)];
+    [(Atd_jsonlike.Loc.zero, "a_string", Atdml_runtime.Jsonlike.jsonlike_of_string x.a_string)];
+    [(Atd_jsonlike.Loc.zero, "a_list", (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_int) x.a_list)];
+    [(Atd_jsonlike.Loc.zero, "a_option", (Atdml_runtime.Jsonlike.jsonlike_of_option Atdml_runtime.Jsonlike.jsonlike_of_string) x.a_option)];
+    [(Atd_jsonlike.Loc.zero, "a_nullable", (Atdml_runtime.Jsonlike.jsonlike_of_nullable Atdml_runtime.Jsonlike.jsonlike_of_bool) x.a_nullable)];
+    [(Atd_jsonlike.Loc.zero, "a_abstract", (fun _ -> failwith "abstract type is not supported in jsonlike mode") x.a_abstract)];
+    [(Atd_jsonlike.Loc.zero, "a_tuple", (fun (x0, x1, x2) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atdml_runtime.Jsonlike.jsonlike_of_int x0; Atdml_runtime.Jsonlike.jsonlike_of_string x1; Atdml_runtime.Jsonlike.jsonlike_of_bool x2])) x.a_tuple)];
+    [(Atd_jsonlike.Loc.zero, "a_nested", (Atdml_runtime.Jsonlike.jsonlike_of_option (fun (x0) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [(Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_float) x0]))) x.a_nested)];
+  ])
+
 let all_types_of_json s =
   all_types_of_yojson (Yojson.Safe.from_string s)
 
@@ -363,6 +397,7 @@ module All_types = struct
   let create = create_all_types
   let of_yojson = all_types_of_yojson
   let of_jsonlike = all_types_of_jsonlike
+  let to_jsonlike = jsonlike_of_all_types
   let to_yojson = yojson_of_all_types
   let of_json = all_types_of_json
   let to_json = json_of_all_types

--- a/atdml/tests/named-snapshots/builtin_types
+++ b/atdml/tests/named-snapshots/builtin_types
@@ -16,9 +16,9 @@ type all_types = {
 
 val create_all_types : a_unit:unit -> a_bool:bool -> a_int:int -> a_float:float -> a_string:string -> a_list:int list -> a_option:string option -> a_nullable:bool option -> a_abstract:Yojson.Safe.t -> a_tuple:(int * string * bool) -> a_nested:(float list) option -> unit -> all_types
 val all_types_of_yojson : Yojson.Safe.t -> all_types
+val yojson_of_all_types : all_types -> Yojson.Safe.t
 val all_types_of_jsonlike : Atd_jsonlike.AST.t -> all_types
 val jsonlike_of_all_types : all_types -> Atd_jsonlike.AST.t
-val yojson_of_all_types : all_types -> Yojson.Safe.t
 val all_types_of_json : string -> all_types
 val json_of_all_types : all_types -> string
 
@@ -26,9 +26,9 @@ module All_types : sig
   type nonrec t = all_types
   val create : a_unit:unit -> a_bool:bool -> a_int:int -> a_float:float -> a_string:string -> a_list:int list -> a_option:string option -> a_nullable:bool option -> a_abstract:Yojson.Safe.t -> a_tuple:(int * string * bool) -> a_nested:(float list) option -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -284,6 +284,21 @@ let all_types_of_yojson (x : Yojson.Safe.t) : all_types =
     { a_unit; a_bool; a_int; a_float; a_string; a_list; a_option; a_nullable; a_abstract; a_tuple; a_nested }
   | _ -> Atdml_runtime.Yojson.bad_type "all_types" x
 
+let yojson_of_all_types (x : all_types) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("a_unit", Atdml_runtime.Yojson.yojson_of_unit x.a_unit)];
+    [("a_bool", Atdml_runtime.Yojson.yojson_of_bool x.a_bool)];
+    [("a_int", Atdml_runtime.Yojson.yojson_of_int x.a_int)];
+    [("a_float", Atdml_runtime.Yojson.yojson_of_float x.a_float)];
+    [("a_string", Atdml_runtime.Yojson.yojson_of_string x.a_string)];
+    [("a_list", (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_int) x.a_list)];
+    [("a_option", (Atdml_runtime.Yojson.yojson_of_option Atdml_runtime.Yojson.yojson_of_string) x.a_option)];
+    [("a_nullable", (Atdml_runtime.Yojson.yojson_of_nullable Atdml_runtime.Yojson.yojson_of_bool) x.a_nullable)];
+    [("a_abstract", (fun x -> x) x.a_abstract)];
+    [("a_tuple", (fun (x0, x1, x2) -> `List [Atdml_runtime.Yojson.yojson_of_int x0; Atdml_runtime.Yojson.yojson_of_string x1; Atdml_runtime.Yojson.yojson_of_bool x2]) x.a_tuple)];
+    [("a_nested", (Atdml_runtime.Yojson.yojson_of_option (fun (x0) -> `List [(Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_float) x0])) x.a_nested)];
+  ])
+
 let all_types_of_jsonlike (x : Atd_jsonlike.AST.t) : all_types =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -356,21 +371,6 @@ let all_types_of_jsonlike (x : Atd_jsonlike.AST.t) : all_types =
     { a_unit; a_bool; a_int; a_float; a_string; a_list; a_option; a_nullable; a_abstract; a_tuple; a_nested }
   | _ -> Atdml_runtime.Jsonlike.bad_type "all_types" x
 
-let yojson_of_all_types (x : all_types) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("a_unit", Atdml_runtime.Yojson.yojson_of_unit x.a_unit)];
-    [("a_bool", Atdml_runtime.Yojson.yojson_of_bool x.a_bool)];
-    [("a_int", Atdml_runtime.Yojson.yojson_of_int x.a_int)];
-    [("a_float", Atdml_runtime.Yojson.yojson_of_float x.a_float)];
-    [("a_string", Atdml_runtime.Yojson.yojson_of_string x.a_string)];
-    [("a_list", (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_int) x.a_list)];
-    [("a_option", (Atdml_runtime.Yojson.yojson_of_option Atdml_runtime.Yojson.yojson_of_string) x.a_option)];
-    [("a_nullable", (Atdml_runtime.Yojson.yojson_of_nullable Atdml_runtime.Yojson.yojson_of_bool) x.a_nullable)];
-    [("a_abstract", (fun x -> x) x.a_abstract)];
-    [("a_tuple", (fun (x0, x1, x2) -> `List [Atdml_runtime.Yojson.yojson_of_int x0; Atdml_runtime.Yojson.yojson_of_string x1; Atdml_runtime.Yojson.yojson_of_bool x2]) x.a_tuple)];
-    [("a_nested", (Atdml_runtime.Yojson.yojson_of_option (fun (x0) -> `List [(Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_float) x0])) x.a_nested)];
-  ])
-
 let jsonlike_of_all_types (x : all_types) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "a_unit", Atdml_runtime.Jsonlike.jsonlike_of_unit x.a_unit)];
@@ -396,9 +396,9 @@ module All_types = struct
   type nonrec t = all_types
   let create = create_all_types
   let of_yojson = all_types_of_yojson
+  let to_yojson = yojson_of_all_types
   let of_jsonlike = all_types_of_jsonlike
   let to_jsonlike = jsonlike_of_all_types
-  let to_yojson = yojson_of_all_types
   let of_json = all_types_of_json
   let to_json = json_of_all_types
 end

--- a/atdml/tests/named-snapshots/classic_sum_types
+++ b/atdml/tests/named-snapshots/classic_sum_types
@@ -8,6 +8,7 @@ type shape =
 
 val shape_of_yojson : Yojson.Safe.t -> shape
 val shape_of_jsonlike : Atd_jsonlike.AST.t -> shape
+val jsonlike_of_shape : shape -> Atd_jsonlike.AST.t
 val yojson_of_shape : shape -> Yojson.Safe.t
 val shape_of_json : string -> shape
 val json_of_shape : shape -> string
@@ -16,6 +17,7 @@ module Shape : sig
   type nonrec t = shape
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -25,6 +27,7 @@ type shapes = shape list
 
 val shapes_of_yojson : Yojson.Safe.t -> shapes
 val shapes_of_jsonlike : Atd_jsonlike.AST.t -> shapes
+val jsonlike_of_shapes : shapes -> Atd_jsonlike.AST.t
 val yojson_of_shapes : shapes -> Yojson.Safe.t
 val shapes_of_json : string -> shapes
 val json_of_shapes : shapes -> string
@@ -33,6 +36,7 @@ module Shapes : sig
   type nonrec t = shapes
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -181,6 +185,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -213,6 +234,13 @@ let yojson_of_shape (x : shape) : Yojson.Safe.t =
   | Point -> `String "Dot"
   | ArcShape v -> `List [`String "arc"; Atdml_runtime.Yojson.yojson_of_float v]
 
+let jsonlike_of_shape (x : shape) : Atd_jsonlike.AST.t =
+  match x with
+  | Circle v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Circle"); Atdml_runtime.Jsonlike.jsonlike_of_float v])
+  | Rect v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "rectangle"); (fun (x0, x1) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atdml_runtime.Jsonlike.jsonlike_of_float x0; Atdml_runtime.Jsonlike.jsonlike_of_float x1])) v])
+  | Point -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Dot")
+  | ArcShape v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "arc"); Atdml_runtime.Jsonlike.jsonlike_of_float v])
+
 let shape_of_json s =
   shape_of_yojson (Yojson.Safe.from_string s)
 
@@ -223,6 +251,7 @@ module Shape = struct
   type nonrec t = shape
   let of_yojson = shape_of_yojson
   let of_jsonlike = shape_of_jsonlike
+  let to_jsonlike = jsonlike_of_shape
   let to_yojson = yojson_of_shape
   let of_json = shape_of_json
   let to_json = json_of_shape
@@ -239,6 +268,9 @@ let shapes_of_jsonlike (x : Atd_jsonlike.AST.t) : shapes =
 let yojson_of_shapes (x : shapes) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_shape) x
 
+let jsonlike_of_shapes (x : shapes) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_shape) x
+
 let shapes_of_json s =
   shapes_of_yojson (Yojson.Safe.from_string s)
 
@@ -249,6 +281,7 @@ module Shapes = struct
   type nonrec t = shapes
   let of_yojson = shapes_of_yojson
   let of_jsonlike = shapes_of_jsonlike
+  let to_jsonlike = jsonlike_of_shapes
   let to_yojson = yojson_of_shapes
   let of_json = shapes_of_json
   let to_json = json_of_shapes

--- a/atdml/tests/named-snapshots/classic_sum_types
+++ b/atdml/tests/named-snapshots/classic_sum_types
@@ -7,18 +7,18 @@ type shape =
   | ArcShape of float
 
 val shape_of_yojson : Yojson.Safe.t -> shape
+val yojson_of_shape : shape -> Yojson.Safe.t
 val shape_of_jsonlike : Atd_jsonlike.AST.t -> shape
 val jsonlike_of_shape : shape -> Atd_jsonlike.AST.t
-val yojson_of_shape : shape -> Yojson.Safe.t
 val shape_of_json : string -> shape
 val json_of_shape : shape -> string
 
 module Shape : sig
   type nonrec t = shape
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -26,18 +26,18 @@ end
 type shapes = shape list
 
 val shapes_of_yojson : Yojson.Safe.t -> shapes
+val yojson_of_shapes : shapes -> Yojson.Safe.t
 val shapes_of_jsonlike : Atd_jsonlike.AST.t -> shapes
 val jsonlike_of_shapes : shapes -> Atd_jsonlike.AST.t
-val yojson_of_shapes : shapes -> Yojson.Safe.t
 val shapes_of_json : string -> shapes
 val json_of_shapes : shapes -> string
 
 module Shapes : sig
   type nonrec t = shapes
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -219,6 +219,13 @@ let shape_of_yojson (x : Yojson.Safe.t) : shape =
   | `List [`String "arc"; v] -> ArcShape (Atdml_runtime.Yojson.float_of_yojson v)
   | _ -> Atdml_runtime.Yojson.bad_sum "shape" x
 
+let yojson_of_shape (x : shape) : Yojson.Safe.t =
+  match x with
+  | Circle v -> `List [`String "Circle"; Atdml_runtime.Yojson.yojson_of_float v]
+  | Rect v -> `List [`String "rectangle"; (fun (x0, x1) -> `List [Atdml_runtime.Yojson.yojson_of_float x0; Atdml_runtime.Yojson.yojson_of_float x1]) v]
+  | Point -> `String "Dot"
+  | ArcShape v -> `List [`String "arc"; Atdml_runtime.Yojson.yojson_of_float v]
+
 let shape_of_jsonlike (x : Atd_jsonlike.AST.t) : shape =
   match x with
   | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Circle"); v]) -> Circle (Atdml_runtime.Jsonlike.float_of_jsonlike v)
@@ -226,13 +233,6 @@ let shape_of_jsonlike (x : Atd_jsonlike.AST.t) : shape =
   | Atd_jsonlike.AST.String (_, "Dot") -> Point
   | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "arc"); v]) -> ArcShape (Atdml_runtime.Jsonlike.float_of_jsonlike v)
   | _ -> Atdml_runtime.Jsonlike.bad_sum "shape" x
-
-let yojson_of_shape (x : shape) : Yojson.Safe.t =
-  match x with
-  | Circle v -> `List [`String "Circle"; Atdml_runtime.Yojson.yojson_of_float v]
-  | Rect v -> `List [`String "rectangle"; (fun (x0, x1) -> `List [Atdml_runtime.Yojson.yojson_of_float x0; Atdml_runtime.Yojson.yojson_of_float x1]) v]
-  | Point -> `String "Dot"
-  | ArcShape v -> `List [`String "arc"; Atdml_runtime.Yojson.yojson_of_float v]
 
 let jsonlike_of_shape (x : shape) : Atd_jsonlike.AST.t =
   match x with
@@ -250,9 +250,9 @@ let json_of_shape x =
 module Shape = struct
   type nonrec t = shape
   let of_yojson = shape_of_yojson
+  let to_yojson = yojson_of_shape
   let of_jsonlike = shape_of_jsonlike
   let to_jsonlike = jsonlike_of_shape
-  let to_yojson = yojson_of_shape
   let of_json = shape_of_json
   let to_json = json_of_shape
 end
@@ -262,11 +262,11 @@ type shapes = shape list
 let shapes_of_yojson (x : Yojson.Safe.t) : shapes =
   (Atdml_runtime.Yojson.list_of_yojson shape_of_yojson) x
 
-let shapes_of_jsonlike (x : Atd_jsonlike.AST.t) : shapes =
-  (Atdml_runtime.Jsonlike.list_of_jsonlike shape_of_jsonlike) x
-
 let yojson_of_shapes (x : shapes) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_shape) x
+
+let shapes_of_jsonlike (x : Atd_jsonlike.AST.t) : shapes =
+  (Atdml_runtime.Jsonlike.list_of_jsonlike shape_of_jsonlike) x
 
 let jsonlike_of_shapes (x : shapes) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_shape) x
@@ -280,9 +280,9 @@ let json_of_shapes x =
 module Shapes = struct
   type nonrec t = shapes
   let of_yojson = shapes_of_yojson
+  let to_yojson = yojson_of_shapes
   let of_jsonlike = shapes_of_jsonlike
   let to_jsonlike = jsonlike_of_shapes
-  let to_yojson = yojson_of_shapes
   let of_json = shapes_of_json
   let to_json = json_of_shapes
 end

--- a/atdml/tests/named-snapshots/color_enum
+++ b/atdml/tests/named-snapshots/color_enum
@@ -7,6 +7,7 @@ type color =
 
 val color_of_yojson : Yojson.Safe.t -> color
 val color_of_jsonlike : Atd_jsonlike.AST.t -> color
+val jsonlike_of_color : color -> Atd_jsonlike.AST.t
 val yojson_of_color : color -> Yojson.Safe.t
 val color_of_json : string -> color
 val json_of_color : color -> string
@@ -15,6 +16,7 @@ module Color : sig
   type nonrec t = color
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -24,6 +26,7 @@ type colors = (color * color * color)
 
 val colors_of_yojson : Yojson.Safe.t -> colors
 val colors_of_jsonlike : Atd_jsonlike.AST.t -> colors
+val jsonlike_of_colors : colors -> Atd_jsonlike.AST.t
 val yojson_of_colors : colors -> Yojson.Safe.t
 val colors_of_json : string -> colors
 val json_of_colors : colors -> string
@@ -32,6 +35,7 @@ module Colors : sig
   type nonrec t = colors
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -180,6 +184,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -208,6 +229,12 @@ let yojson_of_color (x : color) : Yojson.Safe.t =
   | Green -> `String "green"
   | Blue -> `String "Blue"
 
+let jsonlike_of_color (x : color) : Atd_jsonlike.AST.t =
+  match x with
+  | Red -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Red")
+  | Green -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "green")
+  | Blue -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Blue")
+
 let color_of_json s =
   color_of_yojson (Yojson.Safe.from_string s)
 
@@ -218,6 +245,7 @@ module Color = struct
   type nonrec t = color
   let of_yojson = color_of_yojson
   let of_jsonlike = color_of_jsonlike
+  let to_jsonlike = jsonlike_of_color
   let to_yojson = yojson_of_color
   let of_json = color_of_json
   let to_json = json_of_color
@@ -234,6 +262,9 @@ let colors_of_jsonlike (x : Atd_jsonlike.AST.t) : colors =
 let yojson_of_colors (x : colors) : Yojson.Safe.t =
   (fun (x0, x1, x2) -> `List [yojson_of_color x0; yojson_of_color x1; yojson_of_color x2]) x
 
+let jsonlike_of_colors (x : colors) : Atd_jsonlike.AST.t =
+  (fun (x0, x1, x2) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [jsonlike_of_color x0; jsonlike_of_color x1; jsonlike_of_color x2])) x
+
 let colors_of_json s =
   colors_of_yojson (Yojson.Safe.from_string s)
 
@@ -244,6 +275,7 @@ module Colors = struct
   type nonrec t = colors
   let of_yojson = colors_of_yojson
   let of_jsonlike = colors_of_jsonlike
+  let to_jsonlike = jsonlike_of_colors
   let to_yojson = yojson_of_colors
   let of_json = colors_of_json
   let to_json = json_of_colors

--- a/atdml/tests/named-snapshots/color_enum
+++ b/atdml/tests/named-snapshots/color_enum
@@ -6,18 +6,18 @@ type color =
   | Blue
 
 val color_of_yojson : Yojson.Safe.t -> color
+val yojson_of_color : color -> Yojson.Safe.t
 val color_of_jsonlike : Atd_jsonlike.AST.t -> color
 val jsonlike_of_color : color -> Atd_jsonlike.AST.t
-val yojson_of_color : color -> Yojson.Safe.t
 val color_of_json : string -> color
 val json_of_color : color -> string
 
 module Color : sig
   type nonrec t = color
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -25,18 +25,18 @@ end
 type colors = (color * color * color)
 
 val colors_of_yojson : Yojson.Safe.t -> colors
+val yojson_of_colors : colors -> Yojson.Safe.t
 val colors_of_jsonlike : Atd_jsonlike.AST.t -> colors
 val jsonlike_of_colors : colors -> Atd_jsonlike.AST.t
-val yojson_of_colors : colors -> Yojson.Safe.t
 val colors_of_json : string -> colors
 val json_of_colors : colors -> string
 
 module Colors : sig
   type nonrec t = colors
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -216,18 +216,18 @@ let color_of_yojson (x : Yojson.Safe.t) : color =
   | `String "Blue" -> Blue
   | _ -> Atdml_runtime.Yojson.bad_sum "color" x
 
+let yojson_of_color (x : color) : Yojson.Safe.t =
+  match x with
+  | Red -> `String "Red"
+  | Green -> `String "green"
+  | Blue -> `String "Blue"
+
 let color_of_jsonlike (x : Atd_jsonlike.AST.t) : color =
   match x with
   | Atd_jsonlike.AST.String (_, "Red") -> Red
   | Atd_jsonlike.AST.String (_, "green") -> Green
   | Atd_jsonlike.AST.String (_, "Blue") -> Blue
   | _ -> Atdml_runtime.Jsonlike.bad_sum "color" x
-
-let yojson_of_color (x : color) : Yojson.Safe.t =
-  match x with
-  | Red -> `String "Red"
-  | Green -> `String "green"
-  | Blue -> `String "Blue"
 
 let jsonlike_of_color (x : color) : Atd_jsonlike.AST.t =
   match x with
@@ -244,9 +244,9 @@ let json_of_color x =
 module Color = struct
   type nonrec t = color
   let of_yojson = color_of_yojson
+  let to_yojson = yojson_of_color
   let of_jsonlike = color_of_jsonlike
   let to_jsonlike = jsonlike_of_color
-  let to_yojson = yojson_of_color
   let of_json = color_of_json
   let to_json = json_of_color
 end
@@ -256,11 +256,11 @@ type colors = (color * color * color)
 let colors_of_yojson (x : Yojson.Safe.t) : colors =
   (fun x -> match x with | `List lst when List.length lst = 3 -> (color_of_yojson (List.nth lst 0), color_of_yojson (List.nth lst 1), color_of_yojson (List.nth lst 2)) | _ -> Atdml_runtime.Yojson.bad_type "tuple" x) x
 
-let colors_of_jsonlike (x : Atd_jsonlike.AST.t) : colors =
-  (fun x -> match x with | Atd_jsonlike.AST.Array (_, lst) when List.length lst = 3 -> (color_of_jsonlike (List.nth lst 0), color_of_jsonlike (List.nth lst 1), color_of_jsonlike (List.nth lst 2)) | _ -> Atdml_runtime.Jsonlike.bad_type "tuple" x) x
-
 let yojson_of_colors (x : colors) : Yojson.Safe.t =
   (fun (x0, x1, x2) -> `List [yojson_of_color x0; yojson_of_color x1; yojson_of_color x2]) x
+
+let colors_of_jsonlike (x : Atd_jsonlike.AST.t) : colors =
+  (fun x -> match x with | Atd_jsonlike.AST.Array (_, lst) when List.length lst = 3 -> (color_of_jsonlike (List.nth lst 0), color_of_jsonlike (List.nth lst 1), color_of_jsonlike (List.nth lst 2)) | _ -> Atdml_runtime.Jsonlike.bad_type "tuple" x) x
 
 let jsonlike_of_colors (x : colors) : Atd_jsonlike.AST.t =
   (fun (x0, x1, x2) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [jsonlike_of_color x0; jsonlike_of_color x1; jsonlike_of_color x2])) x
@@ -274,9 +274,9 @@ let json_of_colors x =
 module Colors = struct
   type nonrec t = colors
   let of_yojson = colors_of_yojson
+  let to_yojson = yojson_of_colors
   let of_jsonlike = colors_of_jsonlike
   let to_jsonlike = jsonlike_of_colors
-  let to_yojson = yojson_of_colors
   let of_json = colors_of_json
   let to_json = json_of_colors
 end

--- a/atdml/tests/named-snapshots/doc
+++ b/atdml/tests/named-snapshots/doc
@@ -17,12 +17,14 @@ and tree =
 val create_node : value:int -> left:tree -> right:tree -> unit -> node
 val node_of_yojson : Yojson.Safe.t -> node
 val node_of_jsonlike : Atd_jsonlike.AST.t -> node
+val jsonlike_of_node : node -> Atd_jsonlike.AST.t
 val yojson_of_node : node -> Yojson.Safe.t
 val node_of_json : string -> node
 val json_of_node : node -> string
 
 val tree_of_yojson : Yojson.Safe.t -> tree
 val tree_of_jsonlike : Atd_jsonlike.AST.t -> tree
+val jsonlike_of_tree : tree -> Atd_jsonlike.AST.t
 val yojson_of_tree : tree -> Yojson.Safe.t
 val tree_of_json : string -> tree
 val json_of_tree : tree -> string
@@ -32,6 +34,7 @@ module Node : sig
   val create : value:int -> left:tree -> right:tree -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -41,6 +44,7 @@ module Tree : sig
   type nonrec t = tree
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -60,6 +64,7 @@ type person = {
 val create_person : name:string -> age:int -> ?email:string -> unit -> person
 val person_of_yojson : Yojson.Safe.t -> person
 val person_of_jsonlike : Atd_jsonlike.AST.t -> person
+val jsonlike_of_person : person -> Atd_jsonlike.AST.t
 val yojson_of_person : person -> Yojson.Safe.t
 val person_of_json : string -> person
 val json_of_person : person -> string
@@ -69,6 +74,7 @@ module Person : sig
   val create : name:string -> age:int -> ?email:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -82,6 +88,7 @@ type color =
 
 val color_of_yojson : Yojson.Safe.t -> color
 val color_of_jsonlike : Atd_jsonlike.AST.t -> color
+val jsonlike_of_color : color -> Atd_jsonlike.AST.t
 val yojson_of_color : color -> Yojson.Safe.t
 val color_of_json : string -> color
 val json_of_color : color -> string
@@ -90,6 +97,7 @@ module Color : sig
   type nonrec t = color
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -101,6 +109,7 @@ type alias = private string
 val create_alias : string -> alias
 val alias_of_yojson : Yojson.Safe.t -> alias
 val alias_of_jsonlike : Atd_jsonlike.AST.t -> alias
+val jsonlike_of_alias : alias -> Atd_jsonlike.AST.t
 val yojson_of_alias : alias -> Yojson.Safe.t
 val alias_of_json : string -> alias
 val json_of_alias : alias -> string
@@ -110,6 +119,7 @@ module Alias : sig
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -260,6 +270,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -365,6 +392,18 @@ and yojson_of_tree (x : tree) : Yojson.Safe.t =
   | Leaf -> `String "Leaf"
   | Node v -> `List [`String "Node"; yojson_of_node v]
 
+let rec jsonlike_of_node (x : node) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "value", Atdml_runtime.Jsonlike.jsonlike_of_int x.value)];
+    [(Atd_jsonlike.Loc.zero, "left", jsonlike_of_tree x.left)];
+    [(Atd_jsonlike.Loc.zero, "right", jsonlike_of_tree x.right)];
+  ])
+
+and jsonlike_of_tree (x : tree) : Atd_jsonlike.AST.t =
+  match x with
+  | Leaf -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Leaf")
+  | Node v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Node"); jsonlike_of_node v])
+
 let node_of_json s =
   node_of_yojson (Yojson.Safe.from_string s)
 
@@ -382,6 +421,7 @@ module Node = struct
   let create = create_node
   let of_yojson = node_of_yojson
   let of_jsonlike = node_of_jsonlike
+  let to_jsonlike = jsonlike_of_node
   let to_yojson = yojson_of_node
   let of_json = node_of_json
   let to_json = json_of_node
@@ -391,6 +431,7 @@ module Tree = struct
   type nonrec t = tree
   let of_yojson = tree_of_yojson
   let of_jsonlike = tree_of_jsonlike
+  let to_jsonlike = jsonlike_of_tree
   let to_yojson = yojson_of_tree
   let of_json = tree_of_json
   let to_json = json_of_tree
@@ -480,6 +521,13 @@ let yojson_of_person (x : person) : Yojson.Safe.t =
     (match x.email with None -> [] | Some v -> [("email", Atdml_runtime.Yojson.yojson_of_string v)]);
   ])
 
+let jsonlike_of_person (x : person) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "name", Atdml_runtime.Jsonlike.jsonlike_of_string x.name)];
+    [(Atd_jsonlike.Loc.zero, "age", Atdml_runtime.Jsonlike.jsonlike_of_int x.age)];
+    (match x.email with None -> [] | Some v -> [(Atd_jsonlike.Loc.zero, "email", Atdml_runtime.Jsonlike.jsonlike_of_string v)]);
+  ])
+
 let person_of_json s =
   person_of_yojson (Yojson.Safe.from_string s)
 
@@ -491,6 +539,7 @@ module Person = struct
   let create = create_person
   let of_yojson = person_of_yojson
   let of_jsonlike = person_of_jsonlike
+  let to_jsonlike = jsonlike_of_person
   let to_yojson = yojson_of_person
   let of_json = person_of_json
   let to_json = json_of_person
@@ -522,6 +571,12 @@ let yojson_of_color (x : color) : Yojson.Safe.t =
   | Green -> `String "Green"
   | Blue -> `String "Blue"
 
+let jsonlike_of_color (x : color) : Atd_jsonlike.AST.t =
+  match x with
+  | Red -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Red")
+  | Green -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Green")
+  | Blue -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Blue")
+
 let color_of_json s =
   color_of_yojson (Yojson.Safe.from_string s)
 
@@ -532,6 +587,7 @@ module Color = struct
   type nonrec t = color
   let of_yojson = color_of_yojson
   let of_jsonlike = color_of_jsonlike
+  let to_jsonlike = jsonlike_of_color
   let to_yojson = yojson_of_color
   let of_json = color_of_json
   let to_json = json_of_color
@@ -552,6 +608,9 @@ let alias_of_jsonlike (x : Atd_jsonlike.AST.t) : alias =
 let yojson_of_alias (x : alias) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
 
+let jsonlike_of_alias (x : alias) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_string x
+
 let alias_of_json s =
   alias_of_yojson (Yojson.Safe.from_string s)
 
@@ -563,6 +622,7 @@ module Alias = struct
   let create = create_alias
   let of_yojson = alias_of_yojson
   let of_jsonlike = alias_of_jsonlike
+  let to_jsonlike = jsonlike_of_alias
   let to_yojson = yojson_of_alias
   let of_json = alias_of_json
   let to_json = json_of_alias

--- a/atdml/tests/named-snapshots/doc
+++ b/atdml/tests/named-snapshots/doc
@@ -16,16 +16,16 @@ and tree =
 
 val create_node : value:int -> left:tree -> right:tree -> unit -> node
 val node_of_yojson : Yojson.Safe.t -> node
+val yojson_of_node : node -> Yojson.Safe.t
 val node_of_jsonlike : Atd_jsonlike.AST.t -> node
 val jsonlike_of_node : node -> Atd_jsonlike.AST.t
-val yojson_of_node : node -> Yojson.Safe.t
 val node_of_json : string -> node
 val json_of_node : node -> string
 
 val tree_of_yojson : Yojson.Safe.t -> tree
+val yojson_of_tree : tree -> Yojson.Safe.t
 val tree_of_jsonlike : Atd_jsonlike.AST.t -> tree
 val jsonlike_of_tree : tree -> Atd_jsonlike.AST.t
-val yojson_of_tree : tree -> Yojson.Safe.t
 val tree_of_json : string -> tree
 val json_of_tree : tree -> string
 
@@ -33,9 +33,9 @@ module Node : sig
   type nonrec t = node
   val create : value:int -> left:tree -> right:tree -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -43,9 +43,9 @@ end
 module Tree : sig
   type nonrec t = tree
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -63,9 +63,9 @@ type person = {
 
 val create_person : name:string -> age:int -> ?email:string -> unit -> person
 val person_of_yojson : Yojson.Safe.t -> person
+val yojson_of_person : person -> Yojson.Safe.t
 val person_of_jsonlike : Atd_jsonlike.AST.t -> person
 val jsonlike_of_person : person -> Atd_jsonlike.AST.t
-val yojson_of_person : person -> Yojson.Safe.t
 val person_of_json : string -> person
 val json_of_person : person -> string
 
@@ -73,9 +73,9 @@ module Person : sig
   type nonrec t = person
   val create : name:string -> age:int -> ?email:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -87,18 +87,18 @@ type color =
   | Blue
 
 val color_of_yojson : Yojson.Safe.t -> color
+val yojson_of_color : color -> Yojson.Safe.t
 val color_of_jsonlike : Atd_jsonlike.AST.t -> color
 val jsonlike_of_color : color -> Atd_jsonlike.AST.t
-val yojson_of_color : color -> Yojson.Safe.t
 val color_of_json : string -> color
 val json_of_color : color -> string
 
 module Color : sig
   type nonrec t = color
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -108,9 +108,9 @@ type alias = private string
 
 val create_alias : string -> alias
 val alias_of_yojson : Yojson.Safe.t -> alias
+val yojson_of_alias : alias -> Yojson.Safe.t
 val alias_of_jsonlike : Atd_jsonlike.AST.t -> alias
 val jsonlike_of_alias : alias -> Atd_jsonlike.AST.t
-val yojson_of_alias : alias -> Yojson.Safe.t
 val alias_of_json : string -> alias
 val json_of_alias : alias -> string
 
@@ -118,9 +118,9 @@ module Alias : sig
   type nonrec t = alias
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -342,6 +342,18 @@ and tree_of_yojson (x : Yojson.Safe.t) : tree =
   | `List [`String "Node"; v] -> Node (node_of_yojson v)
   | _ -> Atdml_runtime.Yojson.bad_sum "tree" x
 
+let rec yojson_of_node (x : node) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("value", Atdml_runtime.Yojson.yojson_of_int x.value)];
+    [("left", yojson_of_tree x.left)];
+    [("right", yojson_of_tree x.right)];
+  ])
+
+and yojson_of_tree (x : tree) : Yojson.Safe.t =
+  match x with
+  | Leaf -> `String "Leaf"
+  | Node v -> `List [`String "Node"; yojson_of_node v]
+
 let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -380,18 +392,6 @@ and tree_of_jsonlike (x : Atd_jsonlike.AST.t) : tree =
   | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Node"); v]) -> Node (node_of_jsonlike v)
   | _ -> Atdml_runtime.Jsonlike.bad_sum "tree" x
 
-let rec yojson_of_node (x : node) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("value", Atdml_runtime.Yojson.yojson_of_int x.value)];
-    [("left", yojson_of_tree x.left)];
-    [("right", yojson_of_tree x.right)];
-  ])
-
-and yojson_of_tree (x : tree) : Yojson.Safe.t =
-  match x with
-  | Leaf -> `String "Leaf"
-  | Node v -> `List [`String "Node"; yojson_of_node v]
-
 let rec jsonlike_of_node (x : node) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "value", Atdml_runtime.Jsonlike.jsonlike_of_int x.value)];
@@ -420,9 +420,9 @@ module Node = struct
   type nonrec t = node
   let create = create_node
   let of_yojson = node_of_yojson
+  let to_yojson = yojson_of_node
   let of_jsonlike = node_of_jsonlike
   let to_jsonlike = jsonlike_of_node
-  let to_yojson = yojson_of_node
   let of_json = node_of_json
   let to_json = json_of_node
 end
@@ -430,9 +430,9 @@ end
 module Tree = struct
   type nonrec t = tree
   let of_yojson = tree_of_yojson
+  let to_yojson = yojson_of_tree
   let of_jsonlike = tree_of_jsonlike
   let to_jsonlike = jsonlike_of_tree
-  let to_yojson = yojson_of_tree
   let of_json = tree_of_json
   let to_json = json_of_tree
 end
@@ -482,6 +482,13 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
     { name; age; email }
   | _ -> Atdml_runtime.Yojson.bad_type "person" x
 
+let yojson_of_person (x : person) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("name", Atdml_runtime.Yojson.yojson_of_string x.name)];
+    [("age", Atdml_runtime.Yojson.yojson_of_int x.age)];
+    (match x.email with None -> [] | Some v -> [("email", Atdml_runtime.Yojson.yojson_of_string v)]);
+  ])
+
 let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -514,13 +521,6 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
     { name; age; email }
   | _ -> Atdml_runtime.Jsonlike.bad_type "person" x
 
-let yojson_of_person (x : person) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("name", Atdml_runtime.Yojson.yojson_of_string x.name)];
-    [("age", Atdml_runtime.Yojson.yojson_of_int x.age)];
-    (match x.email with None -> [] | Some v -> [("email", Atdml_runtime.Yojson.yojson_of_string v)]);
-  ])
-
 let jsonlike_of_person (x : person) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "name", Atdml_runtime.Jsonlike.jsonlike_of_string x.name)];
@@ -538,9 +538,9 @@ module Person = struct
   type nonrec t = person
   let create = create_person
   let of_yojson = person_of_yojson
+  let to_yojson = yojson_of_person
   let of_jsonlike = person_of_jsonlike
   let to_jsonlike = jsonlike_of_person
-  let to_yojson = yojson_of_person
   let of_json = person_of_json
   let to_json = json_of_person
 end
@@ -558,18 +558,18 @@ let color_of_yojson (x : Yojson.Safe.t) : color =
   | `String "Blue" -> Blue
   | _ -> Atdml_runtime.Yojson.bad_sum "color" x
 
+let yojson_of_color (x : color) : Yojson.Safe.t =
+  match x with
+  | Red -> `String "Red"
+  | Green -> `String "Green"
+  | Blue -> `String "Blue"
+
 let color_of_jsonlike (x : Atd_jsonlike.AST.t) : color =
   match x with
   | Atd_jsonlike.AST.String (_, "Red") -> Red
   | Atd_jsonlike.AST.String (_, "Green") -> Green
   | Atd_jsonlike.AST.String (_, "Blue") -> Blue
   | _ -> Atdml_runtime.Jsonlike.bad_sum "color" x
-
-let yojson_of_color (x : color) : Yojson.Safe.t =
-  match x with
-  | Red -> `String "Red"
-  | Green -> `String "Green"
-  | Blue -> `String "Blue"
 
 let jsonlike_of_color (x : color) : Atd_jsonlike.AST.t =
   match x with
@@ -586,9 +586,9 @@ let json_of_color x =
 module Color = struct
   type nonrec t = color
   let of_yojson = color_of_yojson
+  let to_yojson = yojson_of_color
   let of_jsonlike = color_of_jsonlike
   let to_jsonlike = jsonlike_of_color
-  let to_yojson = yojson_of_color
   let of_json = color_of_json
   let to_json = json_of_color
 end
@@ -602,11 +602,11 @@ let create_alias (x : string) : alias = x
 let alias_of_yojson (x : Yojson.Safe.t) : alias =
   Atdml_runtime.Yojson.string_of_yojson x
 
-let alias_of_jsonlike (x : Atd_jsonlike.AST.t) : alias =
-  Atdml_runtime.Jsonlike.string_of_jsonlike x
-
 let yojson_of_alias (x : alias) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
+
+let alias_of_jsonlike (x : Atd_jsonlike.AST.t) : alias =
+  Atdml_runtime.Jsonlike.string_of_jsonlike x
 
 let jsonlike_of_alias (x : alias) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_string x
@@ -621,9 +621,9 @@ module Alias = struct
   type nonrec t = alias
   let create = create_alias
   let of_yojson = alias_of_yojson
+  let to_yojson = yojson_of_alias
   let of_jsonlike = alias_of_jsonlike
   let to_jsonlike = jsonlike_of_alias
-  let to_yojson = yojson_of_alias
   let of_json = alias_of_json
   let to_json = json_of_alias
 end

--- a/atdml/tests/named-snapshots/field_prefix
+++ b/atdml/tests/named-snapshots/field_prefix
@@ -9,6 +9,7 @@ type t = {
 val create_t : ule:int -> if_:int -> if__:int -> unit -> t
 val t_of_yojson : Yojson.Safe.t -> t
 val t_of_jsonlike : Atd_jsonlike.AST.t -> t
+val jsonlike_of_t : t -> Atd_jsonlike.AST.t
 val yojson_of_t : t -> Yojson.Safe.t
 val t_of_json : string -> t
 val json_of_t : t -> string
@@ -18,6 +19,7 @@ module T : sig
   val create : ule:int -> if_:int -> if__:int -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -166,6 +168,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -248,6 +267,13 @@ let yojson_of_t (x : t) : Yojson.Safe.t =
     [("if_", Atdml_runtime.Yojson.yojson_of_int x.modif_)];
   ])
 
+let jsonlike_of_t (x : t) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "ule", Atdml_runtime.Jsonlike.jsonlike_of_int x.module_)];
+    [(Atd_jsonlike.Loc.zero, "if", Atdml_runtime.Jsonlike.jsonlike_of_int x.modif)];
+    [(Atd_jsonlike.Loc.zero, "if_", Atdml_runtime.Jsonlike.jsonlike_of_int x.modif_)];
+  ])
+
 let t_of_json s =
   t_of_yojson (Yojson.Safe.from_string s)
 
@@ -259,6 +285,7 @@ module T = struct
   let create = create_t
   let of_yojson = t_of_yojson
   let of_jsonlike = t_of_jsonlike
+  let to_jsonlike = jsonlike_of_t
   let to_yojson = yojson_of_t
   let of_json = t_of_json
   let to_json = json_of_t

--- a/atdml/tests/named-snapshots/field_prefix
+++ b/atdml/tests/named-snapshots/field_prefix
@@ -8,9 +8,9 @@ type t = {
 
 val create_t : ule:int -> if_:int -> if__:int -> unit -> t
 val t_of_yojson : Yojson.Safe.t -> t
+val yojson_of_t : t -> Yojson.Safe.t
 val t_of_jsonlike : Atd_jsonlike.AST.t -> t
 val jsonlike_of_t : t -> Atd_jsonlike.AST.t
-val yojson_of_t : t -> Yojson.Safe.t
 val t_of_json : string -> t
 val json_of_t : t -> string
 
@@ -18,9 +18,9 @@ module T : sig
   type nonrec t = t
   val create : ule:int -> if_:int -> if__:int -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -228,6 +228,13 @@ let t_of_yojson (x : Yojson.Safe.t) : t =
     { module_ = ule; modif = if_; modif_ = if__ }
   | _ -> Atdml_runtime.Yojson.bad_type "t" x
 
+let yojson_of_t (x : t) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("ule", Atdml_runtime.Yojson.yojson_of_int x.module_)];
+    [("if", Atdml_runtime.Yojson.yojson_of_int x.modif)];
+    [("if_", Atdml_runtime.Yojson.yojson_of_int x.modif_)];
+  ])
+
 let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -260,13 +267,6 @@ let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
     { module_ = ule; modif = if_; modif_ = if__ }
   | _ -> Atdml_runtime.Jsonlike.bad_type "t" x
 
-let yojson_of_t (x : t) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("ule", Atdml_runtime.Yojson.yojson_of_int x.module_)];
-    [("if", Atdml_runtime.Yojson.yojson_of_int x.modif)];
-    [("if_", Atdml_runtime.Yojson.yojson_of_int x.modif_)];
-  ])
-
 let jsonlike_of_t (x : t) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "ule", Atdml_runtime.Jsonlike.jsonlike_of_int x.module_)];
@@ -284,9 +284,9 @@ module T = struct
   type nonrec t = t
   let create = create_t
   let of_yojson = t_of_yojson
+  let to_yojson = yojson_of_t
   let of_jsonlike = t_of_jsonlike
   let to_jsonlike = jsonlike_of_t
-  let to_yojson = yojson_of_t
   let of_json = t_of_json
   let to_json = json_of_t
 end

--- a/atdml/tests/named-snapshots/imports
+++ b/atdml/tests/named-snapshots/imports
@@ -8,6 +8,7 @@ type tagged = {
 val create_tagged : value:Long.Module.Path.tag -> label:Base_types.label -> unit -> tagged
 val tagged_of_yojson : Yojson.Safe.t -> tagged
 val tagged_of_jsonlike : Atd_jsonlike.AST.t -> tagged
+val jsonlike_of_tagged : tagged -> Atd_jsonlike.AST.t
 val yojson_of_tagged : tagged -> Yojson.Safe.t
 val tagged_of_json : string -> tagged
 val json_of_tagged : tagged -> string
@@ -17,6 +18,7 @@ module Tagged : sig
   val create : value:Long.Module.Path.tag -> label:Base_types.label -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -30,6 +32,7 @@ type greeting = {
 val create_greeting : name:Base_types.person_name -> message:string -> unit -> greeting
 val greeting_of_yojson : Yojson.Safe.t -> greeting
 val greeting_of_jsonlike : Atd_jsonlike.AST.t -> greeting
+val jsonlike_of_greeting : greeting -> Atd_jsonlike.AST.t
 val yojson_of_greeting : greeting -> Yojson.Safe.t
 val greeting_of_json : string -> greeting
 val json_of_greeting : greeting -> string
@@ -39,6 +42,7 @@ module Greeting : sig
   val create : name:Base_types.person_name -> message:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -187,6 +191,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -259,6 +280,12 @@ let yojson_of_tagged (x : tagged) : Yojson.Safe.t =
     [("label", Base_types.yojson_of_label x.label)];
   ])
 
+let jsonlike_of_tagged (x : tagged) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "value", Ext.jsonlike_of_tag x.value)];
+    [(Atd_jsonlike.Loc.zero, "label", Base_types.jsonlike_of_label x.label)];
+  ])
+
 let tagged_of_json s =
   tagged_of_yojson (Yojson.Safe.from_string s)
 
@@ -270,6 +297,7 @@ module Tagged = struct
   let create = create_tagged
   let of_yojson = tagged_of_yojson
   let of_jsonlike = tagged_of_jsonlike
+  let to_jsonlike = jsonlike_of_tagged
   let to_yojson = yojson_of_tagged
   let of_json = tagged_of_json
   let to_json = json_of_tagged
@@ -342,6 +370,12 @@ let yojson_of_greeting (x : greeting) : Yojson.Safe.t =
     [("message", Atdml_runtime.Yojson.yojson_of_string x.message)];
   ])
 
+let jsonlike_of_greeting (x : greeting) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "name", Base_types.jsonlike_of_person_name x.name)];
+    [(Atd_jsonlike.Loc.zero, "message", Atdml_runtime.Jsonlike.jsonlike_of_string x.message)];
+  ])
+
 let greeting_of_json s =
   greeting_of_yojson (Yojson.Safe.from_string s)
 
@@ -353,6 +387,7 @@ module Greeting = struct
   let create = create_greeting
   let of_yojson = greeting_of_yojson
   let of_jsonlike = greeting_of_jsonlike
+  let to_jsonlike = jsonlike_of_greeting
   let to_yojson = yojson_of_greeting
   let of_json = greeting_of_json
   let to_json = json_of_greeting

--- a/atdml/tests/named-snapshots/imports
+++ b/atdml/tests/named-snapshots/imports
@@ -7,9 +7,9 @@ type tagged = {
 
 val create_tagged : value:Long.Module.Path.tag -> label:Base_types.label -> unit -> tagged
 val tagged_of_yojson : Yojson.Safe.t -> tagged
+val yojson_of_tagged : tagged -> Yojson.Safe.t
 val tagged_of_jsonlike : Atd_jsonlike.AST.t -> tagged
 val jsonlike_of_tagged : tagged -> Atd_jsonlike.AST.t
-val yojson_of_tagged : tagged -> Yojson.Safe.t
 val tagged_of_json : string -> tagged
 val json_of_tagged : tagged -> string
 
@@ -17,9 +17,9 @@ module Tagged : sig
   type nonrec t = tagged
   val create : value:Long.Module.Path.tag -> label:Base_types.label -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -31,9 +31,9 @@ type greeting = {
 
 val create_greeting : name:Base_types.person_name -> message:string -> unit -> greeting
 val greeting_of_yojson : Yojson.Safe.t -> greeting
+val yojson_of_greeting : greeting -> Yojson.Safe.t
 val greeting_of_jsonlike : Atd_jsonlike.AST.t -> greeting
 val jsonlike_of_greeting : greeting -> Atd_jsonlike.AST.t
-val yojson_of_greeting : greeting -> Yojson.Safe.t
 val greeting_of_json : string -> greeting
 val json_of_greeting : greeting -> string
 
@@ -41,9 +41,9 @@ module Greeting : sig
   type nonrec t = greeting
   val create : name:Base_types.person_name -> message:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -247,6 +247,12 @@ let tagged_of_yojson (x : Yojson.Safe.t) : tagged =
     { value; label }
   | _ -> Atdml_runtime.Yojson.bad_type "tagged" x
 
+let yojson_of_tagged (x : tagged) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("value", Ext.yojson_of_tag x.value)];
+    [("label", Base_types.yojson_of_label x.label)];
+  ])
+
 let tagged_of_jsonlike (x : Atd_jsonlike.AST.t) : tagged =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -274,12 +280,6 @@ let tagged_of_jsonlike (x : Atd_jsonlike.AST.t) : tagged =
     { value; label }
   | _ -> Atdml_runtime.Jsonlike.bad_type "tagged" x
 
-let yojson_of_tagged (x : tagged) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("value", Ext.yojson_of_tag x.value)];
-    [("label", Base_types.yojson_of_label x.label)];
-  ])
-
 let jsonlike_of_tagged (x : tagged) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "value", Ext.jsonlike_of_tag x.value)];
@@ -296,9 +296,9 @@ module Tagged = struct
   type nonrec t = tagged
   let create = create_tagged
   let of_yojson = tagged_of_yojson
+  let to_yojson = yojson_of_tagged
   let of_jsonlike = tagged_of_jsonlike
   let to_jsonlike = jsonlike_of_tagged
-  let to_yojson = yojson_of_tagged
   let of_json = tagged_of_json
   let to_json = json_of_tagged
 end
@@ -337,6 +337,12 @@ let greeting_of_yojson (x : Yojson.Safe.t) : greeting =
     { name; message }
   | _ -> Atdml_runtime.Yojson.bad_type "greeting" x
 
+let yojson_of_greeting (x : greeting) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("name", Base_types.yojson_of_person_name x.name)];
+    [("message", Atdml_runtime.Yojson.yojson_of_string x.message)];
+  ])
+
 let greeting_of_jsonlike (x : Atd_jsonlike.AST.t) : greeting =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -364,12 +370,6 @@ let greeting_of_jsonlike (x : Atd_jsonlike.AST.t) : greeting =
     { name; message }
   | _ -> Atdml_runtime.Jsonlike.bad_type "greeting" x
 
-let yojson_of_greeting (x : greeting) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("name", Base_types.yojson_of_person_name x.name)];
-    [("message", Atdml_runtime.Yojson.yojson_of_string x.message)];
-  ])
-
 let jsonlike_of_greeting (x : greeting) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "name", Base_types.jsonlike_of_person_name x.name)];
@@ -386,9 +386,9 @@ module Greeting = struct
   type nonrec t = greeting
   let create = create_greeting
   let of_yojson = greeting_of_yojson
+  let to_yojson = yojson_of_greeting
   let of_jsonlike = greeting_of_jsonlike
   let to_jsonlike = jsonlike_of_greeting
-  let to_yojson = yojson_of_greeting
   let of_json = greeting_of_json
   let to_json = json_of_greeting
 end

--- a/atdml/tests/named-snapshots/imports_e2e
+++ b/atdml/tests/named-snapshots/imports_e2e
@@ -8,6 +8,7 @@ type item = {
 val create_item : name:Base_types.person_name -> tag:Long.Module.Path.tag -> unit -> item
 val item_of_yojson : Yojson.Safe.t -> item
 val item_of_jsonlike : Atd_jsonlike.AST.t -> item
+val jsonlike_of_item : item -> Atd_jsonlike.AST.t
 val yojson_of_item : item -> Yojson.Safe.t
 val item_of_json : string -> item
 val json_of_item : item -> string
@@ -17,6 +18,7 @@ module Item : sig
   val create : name:Base_types.person_name -> tag:Long.Module.Path.tag -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -165,6 +167,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -237,6 +256,12 @@ let yojson_of_item (x : item) : Yojson.Safe.t =
     [("tag", Ext.yojson_of_tag x.tag)];
   ])
 
+let jsonlike_of_item (x : item) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "name", Base_types.jsonlike_of_person_name x.name)];
+    [(Atd_jsonlike.Loc.zero, "tag", Ext.jsonlike_of_tag x.tag)];
+  ])
+
 let item_of_json s =
   item_of_yojson (Yojson.Safe.from_string s)
 
@@ -248,6 +273,7 @@ module Item = struct
   let create = create_item
   let of_yojson = item_of_yojson
   let of_jsonlike = item_of_jsonlike
+  let to_jsonlike = jsonlike_of_item
   let to_yojson = yojson_of_item
   let of_json = item_of_json
   let to_json = json_of_item

--- a/atdml/tests/named-snapshots/imports_e2e
+++ b/atdml/tests/named-snapshots/imports_e2e
@@ -7,9 +7,9 @@ type item = {
 
 val create_item : name:Base_types.person_name -> tag:Long.Module.Path.tag -> unit -> item
 val item_of_yojson : Yojson.Safe.t -> item
+val yojson_of_item : item -> Yojson.Safe.t
 val item_of_jsonlike : Atd_jsonlike.AST.t -> item
 val jsonlike_of_item : item -> Atd_jsonlike.AST.t
-val yojson_of_item : item -> Yojson.Safe.t
 val item_of_json : string -> item
 val json_of_item : item -> string
 
@@ -17,9 +17,9 @@ module Item : sig
   type nonrec t = item
   val create : name:Base_types.person_name -> tag:Long.Module.Path.tag -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -223,6 +223,12 @@ let item_of_yojson (x : Yojson.Safe.t) : item =
     { name; tag }
   | _ -> Atdml_runtime.Yojson.bad_type "item" x
 
+let yojson_of_item (x : item) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("name", Base_types.yojson_of_person_name x.name)];
+    [("tag", Ext.yojson_of_tag x.tag)];
+  ])
+
 let item_of_jsonlike (x : Atd_jsonlike.AST.t) : item =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -250,12 +256,6 @@ let item_of_jsonlike (x : Atd_jsonlike.AST.t) : item =
     { name; tag }
   | _ -> Atdml_runtime.Jsonlike.bad_type "item" x
 
-let yojson_of_item (x : item) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("name", Base_types.yojson_of_person_name x.name)];
-    [("tag", Ext.yojson_of_tag x.tag)];
-  ])
-
 let jsonlike_of_item (x : item) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "name", Base_types.jsonlike_of_person_name x.name)];
@@ -272,9 +272,9 @@ module Item = struct
   type nonrec t = item
   let create = create_item
   let of_yojson = item_of_yojson
+  let to_yojson = yojson_of_item
   let of_jsonlike = item_of_jsonlike
   let to_jsonlike = jsonlike_of_item
-  let to_yojson = yojson_of_item
   let of_json = item_of_json
   let to_json = json_of_item
 end

--- a/atdml/tests/named-snapshots/json_repr_object
+++ b/atdml/tests/named-snapshots/json_repr_object
@@ -3,18 +3,18 @@
 type string_map = (string * int) list
 
 val string_map_of_yojson : Yojson.Safe.t -> string_map
+val yojson_of_string_map : string_map -> Yojson.Safe.t
 val string_map_of_jsonlike : Atd_jsonlike.AST.t -> string_map
 val jsonlike_of_string_map : string_map -> Atd_jsonlike.AST.t
-val yojson_of_string_map : string_map -> Yojson.Safe.t
 val string_map_of_json : string -> string_map
 val json_of_string_map : string_map -> string
 
 module String_map : sig
   type nonrec t = string_map
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -22,18 +22,18 @@ end
 type nested = (string * string list) list
 
 val nested_of_yojson : Yojson.Safe.t -> nested
+val yojson_of_nested : nested -> Yojson.Safe.t
 val nested_of_jsonlike : Atd_jsonlike.AST.t -> nested
 val jsonlike_of_nested : nested -> Atd_jsonlike.AST.t
-val yojson_of_nested : nested -> Yojson.Safe.t
 val nested_of_json : string -> nested
 val json_of_nested : nested -> string
 
 module Nested : sig
   type nonrec t = nested
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -45,9 +45,9 @@ type record = {
 
 val create_record : counts:string_map -> tags:nested -> unit -> record
 val record_of_yojson : Yojson.Safe.t -> record
+val yojson_of_record : record -> Yojson.Safe.t
 val record_of_jsonlike : Atd_jsonlike.AST.t -> record
 val jsonlike_of_record : record -> Atd_jsonlike.AST.t
-val yojson_of_record : record -> Yojson.Safe.t
 val record_of_json : string -> record
 val json_of_record : record -> string
 
@@ -55,9 +55,9 @@ module Record : sig
   type nonrec t = record
   val create : counts:string_map -> tags:nested -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -230,11 +230,11 @@ type string_map = (string * int) list
 let string_map_of_yojson (x : Yojson.Safe.t) : string_map =
   (Atdml_runtime.Yojson.assoc_of_yojson Atdml_runtime.Yojson.int_of_yojson) x
 
-let string_map_of_jsonlike (x : Atd_jsonlike.AST.t) : string_map =
-  (Atdml_runtime.Jsonlike.assoc_of_jsonlike Atdml_runtime.Jsonlike.int_of_jsonlike) x
-
 let yojson_of_string_map (x : string_map) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_assoc Atdml_runtime.Yojson.yojson_of_int) x
+
+let string_map_of_jsonlike (x : Atd_jsonlike.AST.t) : string_map =
+  (Atdml_runtime.Jsonlike.assoc_of_jsonlike Atdml_runtime.Jsonlike.int_of_jsonlike) x
 
 let jsonlike_of_string_map (x : string_map) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_assoc Atdml_runtime.Jsonlike.jsonlike_of_int) x
@@ -248,9 +248,9 @@ let json_of_string_map x =
 module String_map = struct
   type nonrec t = string_map
   let of_yojson = string_map_of_yojson
+  let to_yojson = yojson_of_string_map
   let of_jsonlike = string_map_of_jsonlike
   let to_jsonlike = jsonlike_of_string_map
-  let to_yojson = yojson_of_string_map
   let of_json = string_map_of_json
   let to_json = json_of_string_map
 end
@@ -260,11 +260,11 @@ type nested = (string * string list) list
 let nested_of_yojson (x : Yojson.Safe.t) : nested =
   (Atdml_runtime.Yojson.assoc_of_yojson (Atdml_runtime.Yojson.list_of_yojson Atdml_runtime.Yojson.string_of_yojson)) x
 
-let nested_of_jsonlike (x : Atd_jsonlike.AST.t) : nested =
-  (Atdml_runtime.Jsonlike.assoc_of_jsonlike (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike)) x
-
 let yojson_of_nested (x : nested) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_assoc (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string)) x
+
+let nested_of_jsonlike (x : Atd_jsonlike.AST.t) : nested =
+  (Atdml_runtime.Jsonlike.assoc_of_jsonlike (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike)) x
 
 let jsonlike_of_nested (x : nested) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_assoc (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string)) x
@@ -278,9 +278,9 @@ let json_of_nested x =
 module Nested = struct
   type nonrec t = nested
   let of_yojson = nested_of_yojson
+  let to_yojson = yojson_of_nested
   let of_jsonlike = nested_of_jsonlike
   let to_jsonlike = jsonlike_of_nested
-  let to_yojson = yojson_of_nested
   let of_json = nested_of_json
   let to_json = json_of_nested
 end
@@ -319,6 +319,12 @@ let record_of_yojson (x : Yojson.Safe.t) : record =
     { counts; tags }
   | _ -> Atdml_runtime.Yojson.bad_type "record" x
 
+let yojson_of_record (x : record) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("counts", yojson_of_string_map x.counts)];
+    [("tags", yojson_of_nested x.tags)];
+  ])
+
 let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -346,12 +352,6 @@ let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
     { counts; tags }
   | _ -> Atdml_runtime.Jsonlike.bad_type "record" x
 
-let yojson_of_record (x : record) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("counts", yojson_of_string_map x.counts)];
-    [("tags", yojson_of_nested x.tags)];
-  ])
-
 let jsonlike_of_record (x : record) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "counts", jsonlike_of_string_map x.counts)];
@@ -368,9 +368,9 @@ module Record = struct
   type nonrec t = record
   let create = create_record
   let of_yojson = record_of_yojson
+  let to_yojson = yojson_of_record
   let of_jsonlike = record_of_jsonlike
   let to_jsonlike = jsonlike_of_record
-  let to_yojson = yojson_of_record
   let of_json = record_of_json
   let to_json = json_of_record
 end

--- a/atdml/tests/named-snapshots/json_repr_object
+++ b/atdml/tests/named-snapshots/json_repr_object
@@ -4,6 +4,7 @@ type string_map = (string * int) list
 
 val string_map_of_yojson : Yojson.Safe.t -> string_map
 val string_map_of_jsonlike : Atd_jsonlike.AST.t -> string_map
+val jsonlike_of_string_map : string_map -> Atd_jsonlike.AST.t
 val yojson_of_string_map : string_map -> Yojson.Safe.t
 val string_map_of_json : string -> string_map
 val json_of_string_map : string_map -> string
@@ -12,6 +13,7 @@ module String_map : sig
   type nonrec t = string_map
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -21,6 +23,7 @@ type nested = (string * string list) list
 
 val nested_of_yojson : Yojson.Safe.t -> nested
 val nested_of_jsonlike : Atd_jsonlike.AST.t -> nested
+val jsonlike_of_nested : nested -> Atd_jsonlike.AST.t
 val yojson_of_nested : nested -> Yojson.Safe.t
 val nested_of_json : string -> nested
 val json_of_nested : nested -> string
@@ -29,6 +32,7 @@ module Nested : sig
   type nonrec t = nested
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -42,6 +46,7 @@ type record = {
 val create_record : counts:string_map -> tags:nested -> unit -> record
 val record_of_yojson : Yojson.Safe.t -> record
 val record_of_jsonlike : Atd_jsonlike.AST.t -> record
+val jsonlike_of_record : record -> Atd_jsonlike.AST.t
 val yojson_of_record : record -> Yojson.Safe.t
 val record_of_json : string -> record
 val json_of_record : record -> string
@@ -51,6 +56,7 @@ module Record : sig
   val create : counts:string_map -> tags:nested -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -199,6 +205,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -213,6 +236,9 @@ let string_map_of_jsonlike (x : Atd_jsonlike.AST.t) : string_map =
 let yojson_of_string_map (x : string_map) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_assoc Atdml_runtime.Yojson.yojson_of_int) x
 
+let jsonlike_of_string_map (x : string_map) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_assoc Atdml_runtime.Jsonlike.jsonlike_of_int) x
+
 let string_map_of_json s =
   string_map_of_yojson (Yojson.Safe.from_string s)
 
@@ -223,6 +249,7 @@ module String_map = struct
   type nonrec t = string_map
   let of_yojson = string_map_of_yojson
   let of_jsonlike = string_map_of_jsonlike
+  let to_jsonlike = jsonlike_of_string_map
   let to_yojson = yojson_of_string_map
   let of_json = string_map_of_json
   let to_json = json_of_string_map
@@ -239,6 +266,9 @@ let nested_of_jsonlike (x : Atd_jsonlike.AST.t) : nested =
 let yojson_of_nested (x : nested) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_assoc (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string)) x
 
+let jsonlike_of_nested (x : nested) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_assoc (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string)) x
+
 let nested_of_json s =
   nested_of_yojson (Yojson.Safe.from_string s)
 
@@ -249,6 +279,7 @@ module Nested = struct
   type nonrec t = nested
   let of_yojson = nested_of_yojson
   let of_jsonlike = nested_of_jsonlike
+  let to_jsonlike = jsonlike_of_nested
   let to_yojson = yojson_of_nested
   let of_json = nested_of_json
   let to_json = json_of_nested
@@ -321,6 +352,12 @@ let yojson_of_record (x : record) : Yojson.Safe.t =
     [("tags", yojson_of_nested x.tags)];
   ])
 
+let jsonlike_of_record (x : record) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "counts", jsonlike_of_string_map x.counts)];
+    [(Atd_jsonlike.Loc.zero, "tags", jsonlike_of_nested x.tags)];
+  ])
+
 let record_of_json s =
   record_of_yojson (Yojson.Safe.from_string s)
 
@@ -332,6 +369,7 @@ module Record = struct
   let create = create_record
   let of_yojson = record_of_yojson
   let of_jsonlike = record_of_jsonlike
+  let to_jsonlike = jsonlike_of_record
   let to_yojson = yojson_of_record
   let of_json = record_of_json
   let to_json = json_of_record

--- a/atdml/tests/named-snapshots/json_repr_object_sum
+++ b/atdml/tests/named-snapshots/json_repr_object_sum
@@ -6,18 +6,18 @@ type shape =
   | Point
 
 val shape_of_yojson : Yojson.Safe.t -> shape
+val yojson_of_shape : shape -> Yojson.Safe.t
 val shape_of_jsonlike : Atd_jsonlike.AST.t -> shape
 val jsonlike_of_shape : shape -> Atd_jsonlike.AST.t
-val yojson_of_shape : shape -> Yojson.Safe.t
 val shape_of_json : string -> shape
 val json_of_shape : shape -> string
 
 module Shape : sig
   type nonrec t = shape
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -197,18 +197,18 @@ let shape_of_yojson (x : Yojson.Safe.t) : shape =
   | `String "Point" -> Point
   | _ -> Atdml_runtime.Yojson.bad_sum "shape" x
 
+let yojson_of_shape (x : shape) : Yojson.Safe.t =
+  match x with
+  | Circle v -> `Assoc [("Circle", Atdml_runtime.Yojson.yojson_of_float v)]
+  | Square v -> `Assoc [("Square", Atdml_runtime.Yojson.yojson_of_float v)]
+  | Point -> `String "Point"
+
 let shape_of_jsonlike (x : Atd_jsonlike.AST.t) : shape =
   match x with
   | Atd_jsonlike.AST.Object (_, [(_, "Circle", v)]) -> Circle (Atdml_runtime.Jsonlike.float_of_jsonlike v)
   | Atd_jsonlike.AST.Object (_, [(_, "Square", v)]) -> Square (Atdml_runtime.Jsonlike.float_of_jsonlike v)
   | Atd_jsonlike.AST.String (_, "Point") -> Point
   | _ -> Atdml_runtime.Jsonlike.bad_sum "shape" x
-
-let yojson_of_shape (x : shape) : Yojson.Safe.t =
-  match x with
-  | Circle v -> `Assoc [("Circle", Atdml_runtime.Yojson.yojson_of_float v)]
-  | Square v -> `Assoc [("Square", Atdml_runtime.Yojson.yojson_of_float v)]
-  | Point -> `String "Point"
 
 let jsonlike_of_shape (x : shape) : Atd_jsonlike.AST.t =
   match x with
@@ -225,9 +225,9 @@ let json_of_shape x =
 module Shape = struct
   type nonrec t = shape
   let of_yojson = shape_of_yojson
+  let to_yojson = yojson_of_shape
   let of_jsonlike = shape_of_jsonlike
   let to_jsonlike = jsonlike_of_shape
-  let to_yojson = yojson_of_shape
   let of_json = shape_of_json
   let to_json = json_of_shape
 end

--- a/atdml/tests/named-snapshots/json_repr_object_sum
+++ b/atdml/tests/named-snapshots/json_repr_object_sum
@@ -7,6 +7,7 @@ type shape =
 
 val shape_of_yojson : Yojson.Safe.t -> shape
 val shape_of_jsonlike : Atd_jsonlike.AST.t -> shape
+val jsonlike_of_shape : shape -> Atd_jsonlike.AST.t
 val yojson_of_shape : shape -> Yojson.Safe.t
 val shape_of_json : string -> shape
 val json_of_shape : shape -> string
@@ -15,6 +16,7 @@ module Shape : sig
   type nonrec t = shape
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -163,6 +165,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -191,6 +210,12 @@ let yojson_of_shape (x : shape) : Yojson.Safe.t =
   | Square v -> `Assoc [("Square", Atdml_runtime.Yojson.yojson_of_float v)]
   | Point -> `String "Point"
 
+let jsonlike_of_shape (x : shape) : Atd_jsonlike.AST.t =
+  match x with
+  | Circle v -> Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, [(Atd_jsonlike.Loc.zero, "Circle", Atdml_runtime.Jsonlike.jsonlike_of_float v)])
+  | Square v -> Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, [(Atd_jsonlike.Loc.zero, "Square", Atdml_runtime.Jsonlike.jsonlike_of_float v)])
+  | Point -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Point")
+
 let shape_of_json s =
   shape_of_yojson (Yojson.Safe.from_string s)
 
@@ -201,6 +226,7 @@ module Shape = struct
   type nonrec t = shape
   let of_yojson = shape_of_yojson
   let of_jsonlike = shape_of_jsonlike
+  let to_jsonlike = jsonlike_of_shape
   let to_yojson = yojson_of_shape
   let of_json = shape_of_json
   let to_json = json_of_shape

--- a/atdml/tests/named-snapshots/keyword_field_and_variant_names
+++ b/atdml/tests/named-snapshots/keyword_field_and_variant_names
@@ -6,6 +6,7 @@ type sum_with_keyword_names =
 
 val sum_with_keyword_names_of_yojson : Yojson.Safe.t -> sum_with_keyword_names
 val sum_with_keyword_names_of_jsonlike : Atd_jsonlike.AST.t -> sum_with_keyword_names
+val jsonlike_of_sum_with_keyword_names : sum_with_keyword_names -> Atd_jsonlike.AST.t
 val yojson_of_sum_with_keyword_names : sum_with_keyword_names -> Yojson.Safe.t
 val sum_with_keyword_names_of_json : string -> sum_with_keyword_names
 val json_of_sum_with_keyword_names : sum_with_keyword_names -> string
@@ -14,6 +15,7 @@ module Sum_with_keyword_names : sig
   type nonrec t = sum_with_keyword_names
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -29,6 +31,7 @@ type record_with_keyword_fields = {
 val create_record_with_keyword_fields : method_:string -> object_:int -> ?begin_:bool -> ?end_:string list -> unit -> record_with_keyword_fields
 val record_with_keyword_fields_of_yojson : Yojson.Safe.t -> record_with_keyword_fields
 val record_with_keyword_fields_of_jsonlike : Atd_jsonlike.AST.t -> record_with_keyword_fields
+val jsonlike_of_record_with_keyword_fields : record_with_keyword_fields -> Atd_jsonlike.AST.t
 val yojson_of_record_with_keyword_fields : record_with_keyword_fields -> Yojson.Safe.t
 val record_with_keyword_fields_of_json : string -> record_with_keyword_fields
 val json_of_record_with_keyword_fields : record_with_keyword_fields -> string
@@ -38,6 +41,7 @@ module Record_with_keyword_fields : sig
   val create : method_:string -> object_:int -> ?begin_:bool -> ?end_:string list -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -186,6 +190,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -210,6 +231,11 @@ let yojson_of_sum_with_keyword_names (x : sum_with_keyword_names) : Yojson.Safe.
   | Fun -> `String "Fun"
   | Method v -> `List [`String "Method"; Atdml_runtime.Yojson.yojson_of_string v]
 
+let jsonlike_of_sum_with_keyword_names (x : sum_with_keyword_names) : Atd_jsonlike.AST.t =
+  match x with
+  | Fun -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Fun")
+  | Method v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Method"); Atdml_runtime.Jsonlike.jsonlike_of_string v])
+
 let sum_with_keyword_names_of_json s =
   sum_with_keyword_names_of_yojson (Yojson.Safe.from_string s)
 
@@ -220,6 +246,7 @@ module Sum_with_keyword_names = struct
   type nonrec t = sum_with_keyword_names
   let of_yojson = sum_with_keyword_names_of_yojson
   let of_jsonlike = sum_with_keyword_names_of_jsonlike
+  let to_jsonlike = jsonlike_of_sum_with_keyword_names
   let to_yojson = yojson_of_sum_with_keyword_names
   let of_json = sum_with_keyword_names_of_json
   let to_json = json_of_sum_with_keyword_names
@@ -316,6 +343,14 @@ let yojson_of_record_with_keyword_fields (x : record_with_keyword_fields) : Yojs
     [("end", (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x.end_)];
   ])
 
+let jsonlike_of_record_with_keyword_fields (x : record_with_keyword_fields) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "method", Atdml_runtime.Jsonlike.jsonlike_of_string x.method_)];
+    [(Atd_jsonlike.Loc.zero, "object", Atdml_runtime.Jsonlike.jsonlike_of_int x.object_)];
+    (match x.begin_ with None -> [] | Some v -> [(Atd_jsonlike.Loc.zero, "begin", Atdml_runtime.Jsonlike.jsonlike_of_bool v)]);
+    [(Atd_jsonlike.Loc.zero, "end", (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string) x.end_)];
+  ])
+
 let record_with_keyword_fields_of_json s =
   record_with_keyword_fields_of_yojson (Yojson.Safe.from_string s)
 
@@ -327,6 +362,7 @@ module Record_with_keyword_fields = struct
   let create = create_record_with_keyword_fields
   let of_yojson = record_with_keyword_fields_of_yojson
   let of_jsonlike = record_with_keyword_fields_of_jsonlike
+  let to_jsonlike = jsonlike_of_record_with_keyword_fields
   let to_yojson = yojson_of_record_with_keyword_fields
   let of_json = record_with_keyword_fields_of_json
   let to_json = json_of_record_with_keyword_fields

--- a/atdml/tests/named-snapshots/keyword_field_and_variant_names
+++ b/atdml/tests/named-snapshots/keyword_field_and_variant_names
@@ -5,18 +5,18 @@ type sum_with_keyword_names =
   | Method of string
 
 val sum_with_keyword_names_of_yojson : Yojson.Safe.t -> sum_with_keyword_names
+val yojson_of_sum_with_keyword_names : sum_with_keyword_names -> Yojson.Safe.t
 val sum_with_keyword_names_of_jsonlike : Atd_jsonlike.AST.t -> sum_with_keyword_names
 val jsonlike_of_sum_with_keyword_names : sum_with_keyword_names -> Atd_jsonlike.AST.t
-val yojson_of_sum_with_keyword_names : sum_with_keyword_names -> Yojson.Safe.t
 val sum_with_keyword_names_of_json : string -> sum_with_keyword_names
 val json_of_sum_with_keyword_names : sum_with_keyword_names -> string
 
 module Sum_with_keyword_names : sig
   type nonrec t = sum_with_keyword_names
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -30,9 +30,9 @@ type record_with_keyword_fields = {
 
 val create_record_with_keyword_fields : method_:string -> object_:int -> ?begin_:bool -> ?end_:string list -> unit -> record_with_keyword_fields
 val record_with_keyword_fields_of_yojson : Yojson.Safe.t -> record_with_keyword_fields
+val yojson_of_record_with_keyword_fields : record_with_keyword_fields -> Yojson.Safe.t
 val record_with_keyword_fields_of_jsonlike : Atd_jsonlike.AST.t -> record_with_keyword_fields
 val jsonlike_of_record_with_keyword_fields : record_with_keyword_fields -> Atd_jsonlike.AST.t
-val yojson_of_record_with_keyword_fields : record_with_keyword_fields -> Yojson.Safe.t
 val record_with_keyword_fields_of_json : string -> record_with_keyword_fields
 val json_of_record_with_keyword_fields : record_with_keyword_fields -> string
 
@@ -40,9 +40,9 @@ module Record_with_keyword_fields : sig
   type nonrec t = record_with_keyword_fields
   val create : method_:string -> object_:int -> ?begin_:bool -> ?end_:string list -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -220,16 +220,16 @@ let sum_with_keyword_names_of_yojson (x : Yojson.Safe.t) : sum_with_keyword_name
   | `List [`String "Method"; v] -> Method (Atdml_runtime.Yojson.string_of_yojson v)
   | _ -> Atdml_runtime.Yojson.bad_sum "sum_with_keyword_names" x
 
+let yojson_of_sum_with_keyword_names (x : sum_with_keyword_names) : Yojson.Safe.t =
+  match x with
+  | Fun -> `String "Fun"
+  | Method v -> `List [`String "Method"; Atdml_runtime.Yojson.yojson_of_string v]
+
 let sum_with_keyword_names_of_jsonlike (x : Atd_jsonlike.AST.t) : sum_with_keyword_names =
   match x with
   | Atd_jsonlike.AST.String (_, "Fun") -> Fun
   | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Method"); v]) -> Method (Atdml_runtime.Jsonlike.string_of_jsonlike v)
   | _ -> Atdml_runtime.Jsonlike.bad_sum "sum_with_keyword_names" x
-
-let yojson_of_sum_with_keyword_names (x : sum_with_keyword_names) : Yojson.Safe.t =
-  match x with
-  | Fun -> `String "Fun"
-  | Method v -> `List [`String "Method"; Atdml_runtime.Yojson.yojson_of_string v]
 
 let jsonlike_of_sum_with_keyword_names (x : sum_with_keyword_names) : Atd_jsonlike.AST.t =
   match x with
@@ -245,9 +245,9 @@ let json_of_sum_with_keyword_names x =
 module Sum_with_keyword_names = struct
   type nonrec t = sum_with_keyword_names
   let of_yojson = sum_with_keyword_names_of_yojson
+  let to_yojson = yojson_of_sum_with_keyword_names
   let of_jsonlike = sum_with_keyword_names_of_jsonlike
   let to_jsonlike = jsonlike_of_sum_with_keyword_names
-  let to_yojson = yojson_of_sum_with_keyword_names
   let of_json = sum_with_keyword_names_of_json
   let to_json = json_of_sum_with_keyword_names
 end
@@ -298,6 +298,14 @@ let record_with_keyword_fields_of_yojson (x : Yojson.Safe.t) : record_with_keywo
     { method_; object_; begin_; end_ }
   | _ -> Atdml_runtime.Yojson.bad_type "record_with_keyword_fields" x
 
+let yojson_of_record_with_keyword_fields (x : record_with_keyword_fields) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("method", Atdml_runtime.Yojson.yojson_of_string x.method_)];
+    [("object", Atdml_runtime.Yojson.yojson_of_int x.object_)];
+    (match x.begin_ with None -> [] | Some v -> [("begin", Atdml_runtime.Yojson.yojson_of_bool v)]);
+    [("end", (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x.end_)];
+  ])
+
 let record_with_keyword_fields_of_jsonlike (x : Atd_jsonlike.AST.t) : record_with_keyword_fields =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -335,14 +343,6 @@ let record_with_keyword_fields_of_jsonlike (x : Atd_jsonlike.AST.t) : record_wit
     { method_; object_; begin_; end_ }
   | _ -> Atdml_runtime.Jsonlike.bad_type "record_with_keyword_fields" x
 
-let yojson_of_record_with_keyword_fields (x : record_with_keyword_fields) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("method", Atdml_runtime.Yojson.yojson_of_string x.method_)];
-    [("object", Atdml_runtime.Yojson.yojson_of_int x.object_)];
-    (match x.begin_ with None -> [] | Some v -> [("begin", Atdml_runtime.Yojson.yojson_of_bool v)]);
-    [("end", (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x.end_)];
-  ])
-
 let jsonlike_of_record_with_keyword_fields (x : record_with_keyword_fields) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "method", Atdml_runtime.Jsonlike.jsonlike_of_string x.method_)];
@@ -361,9 +361,9 @@ module Record_with_keyword_fields = struct
   type nonrec t = record_with_keyword_fields
   let create = create_record_with_keyword_fields
   let of_yojson = record_with_keyword_fields_of_yojson
+  let to_yojson = yojson_of_record_with_keyword_fields
   let of_jsonlike = record_with_keyword_fields_of_jsonlike
   let to_jsonlike = jsonlike_of_record_with_keyword_fields
-  let to_yojson = yojson_of_record_with_keyword_fields
   let of_json = record_with_keyword_fields_of_json
   let to_json = json_of_record_with_keyword_fields
 end

--- a/atdml/tests/named-snapshots/mutually_recursive_types
+++ b/atdml/tests/named-snapshots/mutually_recursive_types
@@ -12,12 +12,14 @@ and tree =
 val create_node : value:int -> children:(tree * tree) -> unit -> node
 val node_of_yojson : Yojson.Safe.t -> node
 val node_of_jsonlike : Atd_jsonlike.AST.t -> node
+val jsonlike_of_node : node -> Atd_jsonlike.AST.t
 val yojson_of_node : node -> Yojson.Safe.t
 val node_of_json : string -> node
 val json_of_node : node -> string
 
 val tree_of_yojson : Yojson.Safe.t -> tree
 val tree_of_jsonlike : Atd_jsonlike.AST.t -> tree
+val jsonlike_of_tree : tree -> Atd_jsonlike.AST.t
 val yojson_of_tree : tree -> Yojson.Safe.t
 val tree_of_json : string -> tree
 val json_of_tree : tree -> string
@@ -27,6 +29,7 @@ module Node : sig
   val create : value:int -> children:(tree * tree) -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -36,6 +39,7 @@ module Tree : sig
   type nonrec t = tree
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -184,6 +188,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -275,6 +296,17 @@ and yojson_of_tree (x : tree) : Yojson.Safe.t =
   | Leaf -> `String "Leaf"
   | Node v -> `List [`String "Node"; yojson_of_node v]
 
+let rec jsonlike_of_node (x : node) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "value", Atdml_runtime.Jsonlike.jsonlike_of_int x.value)];
+    [(Atd_jsonlike.Loc.zero, "children", (fun (x0, x1) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [jsonlike_of_tree x0; jsonlike_of_tree x1])) x.children)];
+  ])
+
+and jsonlike_of_tree (x : tree) : Atd_jsonlike.AST.t =
+  match x with
+  | Leaf -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Leaf")
+  | Node v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Node"); jsonlike_of_node v])
+
 let node_of_json s =
   node_of_yojson (Yojson.Safe.from_string s)
 
@@ -292,6 +324,7 @@ module Node = struct
   let create = create_node
   let of_yojson = node_of_yojson
   let of_jsonlike = node_of_jsonlike
+  let to_jsonlike = jsonlike_of_node
   let to_yojson = yojson_of_node
   let of_json = node_of_json
   let to_json = json_of_node
@@ -301,6 +334,7 @@ module Tree = struct
   type nonrec t = tree
   let of_yojson = tree_of_yojson
   let of_jsonlike = tree_of_jsonlike
+  let to_jsonlike = jsonlike_of_tree
   let to_yojson = yojson_of_tree
   let of_json = tree_of_json
   let to_json = json_of_tree

--- a/atdml/tests/named-snapshots/mutually_recursive_types
+++ b/atdml/tests/named-snapshots/mutually_recursive_types
@@ -11,16 +11,16 @@ and tree =
 
 val create_node : value:int -> children:(tree * tree) -> unit -> node
 val node_of_yojson : Yojson.Safe.t -> node
+val yojson_of_node : node -> Yojson.Safe.t
 val node_of_jsonlike : Atd_jsonlike.AST.t -> node
 val jsonlike_of_node : node -> Atd_jsonlike.AST.t
-val yojson_of_node : node -> Yojson.Safe.t
 val node_of_json : string -> node
 val json_of_node : node -> string
 
 val tree_of_yojson : Yojson.Safe.t -> tree
+val yojson_of_tree : tree -> Yojson.Safe.t
 val tree_of_jsonlike : Atd_jsonlike.AST.t -> tree
 val jsonlike_of_tree : tree -> Atd_jsonlike.AST.t
-val yojson_of_tree : tree -> Yojson.Safe.t
 val tree_of_json : string -> tree
 val json_of_tree : tree -> string
 
@@ -28,9 +28,9 @@ module Node : sig
   type nonrec t = node
   val create : value:int -> children:(tree * tree) -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -38,9 +38,9 @@ end
 module Tree : sig
   type nonrec t = tree
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -252,6 +252,17 @@ and tree_of_yojson (x : Yojson.Safe.t) : tree =
   | `List [`String "Node"; v] -> Node (node_of_yojson v)
   | _ -> Atdml_runtime.Yojson.bad_sum "tree" x
 
+let rec yojson_of_node (x : node) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("value", Atdml_runtime.Yojson.yojson_of_int x.value)];
+    [("children", (fun (x0, x1) -> `List [yojson_of_tree x0; yojson_of_tree x1]) x.children)];
+  ])
+
+and yojson_of_tree (x : tree) : Yojson.Safe.t =
+  match x with
+  | Leaf -> `String "Leaf"
+  | Node v -> `List [`String "Node"; yojson_of_node v]
+
 let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -285,17 +296,6 @@ and tree_of_jsonlike (x : Atd_jsonlike.AST.t) : tree =
   | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Node"); v]) -> Node (node_of_jsonlike v)
   | _ -> Atdml_runtime.Jsonlike.bad_sum "tree" x
 
-let rec yojson_of_node (x : node) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("value", Atdml_runtime.Yojson.yojson_of_int x.value)];
-    [("children", (fun (x0, x1) -> `List [yojson_of_tree x0; yojson_of_tree x1]) x.children)];
-  ])
-
-and yojson_of_tree (x : tree) : Yojson.Safe.t =
-  match x with
-  | Leaf -> `String "Leaf"
-  | Node v -> `List [`String "Node"; yojson_of_node v]
-
 let rec jsonlike_of_node (x : node) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "value", Atdml_runtime.Jsonlike.jsonlike_of_int x.value)];
@@ -323,9 +323,9 @@ module Node = struct
   type nonrec t = node
   let create = create_node
   let of_yojson = node_of_yojson
+  let to_yojson = yojson_of_node
   let of_jsonlike = node_of_jsonlike
   let to_jsonlike = jsonlike_of_node
-  let to_yojson = yojson_of_node
   let of_json = node_of_json
   let to_json = json_of_node
 end
@@ -333,9 +333,9 @@ end
 module Tree = struct
   type nonrec t = tree
   let of_yojson = tree_of_yojson
+  let to_yojson = yojson_of_tree
   let of_jsonlike = tree_of_jsonlike
   let to_jsonlike = jsonlike_of_tree
-  let to_yojson = yojson_of_tree
   let of_json = tree_of_json
   let to_json = json_of_tree
 end

--- a/atdml/tests/named-snapshots/ocaml_private_public
+++ b/atdml/tests/named-snapshots/ocaml_private_public
@@ -7,6 +7,7 @@ type status = private [
 
 val status_of_yojson : Yojson.Safe.t -> status
 val status_of_jsonlike : Atd_jsonlike.AST.t -> status
+val jsonlike_of_status : status -> Atd_jsonlike.AST.t
 val yojson_of_status : status -> Yojson.Safe.t
 val status_of_json : string -> status
 val json_of_status : status -> string
@@ -15,6 +16,7 @@ module Status : sig
   type nonrec t = status
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -28,6 +30,7 @@ type point = private {
 val create_point : x:float -> y:float -> unit -> point
 val point_of_yojson : Yojson.Safe.t -> point
 val point_of_jsonlike : Atd_jsonlike.AST.t -> point
+val jsonlike_of_point : point -> Atd_jsonlike.AST.t
 val yojson_of_point : point -> Yojson.Safe.t
 val point_of_json : string -> point
 val json_of_point : point -> string
@@ -37,6 +40,7 @@ module Point : sig
   val create : x:float -> y:float -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -47,6 +51,7 @@ type open_id = string
 val create_open_id : string -> open_id
 val open_id_of_yojson : Yojson.Safe.t -> open_id
 val open_id_of_jsonlike : Atd_jsonlike.AST.t -> open_id
+val jsonlike_of_open_id : open_id -> Atd_jsonlike.AST.t
 val yojson_of_open_id : open_id -> Yojson.Safe.t
 val open_id_of_json : string -> open_id
 val json_of_open_id : open_id -> string
@@ -56,6 +61,7 @@ module Open_id : sig
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -66,6 +72,7 @@ type id = private string
 val create_id : string -> id
 val id_of_yojson : Yojson.Safe.t -> id
 val id_of_jsonlike : Atd_jsonlike.AST.t -> id
+val jsonlike_of_id : id -> Atd_jsonlike.AST.t
 val yojson_of_id : id -> Yojson.Safe.t
 val id_of_json : string -> id
 val json_of_id : id -> string
@@ -75,6 +82,7 @@ module Id : sig
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -84,6 +92,7 @@ type ids = private id list
 
 val ids_of_yojson : Yojson.Safe.t -> ids
 val ids_of_jsonlike : Atd_jsonlike.AST.t -> ids
+val jsonlike_of_ids : ids -> Atd_jsonlike.AST.t
 val yojson_of_ids : ids -> Yojson.Safe.t
 val ids_of_json : string -> ids
 val json_of_ids : ids -> string
@@ -92,6 +101,7 @@ module Ids : sig
   type nonrec t = ids
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -104,6 +114,7 @@ type color = private
 
 val color_of_yojson : Yojson.Safe.t -> color
 val color_of_jsonlike : Atd_jsonlike.AST.t -> color
+val jsonlike_of_color : color -> Atd_jsonlike.AST.t
 val yojson_of_color : color -> Yojson.Safe.t
 val color_of_json : string -> color
 val json_of_color : color -> string
@@ -112,6 +123,7 @@ module Color : sig
   type nonrec t = color
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -260,6 +272,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -285,6 +314,11 @@ let yojson_of_status (x : status) : Yojson.Safe.t =
   | `Active -> `String "Active"
   | `Inactive -> `String "Inactive"
 
+let jsonlike_of_status (x : status) : Atd_jsonlike.AST.t =
+  match x with
+  | `Active -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Active")
+  | `Inactive -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Inactive")
+
 let status_of_json s =
   status_of_yojson (Yojson.Safe.from_string s)
 
@@ -295,6 +329,7 @@ module Status = struct
   type nonrec t = status
   let of_yojson = status_of_yojson
   let of_jsonlike = status_of_jsonlike
+  let to_jsonlike = jsonlike_of_status
   let to_yojson = yojson_of_status
   let of_json = status_of_json
   let to_json = json_of_status
@@ -367,6 +402,12 @@ let yojson_of_point (x : point) : Yojson.Safe.t =
     [("y", Atdml_runtime.Yojson.yojson_of_float x.y)];
   ])
 
+let jsonlike_of_point (x : point) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "x", Atdml_runtime.Jsonlike.jsonlike_of_float x.x)];
+    [(Atd_jsonlike.Loc.zero, "y", Atdml_runtime.Jsonlike.jsonlike_of_float x.y)];
+  ])
+
 let point_of_json s =
   point_of_yojson (Yojson.Safe.from_string s)
 
@@ -378,6 +419,7 @@ module Point = struct
   let create = create_point
   let of_yojson = point_of_yojson
   let of_jsonlike = point_of_jsonlike
+  let to_jsonlike = jsonlike_of_point
   let to_yojson = yojson_of_point
   let of_json = point_of_json
   let to_json = json_of_point
@@ -397,6 +439,9 @@ let open_id_of_jsonlike (x : Atd_jsonlike.AST.t) : open_id =
 let yojson_of_open_id (x : open_id) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
 
+let jsonlike_of_open_id (x : open_id) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_string x
+
 let open_id_of_json s =
   open_id_of_yojson (Yojson.Safe.from_string s)
 
@@ -408,6 +453,7 @@ module Open_id = struct
   let create = create_open_id
   let of_yojson = open_id_of_yojson
   let of_jsonlike = open_id_of_jsonlike
+  let to_jsonlike = jsonlike_of_open_id
   let to_yojson = yojson_of_open_id
   let of_json = open_id_of_json
   let to_json = json_of_open_id
@@ -427,6 +473,9 @@ let id_of_jsonlike (x : Atd_jsonlike.AST.t) : id =
 let yojson_of_id (x : id) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
 
+let jsonlike_of_id (x : id) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_string x
+
 let id_of_json s =
   id_of_yojson (Yojson.Safe.from_string s)
 
@@ -438,6 +487,7 @@ module Id = struct
   let create = create_id
   let of_yojson = id_of_yojson
   let of_jsonlike = id_of_jsonlike
+  let to_jsonlike = jsonlike_of_id
   let to_yojson = yojson_of_id
   let of_json = id_of_json
   let to_json = json_of_id
@@ -454,6 +504,9 @@ let ids_of_jsonlike (x : Atd_jsonlike.AST.t) : ids =
 let yojson_of_ids (x : ids) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_id) x
 
+let jsonlike_of_ids (x : ids) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_id) x
+
 let ids_of_json s =
   ids_of_yojson (Yojson.Safe.from_string s)
 
@@ -464,6 +517,7 @@ module Ids = struct
   type nonrec t = ids
   let of_yojson = ids_of_yojson
   let of_jsonlike = ids_of_jsonlike
+  let to_jsonlike = jsonlike_of_ids
   let to_yojson = yojson_of_ids
   let of_json = ids_of_json
   let to_json = json_of_ids
@@ -494,6 +548,12 @@ let yojson_of_color (x : color) : Yojson.Safe.t =
   | Green -> `String "Green"
   | Blue -> `String "Blue"
 
+let jsonlike_of_color (x : color) : Atd_jsonlike.AST.t =
+  match x with
+  | Red -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Red")
+  | Green -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Green")
+  | Blue -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Blue")
+
 let color_of_json s =
   color_of_yojson (Yojson.Safe.from_string s)
 
@@ -504,6 +564,7 @@ module Color = struct
   type nonrec t = color
   let of_yojson = color_of_yojson
   let of_jsonlike = color_of_jsonlike
+  let to_jsonlike = jsonlike_of_color
   let to_yojson = yojson_of_color
   let of_json = color_of_json
   let to_json = json_of_color

--- a/atdml/tests/named-snapshots/ocaml_private_public
+++ b/atdml/tests/named-snapshots/ocaml_private_public
@@ -6,18 +6,18 @@ type status = private [
 ]
 
 val status_of_yojson : Yojson.Safe.t -> status
+val yojson_of_status : status -> Yojson.Safe.t
 val status_of_jsonlike : Atd_jsonlike.AST.t -> status
 val jsonlike_of_status : status -> Atd_jsonlike.AST.t
-val yojson_of_status : status -> Yojson.Safe.t
 val status_of_json : string -> status
 val json_of_status : status -> string
 
 module Status : sig
   type nonrec t = status
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -29,9 +29,9 @@ type point = private {
 
 val create_point : x:float -> y:float -> unit -> point
 val point_of_yojson : Yojson.Safe.t -> point
+val yojson_of_point : point -> Yojson.Safe.t
 val point_of_jsonlike : Atd_jsonlike.AST.t -> point
 val jsonlike_of_point : point -> Atd_jsonlike.AST.t
-val yojson_of_point : point -> Yojson.Safe.t
 val point_of_json : string -> point
 val json_of_point : point -> string
 
@@ -39,9 +39,9 @@ module Point : sig
   type nonrec t = point
   val create : x:float -> y:float -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -50,9 +50,9 @@ type open_id = string
 
 val create_open_id : string -> open_id
 val open_id_of_yojson : Yojson.Safe.t -> open_id
+val yojson_of_open_id : open_id -> Yojson.Safe.t
 val open_id_of_jsonlike : Atd_jsonlike.AST.t -> open_id
 val jsonlike_of_open_id : open_id -> Atd_jsonlike.AST.t
-val yojson_of_open_id : open_id -> Yojson.Safe.t
 val open_id_of_json : string -> open_id
 val json_of_open_id : open_id -> string
 
@@ -60,9 +60,9 @@ module Open_id : sig
   type nonrec t = open_id
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -71,9 +71,9 @@ type id = private string
 
 val create_id : string -> id
 val id_of_yojson : Yojson.Safe.t -> id
+val yojson_of_id : id -> Yojson.Safe.t
 val id_of_jsonlike : Atd_jsonlike.AST.t -> id
 val jsonlike_of_id : id -> Atd_jsonlike.AST.t
-val yojson_of_id : id -> Yojson.Safe.t
 val id_of_json : string -> id
 val json_of_id : id -> string
 
@@ -81,9 +81,9 @@ module Id : sig
   type nonrec t = id
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -91,18 +91,18 @@ end
 type ids = private id list
 
 val ids_of_yojson : Yojson.Safe.t -> ids
+val yojson_of_ids : ids -> Yojson.Safe.t
 val ids_of_jsonlike : Atd_jsonlike.AST.t -> ids
 val jsonlike_of_ids : ids -> Atd_jsonlike.AST.t
-val yojson_of_ids : ids -> Yojson.Safe.t
 val ids_of_json : string -> ids
 val json_of_ids : ids -> string
 
 module Ids : sig
   type nonrec t = ids
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -113,18 +113,18 @@ type color = private
   | Blue
 
 val color_of_yojson : Yojson.Safe.t -> color
+val yojson_of_color : color -> Yojson.Safe.t
 val color_of_jsonlike : Atd_jsonlike.AST.t -> color
 val jsonlike_of_color : color -> Atd_jsonlike.AST.t
-val yojson_of_color : color -> Yojson.Safe.t
 val color_of_json : string -> color
 val json_of_color : color -> string
 
 module Color : sig
   type nonrec t = color
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -303,16 +303,16 @@ let status_of_yojson (x : Yojson.Safe.t) : status =
   | `String "Inactive" -> `Inactive
   | _ -> Atdml_runtime.Yojson.bad_sum "status" x
 
+let yojson_of_status (x : status) : Yojson.Safe.t =
+  match x with
+  | `Active -> `String "Active"
+  | `Inactive -> `String "Inactive"
+
 let status_of_jsonlike (x : Atd_jsonlike.AST.t) : status =
   match x with
   | Atd_jsonlike.AST.String (_, "Active") -> `Active
   | Atd_jsonlike.AST.String (_, "Inactive") -> `Inactive
   | _ -> Atdml_runtime.Jsonlike.bad_sum "status" x
-
-let yojson_of_status (x : status) : Yojson.Safe.t =
-  match x with
-  | `Active -> `String "Active"
-  | `Inactive -> `String "Inactive"
 
 let jsonlike_of_status (x : status) : Atd_jsonlike.AST.t =
   match x with
@@ -328,9 +328,9 @@ let json_of_status x =
 module Status = struct
   type nonrec t = status
   let of_yojson = status_of_yojson
+  let to_yojson = yojson_of_status
   let of_jsonlike = status_of_jsonlike
   let to_jsonlike = jsonlike_of_status
-  let to_yojson = yojson_of_status
   let of_json = status_of_json
   let to_json = json_of_status
 end
@@ -369,6 +369,12 @@ let point_of_yojson (x : Yojson.Safe.t) : point =
     { x; y }
   | _ -> Atdml_runtime.Yojson.bad_type "point" x
 
+let yojson_of_point (x : point) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("x", Atdml_runtime.Yojson.yojson_of_float x.x)];
+    [("y", Atdml_runtime.Yojson.yojson_of_float x.y)];
+  ])
+
 let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -396,12 +402,6 @@ let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
     { x; y }
   | _ -> Atdml_runtime.Jsonlike.bad_type "point" x
 
-let yojson_of_point (x : point) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("x", Atdml_runtime.Yojson.yojson_of_float x.x)];
-    [("y", Atdml_runtime.Yojson.yojson_of_float x.y)];
-  ])
-
 let jsonlike_of_point (x : point) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "x", Atdml_runtime.Jsonlike.jsonlike_of_float x.x)];
@@ -418,9 +418,9 @@ module Point = struct
   type nonrec t = point
   let create = create_point
   let of_yojson = point_of_yojson
+  let to_yojson = yojson_of_point
   let of_jsonlike = point_of_jsonlike
   let to_jsonlike = jsonlike_of_point
-  let to_yojson = yojson_of_point
   let of_json = point_of_json
   let to_json = json_of_point
 end
@@ -433,11 +433,11 @@ let create_open_id (x : string) : open_id = x
 let open_id_of_yojson (x : Yojson.Safe.t) : open_id =
   Atdml_runtime.Yojson.string_of_yojson x
 
-let open_id_of_jsonlike (x : Atd_jsonlike.AST.t) : open_id =
-  Atdml_runtime.Jsonlike.string_of_jsonlike x
-
 let yojson_of_open_id (x : open_id) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
+
+let open_id_of_jsonlike (x : Atd_jsonlike.AST.t) : open_id =
+  Atdml_runtime.Jsonlike.string_of_jsonlike x
 
 let jsonlike_of_open_id (x : open_id) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_string x
@@ -452,9 +452,9 @@ module Open_id = struct
   type nonrec t = open_id
   let create = create_open_id
   let of_yojson = open_id_of_yojson
+  let to_yojson = yojson_of_open_id
   let of_jsonlike = open_id_of_jsonlike
   let to_jsonlike = jsonlike_of_open_id
-  let to_yojson = yojson_of_open_id
   let of_json = open_id_of_json
   let to_json = json_of_open_id
 end
@@ -467,11 +467,11 @@ let create_id (x : string) : id = x
 let id_of_yojson (x : Yojson.Safe.t) : id =
   Atdml_runtime.Yojson.string_of_yojson x
 
-let id_of_jsonlike (x : Atd_jsonlike.AST.t) : id =
-  Atdml_runtime.Jsonlike.string_of_jsonlike x
-
 let yojson_of_id (x : id) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
+
+let id_of_jsonlike (x : Atd_jsonlike.AST.t) : id =
+  Atdml_runtime.Jsonlike.string_of_jsonlike x
 
 let jsonlike_of_id (x : id) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_string x
@@ -486,9 +486,9 @@ module Id = struct
   type nonrec t = id
   let create = create_id
   let of_yojson = id_of_yojson
+  let to_yojson = yojson_of_id
   let of_jsonlike = id_of_jsonlike
   let to_jsonlike = jsonlike_of_id
-  let to_yojson = yojson_of_id
   let of_json = id_of_json
   let to_json = json_of_id
 end
@@ -498,11 +498,11 @@ type ids = id list
 let ids_of_yojson (x : Yojson.Safe.t) : ids =
   (Atdml_runtime.Yojson.list_of_yojson id_of_yojson) x
 
-let ids_of_jsonlike (x : Atd_jsonlike.AST.t) : ids =
-  (Atdml_runtime.Jsonlike.list_of_jsonlike id_of_jsonlike) x
-
 let yojson_of_ids (x : ids) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_id) x
+
+let ids_of_jsonlike (x : Atd_jsonlike.AST.t) : ids =
+  (Atdml_runtime.Jsonlike.list_of_jsonlike id_of_jsonlike) x
 
 let jsonlike_of_ids (x : ids) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_id) x
@@ -516,9 +516,9 @@ let json_of_ids x =
 module Ids = struct
   type nonrec t = ids
   let of_yojson = ids_of_yojson
+  let to_yojson = yojson_of_ids
   let of_jsonlike = ids_of_jsonlike
   let to_jsonlike = jsonlike_of_ids
-  let to_yojson = yojson_of_ids
   let of_json = ids_of_json
   let to_json = json_of_ids
 end
@@ -535,18 +535,18 @@ let color_of_yojson (x : Yojson.Safe.t) : color =
   | `String "Blue" -> Blue
   | _ -> Atdml_runtime.Yojson.bad_sum "color" x
 
+let yojson_of_color (x : color) : Yojson.Safe.t =
+  match x with
+  | Red -> `String "Red"
+  | Green -> `String "Green"
+  | Blue -> `String "Blue"
+
 let color_of_jsonlike (x : Atd_jsonlike.AST.t) : color =
   match x with
   | Atd_jsonlike.AST.String (_, "Red") -> Red
   | Atd_jsonlike.AST.String (_, "Green") -> Green
   | Atd_jsonlike.AST.String (_, "Blue") -> Blue
   | _ -> Atdml_runtime.Jsonlike.bad_sum "color" x
-
-let yojson_of_color (x : color) : Yojson.Safe.t =
-  match x with
-  | Red -> `String "Red"
-  | Green -> `String "Green"
-  | Blue -> `String "Blue"
 
 let jsonlike_of_color (x : color) : Atd_jsonlike.AST.t =
   match x with
@@ -563,9 +563,9 @@ let json_of_color x =
 module Color = struct
   type nonrec t = color
   let of_yojson = color_of_yojson
+  let to_yojson = yojson_of_color
   let of_jsonlike = color_of_jsonlike
   let to_jsonlike = jsonlike_of_color
-  let to_yojson = yojson_of_color
   let of_json = color_of_json
   let to_json = json_of_color
 end

--- a/atdml/tests/named-snapshots/parametric_types
+++ b/atdml/tests/named-snapshots/parametric_types
@@ -8,6 +8,10 @@ val result_of_yojson :
   (Yojson.Safe.t -> 'a) ->
   Yojson.Safe.t ->
   'a result
+val yojson_of_result :
+  ('a -> Yojson.Safe.t) ->
+  'a result ->
+  Yojson.Safe.t
 val result_of_jsonlike :
   (Atd_jsonlike.AST.t -> 'a) ->
   Atd_jsonlike.AST.t ->
@@ -16,10 +20,6 @@ val jsonlike_of_result :
   ('a -> Atd_jsonlike.AST.t) ->
   'a result ->
   Atd_jsonlike.AST.t
-val yojson_of_result :
-  ('a -> Yojson.Safe.t) ->
-  'a result ->
-  Yojson.Safe.t
 val result_of_json :
   (Yojson.Safe.t -> 'a) ->
   string ->
@@ -35,6 +35,10 @@ module Result : sig
     (Yojson.Safe.t -> 'a) ->
     Yojson.Safe.t ->
     'a t
+  val to_yojson :
+    ('a -> Yojson.Safe.t) ->
+    'a t ->
+    Yojson.Safe.t
   val of_jsonlike :
     (Atd_jsonlike.AST.t -> 'a) ->
     Atd_jsonlike.AST.t ->
@@ -43,10 +47,6 @@ module Result : sig
     ('a -> Atd_jsonlike.AST.t) ->
     'a t ->
     Atd_jsonlike.AST.t
-  val to_yojson :
-    ('a -> Yojson.Safe.t) ->
-    'a t ->
-    Yojson.Safe.t
   val of_json :
     (Yojson.Safe.t -> 'a) ->
     string ->
@@ -66,6 +66,11 @@ val either_of_yojson :
   (Yojson.Safe.t -> 'b) ->
   Yojson.Safe.t ->
   ('a, 'b) either
+val yojson_of_either :
+  ('a -> Yojson.Safe.t) ->
+  ('b -> Yojson.Safe.t) ->
+  ('a, 'b) either ->
+  Yojson.Safe.t
 val either_of_jsonlike :
   (Atd_jsonlike.AST.t -> 'a) ->
   (Atd_jsonlike.AST.t -> 'b) ->
@@ -76,11 +81,6 @@ val jsonlike_of_either :
   ('b -> Atd_jsonlike.AST.t) ->
   ('a, 'b) either ->
   Atd_jsonlike.AST.t
-val yojson_of_either :
-  ('a -> Yojson.Safe.t) ->
-  ('b -> Yojson.Safe.t) ->
-  ('a, 'b) either ->
-  Yojson.Safe.t
 val either_of_json :
   (Yojson.Safe.t -> 'a) ->
   (Yojson.Safe.t -> 'b) ->
@@ -99,6 +99,11 @@ module Either : sig
     (Yojson.Safe.t -> 'b) ->
     Yojson.Safe.t ->
     ('a, 'b) t
+  val to_yojson :
+    ('a -> Yojson.Safe.t) ->
+    ('b -> Yojson.Safe.t) ->
+    ('a, 'b) t ->
+    Yojson.Safe.t
   val of_jsonlike :
     (Atd_jsonlike.AST.t -> 'a) ->
     (Atd_jsonlike.AST.t -> 'b) ->
@@ -109,11 +114,6 @@ module Either : sig
     ('b -> Atd_jsonlike.AST.t) ->
     ('a, 'b) t ->
     Atd_jsonlike.AST.t
-  val to_yojson :
-    ('a -> Yojson.Safe.t) ->
-    ('b -> Yojson.Safe.t) ->
-    ('a, 'b) t ->
-    Yojson.Safe.t
   val of_json :
     (Yojson.Safe.t -> 'a) ->
     (Yojson.Safe.t -> 'b) ->
@@ -129,18 +129,18 @@ end
 type all = ((int) result * (bool, string) either)
 
 val all_of_yojson : Yojson.Safe.t -> all
+val yojson_of_all : all -> Yojson.Safe.t
 val all_of_jsonlike : Atd_jsonlike.AST.t -> all
 val jsonlike_of_all : all -> Atd_jsonlike.AST.t
-val yojson_of_all : all -> Yojson.Safe.t
 val all_of_json : string -> all
 val json_of_all : all -> string
 
 module All : sig
   type nonrec t = all
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -319,18 +319,18 @@ let result_of_yojson : 'a. (Yojson.Safe.t -> 'a) -> Yojson.Safe.t -> 'a result =
     | `List [`String "Error"; v] -> Error (Atdml_runtime.Yojson.string_of_yojson v)
     | _ -> Atdml_runtime.Yojson.bad_sum "result" x
 
+let yojson_of_result : 'a. ('a -> Yojson.Safe.t) -> 'a result -> Yojson.Safe.t =
+  fun yojson_of_a x ->
+    match x with
+    | Ok v -> `List [`String "Ok"; yojson_of_a v]
+    | Error v -> `List [`String "Error"; Atdml_runtime.Yojson.yojson_of_string v]
+
 let result_of_jsonlike : 'a. (Atd_jsonlike.AST.t -> 'a) -> Atd_jsonlike.AST.t -> 'a result =
   fun of_jsonlike_a x ->
     match x with
     | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Ok"); v]) -> Ok (of_jsonlike_a v)
     | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Error"); v]) -> Error (Atdml_runtime.Jsonlike.string_of_jsonlike v)
     | _ -> Atdml_runtime.Jsonlike.bad_sum "result" x
-
-let yojson_of_result : 'a. ('a -> Yojson.Safe.t) -> 'a result -> Yojson.Safe.t =
-  fun yojson_of_a x ->
-    match x with
-    | Ok v -> `List [`String "Ok"; yojson_of_a v]
-    | Error v -> `List [`String "Error"; Atdml_runtime.Yojson.yojson_of_string v]
 
 let jsonlike_of_result : 'a. ('a -> Atd_jsonlike.AST.t) -> 'a result -> Atd_jsonlike.AST.t =
   fun jsonlike_of_a x ->
@@ -347,9 +347,9 @@ let json_of_result yojson_of_a x =
 module Result = struct
   type nonrec 'a t = 'a result
   let of_yojson = result_of_yojson
+  let to_yojson = yojson_of_result
   let of_jsonlike = result_of_jsonlike
   let to_jsonlike = jsonlike_of_result
-  let to_yojson = yojson_of_result
   let of_json = result_of_json
   let to_json = json_of_result
 end
@@ -365,18 +365,18 @@ let either_of_yojson : 'a 'b. (Yojson.Safe.t -> 'a) -> (Yojson.Safe.t -> 'b) -> 
     | `List [`String "Right"; v] -> Right (of_yojson_b v)
     | _ -> Atdml_runtime.Yojson.bad_sum "either" x
 
+let yojson_of_either : 'a 'b. ('a -> Yojson.Safe.t) -> ('b -> Yojson.Safe.t) -> ('a, 'b) either -> Yojson.Safe.t =
+  fun yojson_of_a yojson_of_b x ->
+    match x with
+    | Left v -> `List [`String "Left"; yojson_of_a v]
+    | Right v -> `List [`String "Right"; yojson_of_b v]
+
 let either_of_jsonlike : 'a 'b. (Atd_jsonlike.AST.t -> 'a) -> (Atd_jsonlike.AST.t -> 'b) -> Atd_jsonlike.AST.t -> ('a, 'b) either =
   fun of_jsonlike_a of_jsonlike_b x ->
     match x with
     | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Left"); v]) -> Left (of_jsonlike_a v)
     | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Right"); v]) -> Right (of_jsonlike_b v)
     | _ -> Atdml_runtime.Jsonlike.bad_sum "either" x
-
-let yojson_of_either : 'a 'b. ('a -> Yojson.Safe.t) -> ('b -> Yojson.Safe.t) -> ('a, 'b) either -> Yojson.Safe.t =
-  fun yojson_of_a yojson_of_b x ->
-    match x with
-    | Left v -> `List [`String "Left"; yojson_of_a v]
-    | Right v -> `List [`String "Right"; yojson_of_b v]
 
 let jsonlike_of_either : 'a 'b. ('a -> Atd_jsonlike.AST.t) -> ('b -> Atd_jsonlike.AST.t) -> ('a, 'b) either -> Atd_jsonlike.AST.t =
   fun jsonlike_of_a jsonlike_of_b x ->
@@ -393,9 +393,9 @@ let json_of_either yojson_of_a yojson_of_b x =
 module Either = struct
   type nonrec ('a, 'b) t = ('a, 'b) either
   let of_yojson = either_of_yojson
+  let to_yojson = yojson_of_either
   let of_jsonlike = either_of_jsonlike
   let to_jsonlike = jsonlike_of_either
-  let to_yojson = yojson_of_either
   let of_json = either_of_json
   let to_json = json_of_either
 end
@@ -405,11 +405,11 @@ type all = ((int) result * (bool, string) either)
 let all_of_yojson (x : Yojson.Safe.t) : all =
   (fun x -> match x with | `List lst when List.length lst = 2 -> ((result_of_yojson Atdml_runtime.Yojson.int_of_yojson) (List.nth lst 0), (either_of_yojson Atdml_runtime.Yojson.bool_of_yojson Atdml_runtime.Yojson.string_of_yojson) (List.nth lst 1)) | _ -> Atdml_runtime.Yojson.bad_type "tuple" x) x
 
-let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
-  (fun x -> match x with | Atd_jsonlike.AST.Array (_, lst) when List.length lst = 2 -> ((result_of_jsonlike Atdml_runtime.Jsonlike.int_of_jsonlike) (List.nth lst 0), (either_of_jsonlike Atdml_runtime.Jsonlike.bool_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) (List.nth lst 1)) | _ -> Atdml_runtime.Jsonlike.bad_type "tuple" x) x
-
 let yojson_of_all (x : all) : Yojson.Safe.t =
   (fun (x0, x1) -> `List [(yojson_of_result Atdml_runtime.Yojson.yojson_of_int) x0; (yojson_of_either Atdml_runtime.Yojson.yojson_of_bool Atdml_runtime.Yojson.yojson_of_string) x1]) x
+
+let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
+  (fun x -> match x with | Atd_jsonlike.AST.Array (_, lst) when List.length lst = 2 -> ((result_of_jsonlike Atdml_runtime.Jsonlike.int_of_jsonlike) (List.nth lst 0), (either_of_jsonlike Atdml_runtime.Jsonlike.bool_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) (List.nth lst 1)) | _ -> Atdml_runtime.Jsonlike.bad_type "tuple" x) x
 
 let jsonlike_of_all (x : all) : Atd_jsonlike.AST.t =
   (fun (x0, x1) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [(jsonlike_of_result Atdml_runtime.Jsonlike.jsonlike_of_int) x0; (jsonlike_of_either Atdml_runtime.Jsonlike.jsonlike_of_bool Atdml_runtime.Jsonlike.jsonlike_of_string) x1])) x
@@ -423,9 +423,9 @@ let json_of_all x =
 module All = struct
   type nonrec t = all
   let of_yojson = all_of_yojson
+  let to_yojson = yojson_of_all
   let of_jsonlike = all_of_jsonlike
   let to_jsonlike = jsonlike_of_all
-  let to_yojson = yojson_of_all
   let of_json = all_of_json
   let to_json = json_of_all
 end

--- a/atdml/tests/named-snapshots/parametric_types
+++ b/atdml/tests/named-snapshots/parametric_types
@@ -12,6 +12,10 @@ val result_of_jsonlike :
   (Atd_jsonlike.AST.t -> 'a) ->
   Atd_jsonlike.AST.t ->
   'a result
+val jsonlike_of_result :
+  ('a -> Atd_jsonlike.AST.t) ->
+  'a result ->
+  Atd_jsonlike.AST.t
 val yojson_of_result :
   ('a -> Yojson.Safe.t) ->
   'a result ->
@@ -35,6 +39,10 @@ module Result : sig
     (Atd_jsonlike.AST.t -> 'a) ->
     Atd_jsonlike.AST.t ->
     'a t
+  val to_jsonlike :
+    ('a -> Atd_jsonlike.AST.t) ->
+    'a t ->
+    Atd_jsonlike.AST.t
   val to_yojson :
     ('a -> Yojson.Safe.t) ->
     'a t ->
@@ -63,6 +71,11 @@ val either_of_jsonlike :
   (Atd_jsonlike.AST.t -> 'b) ->
   Atd_jsonlike.AST.t ->
   ('a, 'b) either
+val jsonlike_of_either :
+  ('a -> Atd_jsonlike.AST.t) ->
+  ('b -> Atd_jsonlike.AST.t) ->
+  ('a, 'b) either ->
+  Atd_jsonlike.AST.t
 val yojson_of_either :
   ('a -> Yojson.Safe.t) ->
   ('b -> Yojson.Safe.t) ->
@@ -91,6 +104,11 @@ module Either : sig
     (Atd_jsonlike.AST.t -> 'b) ->
     Atd_jsonlike.AST.t ->
     ('a, 'b) t
+  val to_jsonlike :
+    ('a -> Atd_jsonlike.AST.t) ->
+    ('b -> Atd_jsonlike.AST.t) ->
+    ('a, 'b) t ->
+    Atd_jsonlike.AST.t
   val to_yojson :
     ('a -> Yojson.Safe.t) ->
     ('b -> Yojson.Safe.t) ->
@@ -112,6 +130,7 @@ type all = ((int) result * (bool, string) either)
 
 val all_of_yojson : Yojson.Safe.t -> all
 val all_of_jsonlike : Atd_jsonlike.AST.t -> all
+val jsonlike_of_all : all -> Atd_jsonlike.AST.t
 val yojson_of_all : all -> Yojson.Safe.t
 val all_of_json : string -> all
 val json_of_all : all -> string
@@ -120,6 +139,7 @@ module All : sig
   type nonrec t = all
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -268,6 +288,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -295,6 +332,12 @@ let yojson_of_result : 'a. ('a -> Yojson.Safe.t) -> 'a result -> Yojson.Safe.t =
     | Ok v -> `List [`String "Ok"; yojson_of_a v]
     | Error v -> `List [`String "Error"; Atdml_runtime.Yojson.yojson_of_string v]
 
+let jsonlike_of_result : 'a. ('a -> Atd_jsonlike.AST.t) -> 'a result -> Atd_jsonlike.AST.t =
+  fun jsonlike_of_a x ->
+    match x with
+    | Ok v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Ok"); jsonlike_of_a v])
+    | Error v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Error"); Atdml_runtime.Jsonlike.jsonlike_of_string v])
+
 let result_of_json of_yojson_a s =
   (result_of_yojson of_yojson_a) (Yojson.Safe.from_string s)
 
@@ -305,6 +348,7 @@ module Result = struct
   type nonrec 'a t = 'a result
   let of_yojson = result_of_yojson
   let of_jsonlike = result_of_jsonlike
+  let to_jsonlike = jsonlike_of_result
   let to_yojson = yojson_of_result
   let of_json = result_of_json
   let to_json = json_of_result
@@ -334,6 +378,12 @@ let yojson_of_either : 'a 'b. ('a -> Yojson.Safe.t) -> ('b -> Yojson.Safe.t) -> 
     | Left v -> `List [`String "Left"; yojson_of_a v]
     | Right v -> `List [`String "Right"; yojson_of_b v]
 
+let jsonlike_of_either : 'a 'b. ('a -> Atd_jsonlike.AST.t) -> ('b -> Atd_jsonlike.AST.t) -> ('a, 'b) either -> Atd_jsonlike.AST.t =
+  fun jsonlike_of_a jsonlike_of_b x ->
+    match x with
+    | Left v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Left"); jsonlike_of_a v])
+    | Right v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Right"); jsonlike_of_b v])
+
 let either_of_json of_yojson_a of_yojson_b s =
   (either_of_yojson of_yojson_a of_yojson_b) (Yojson.Safe.from_string s)
 
@@ -344,6 +394,7 @@ module Either = struct
   type nonrec ('a, 'b) t = ('a, 'b) either
   let of_yojson = either_of_yojson
   let of_jsonlike = either_of_jsonlike
+  let to_jsonlike = jsonlike_of_either
   let to_yojson = yojson_of_either
   let of_json = either_of_json
   let to_json = json_of_either
@@ -360,6 +411,9 @@ let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
 let yojson_of_all (x : all) : Yojson.Safe.t =
   (fun (x0, x1) -> `List [(yojson_of_result Atdml_runtime.Yojson.yojson_of_int) x0; (yojson_of_either Atdml_runtime.Yojson.yojson_of_bool Atdml_runtime.Yojson.yojson_of_string) x1]) x
 
+let jsonlike_of_all (x : all) : Atd_jsonlike.AST.t =
+  (fun (x0, x1) -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [(jsonlike_of_result Atdml_runtime.Jsonlike.jsonlike_of_int) x0; (jsonlike_of_either Atdml_runtime.Jsonlike.jsonlike_of_bool Atdml_runtime.Jsonlike.jsonlike_of_string) x1])) x
+
 let all_of_json s =
   all_of_yojson (Yojson.Safe.from_string s)
 
@@ -370,6 +424,7 @@ module All = struct
   type nonrec t = all
   let of_yojson = all_of_yojson
   let of_jsonlike = all_of_jsonlike
+  let to_jsonlike = jsonlike_of_all
   let to_yojson = yojson_of_all
   let of_json = all_of_json
   let to_json = json_of_all

--- a/atdml/tests/named-snapshots/polymorphic_variants
+++ b/atdml/tests/named-snapshots/polymorphic_variants
@@ -7,18 +7,18 @@ type status = [
 ]
 
 val status_of_yojson : Yojson.Safe.t -> status
+val yojson_of_status : status -> Yojson.Safe.t
 val status_of_jsonlike : Atd_jsonlike.AST.t -> status
 val jsonlike_of_status : status -> Atd_jsonlike.AST.t
-val yojson_of_status : status -> Yojson.Safe.t
 val status_of_json : string -> status
 val json_of_status : status -> string
 
 module Status : sig
   type nonrec t = status
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -26,18 +26,18 @@ end
 type statuses = status list
 
 val statuses_of_yojson : Yojson.Safe.t -> statuses
+val yojson_of_statuses : statuses -> Yojson.Safe.t
 val statuses_of_jsonlike : Atd_jsonlike.AST.t -> statuses
 val jsonlike_of_statuses : statuses -> Atd_jsonlike.AST.t
-val yojson_of_statuses : statuses -> Yojson.Safe.t
 val statuses_of_json : string -> statuses
 val json_of_statuses : statuses -> string
 
 module Statuses : sig
   type nonrec t = statuses
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -218,18 +218,18 @@ let status_of_yojson (x : Yojson.Safe.t) : status =
   | `List [`String "Pending"; v] -> `Pending (Atdml_runtime.Yojson.string_of_yojson v)
   | _ -> Atdml_runtime.Yojson.bad_sum "status" x
 
+let yojson_of_status (x : status) : Yojson.Safe.t =
+  match x with
+  | `Active -> `String "Active"
+  | `Inactive -> `String "Inactive"
+  | `Pending v -> `List [`String "Pending"; Atdml_runtime.Yojson.yojson_of_string v]
+
 let status_of_jsonlike (x : Atd_jsonlike.AST.t) : status =
   match x with
   | Atd_jsonlike.AST.String (_, "Active") -> `Active
   | Atd_jsonlike.AST.String (_, "Inactive") -> `Inactive
   | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Pending"); v]) -> `Pending (Atdml_runtime.Jsonlike.string_of_jsonlike v)
   | _ -> Atdml_runtime.Jsonlike.bad_sum "status" x
-
-let yojson_of_status (x : status) : Yojson.Safe.t =
-  match x with
-  | `Active -> `String "Active"
-  | `Inactive -> `String "Inactive"
-  | `Pending v -> `List [`String "Pending"; Atdml_runtime.Yojson.yojson_of_string v]
 
 let jsonlike_of_status (x : status) : Atd_jsonlike.AST.t =
   match x with
@@ -246,9 +246,9 @@ let json_of_status x =
 module Status = struct
   type nonrec t = status
   let of_yojson = status_of_yojson
+  let to_yojson = yojson_of_status
   let of_jsonlike = status_of_jsonlike
   let to_jsonlike = jsonlike_of_status
-  let to_yojson = yojson_of_status
   let of_json = status_of_json
   let to_json = json_of_status
 end
@@ -258,11 +258,11 @@ type statuses = status list
 let statuses_of_yojson (x : Yojson.Safe.t) : statuses =
   (Atdml_runtime.Yojson.list_of_yojson status_of_yojson) x
 
-let statuses_of_jsonlike (x : Atd_jsonlike.AST.t) : statuses =
-  (Atdml_runtime.Jsonlike.list_of_jsonlike status_of_jsonlike) x
-
 let yojson_of_statuses (x : statuses) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_status) x
+
+let statuses_of_jsonlike (x : Atd_jsonlike.AST.t) : statuses =
+  (Atdml_runtime.Jsonlike.list_of_jsonlike status_of_jsonlike) x
 
 let jsonlike_of_statuses (x : statuses) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_status) x
@@ -276,9 +276,9 @@ let json_of_statuses x =
 module Statuses = struct
   type nonrec t = statuses
   let of_yojson = statuses_of_yojson
+  let to_yojson = yojson_of_statuses
   let of_jsonlike = statuses_of_jsonlike
   let to_jsonlike = jsonlike_of_statuses
-  let to_yojson = yojson_of_statuses
   let of_json = statuses_of_json
   let to_json = json_of_statuses
 end

--- a/atdml/tests/named-snapshots/polymorphic_variants
+++ b/atdml/tests/named-snapshots/polymorphic_variants
@@ -8,6 +8,7 @@ type status = [
 
 val status_of_yojson : Yojson.Safe.t -> status
 val status_of_jsonlike : Atd_jsonlike.AST.t -> status
+val jsonlike_of_status : status -> Atd_jsonlike.AST.t
 val yojson_of_status : status -> Yojson.Safe.t
 val status_of_json : string -> status
 val json_of_status : status -> string
@@ -16,6 +17,7 @@ module Status : sig
   type nonrec t = status
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -25,6 +27,7 @@ type statuses = status list
 
 val statuses_of_yojson : Yojson.Safe.t -> statuses
 val statuses_of_jsonlike : Atd_jsonlike.AST.t -> statuses
+val jsonlike_of_statuses : statuses -> Atd_jsonlike.AST.t
 val yojson_of_statuses : statuses -> Yojson.Safe.t
 val statuses_of_json : string -> statuses
 val json_of_statuses : statuses -> string
@@ -33,6 +36,7 @@ module Statuses : sig
   type nonrec t = statuses
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -181,6 +185,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -210,6 +231,12 @@ let yojson_of_status (x : status) : Yojson.Safe.t =
   | `Inactive -> `String "Inactive"
   | `Pending v -> `List [`String "Pending"; Atdml_runtime.Yojson.yojson_of_string v]
 
+let jsonlike_of_status (x : status) : Atd_jsonlike.AST.t =
+  match x with
+  | `Active -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Active")
+  | `Inactive -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Inactive")
+  | `Pending v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Pending"); Atdml_runtime.Jsonlike.jsonlike_of_string v])
+
 let status_of_json s =
   status_of_yojson (Yojson.Safe.from_string s)
 
@@ -220,6 +247,7 @@ module Status = struct
   type nonrec t = status
   let of_yojson = status_of_yojson
   let of_jsonlike = status_of_jsonlike
+  let to_jsonlike = jsonlike_of_status
   let to_yojson = yojson_of_status
   let of_json = status_of_json
   let to_json = json_of_status
@@ -236,6 +264,9 @@ let statuses_of_jsonlike (x : Atd_jsonlike.AST.t) : statuses =
 let yojson_of_statuses (x : statuses) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list yojson_of_status) x
 
+let jsonlike_of_statuses (x : statuses) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_status) x
+
 let statuses_of_json s =
   statuses_of_yojson (Yojson.Safe.from_string s)
 
@@ -246,6 +277,7 @@ module Statuses = struct
   type nonrec t = statuses
   let of_yojson = statuses_of_yojson
   let of_jsonlike = statuses_of_jsonlike
+  let to_jsonlike = jsonlike_of_statuses
   let to_yojson = yojson_of_statuses
   let of_json = statuses_of_json
   let to_json = json_of_statuses

--- a/atdml/tests/named-snapshots/records
+++ b/atdml/tests/named-snapshots/records
@@ -14,9 +14,9 @@ type person = {
 
 val create_person : name:string -> age:int -> lol:int option -> ?email:string -> ?score:float -> ?active:bool -> ?tags:string list -> ?level:int -> address:string -> unit -> person
 val person_of_yojson : Yojson.Safe.t -> person
+val yojson_of_person : person -> Yojson.Safe.t
 val person_of_jsonlike : Atd_jsonlike.AST.t -> person
 val jsonlike_of_person : person -> Atd_jsonlike.AST.t
-val yojson_of_person : person -> Yojson.Safe.t
 val person_of_json : string -> person
 val json_of_person : person -> string
 
@@ -24,9 +24,9 @@ module Person : sig
   type nonrec t = person
   val create : name:string -> age:int -> lol:int option -> ?email:string -> ?score:float -> ?active:bool -> ?tags:string list -> ?level:int -> address:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -270,6 +270,19 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
     { name; age; lol; email; score; active; tags; level; address }
   | _ -> Atdml_runtime.Yojson.bad_type "person" x
 
+let yojson_of_person (x : person) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("name", Atdml_runtime.Yojson.yojson_of_string x.name)];
+    [("age", Atdml_runtime.Yojson.yojson_of_int x.age)];
+    [("lol", (Atdml_runtime.Yojson.yojson_of_nullable Atdml_runtime.Yojson.yojson_of_int) x.lol)];
+    (match x.email with None -> [] | Some v -> [("email", Atdml_runtime.Yojson.yojson_of_string v)]);
+    [("score", Atdml_runtime.Yojson.yojson_of_float x.score)];
+    [("active", Atdml_runtime.Yojson.yojson_of_bool x.active)];
+    [("tags", (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x.tags)];
+    [("level", Atdml_runtime.Yojson.yojson_of_int x.level)];
+    [("addr", Atdml_runtime.Yojson.yojson_of_string x.address)];
+  ])
+
 let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -332,19 +345,6 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
     { name; age; lol; email; score; active; tags; level; address }
   | _ -> Atdml_runtime.Jsonlike.bad_type "person" x
 
-let yojson_of_person (x : person) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("name", Atdml_runtime.Yojson.yojson_of_string x.name)];
-    [("age", Atdml_runtime.Yojson.yojson_of_int x.age)];
-    [("lol", (Atdml_runtime.Yojson.yojson_of_nullable Atdml_runtime.Yojson.yojson_of_int) x.lol)];
-    (match x.email with None -> [] | Some v -> [("email", Atdml_runtime.Yojson.yojson_of_string v)]);
-    [("score", Atdml_runtime.Yojson.yojson_of_float x.score)];
-    [("active", Atdml_runtime.Yojson.yojson_of_bool x.active)];
-    [("tags", (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x.tags)];
-    [("level", Atdml_runtime.Yojson.yojson_of_int x.level)];
-    [("addr", Atdml_runtime.Yojson.yojson_of_string x.address)];
-  ])
-
 let jsonlike_of_person (x : person) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "name", Atdml_runtime.Jsonlike.jsonlike_of_string x.name)];
@@ -368,9 +368,9 @@ module Person = struct
   type nonrec t = person
   let create = create_person
   let of_yojson = person_of_yojson
+  let to_yojson = yojson_of_person
   let of_jsonlike = person_of_jsonlike
   let to_jsonlike = jsonlike_of_person
-  let to_yojson = yojson_of_person
   let of_json = person_of_json
   let to_json = json_of_person
 end

--- a/atdml/tests/named-snapshots/records
+++ b/atdml/tests/named-snapshots/records
@@ -15,6 +15,7 @@ type person = {
 val create_person : name:string -> age:int -> lol:int option -> ?email:string -> ?score:float -> ?active:bool -> ?tags:string list -> ?level:int -> address:string -> unit -> person
 val person_of_yojson : Yojson.Safe.t -> person
 val person_of_jsonlike : Atd_jsonlike.AST.t -> person
+val jsonlike_of_person : person -> Atd_jsonlike.AST.t
 val yojson_of_person : person -> Yojson.Safe.t
 val person_of_json : string -> person
 val json_of_person : person -> string
@@ -24,6 +25,7 @@ module Person : sig
   val create : name:string -> age:int -> lol:int option -> ?email:string -> ?score:float -> ?active:bool -> ?tags:string list -> ?level:int -> address:string -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -172,6 +174,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -326,6 +345,19 @@ let yojson_of_person (x : person) : Yojson.Safe.t =
     [("addr", Atdml_runtime.Yojson.yojson_of_string x.address)];
   ])
 
+let jsonlike_of_person (x : person) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "name", Atdml_runtime.Jsonlike.jsonlike_of_string x.name)];
+    [(Atd_jsonlike.Loc.zero, "age", Atdml_runtime.Jsonlike.jsonlike_of_int x.age)];
+    [(Atd_jsonlike.Loc.zero, "lol", (Atdml_runtime.Jsonlike.jsonlike_of_nullable Atdml_runtime.Jsonlike.jsonlike_of_int) x.lol)];
+    (match x.email with None -> [] | Some v -> [(Atd_jsonlike.Loc.zero, "email", Atdml_runtime.Jsonlike.jsonlike_of_string v)]);
+    [(Atd_jsonlike.Loc.zero, "score", Atdml_runtime.Jsonlike.jsonlike_of_float x.score)];
+    [(Atd_jsonlike.Loc.zero, "active", Atdml_runtime.Jsonlike.jsonlike_of_bool x.active)];
+    [(Atd_jsonlike.Loc.zero, "tags", (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string) x.tags)];
+    [(Atd_jsonlike.Loc.zero, "level", Atdml_runtime.Jsonlike.jsonlike_of_int x.level)];
+    [(Atd_jsonlike.Loc.zero, "addr", Atdml_runtime.Jsonlike.jsonlike_of_string x.address)];
+  ])
+
 let person_of_json s =
   person_of_yojson (Yojson.Safe.from_string s)
 
@@ -337,6 +369,7 @@ module Person = struct
   let create = create_person
   let of_yojson = person_of_yojson
   let of_jsonlike = person_of_jsonlike
+  let to_jsonlike = jsonlike_of_person
   let to_yojson = yojson_of_person
   let of_json = person_of_json
   let to_json = json_of_person

--- a/atdml/tests/named-snapshots/type_aliases
+++ b/atdml/tests/named-snapshots/type_aliases
@@ -3,18 +3,18 @@
 type tag_list = string list
 
 val tag_list_of_yojson : Yojson.Safe.t -> tag_list
+val yojson_of_tag_list : tag_list -> Yojson.Safe.t
 val tag_list_of_jsonlike : Atd_jsonlike.AST.t -> tag_list
 val jsonlike_of_tag_list : tag_list -> Atd_jsonlike.AST.t
-val yojson_of_tag_list : tag_list -> Yojson.Safe.t
 val tag_list_of_json : string -> tag_list
 val json_of_tag_list : tag_list -> string
 
 module Tag_list : sig
   type nonrec t = tag_list
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -23,9 +23,9 @@ type score = private float
 
 val create_score : float -> score
 val score_of_yojson : Yojson.Safe.t -> score
+val yojson_of_score : score -> Yojson.Safe.t
 val score_of_jsonlike : Atd_jsonlike.AST.t -> score
 val jsonlike_of_score : score -> Atd_jsonlike.AST.t
-val yojson_of_score : score -> Yojson.Safe.t
 val score_of_json : string -> score
 val json_of_score : score -> string
 
@@ -33,9 +33,9 @@ module Score : sig
   type nonrec t = score
   val create : float -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -43,18 +43,18 @@ end
 type opt_name = string option
 
 val opt_name_of_yojson : Yojson.Safe.t -> opt_name
+val yojson_of_opt_name : opt_name -> Yojson.Safe.t
 val opt_name_of_jsonlike : Atd_jsonlike.AST.t -> opt_name
 val jsonlike_of_opt_name : opt_name -> Atd_jsonlike.AST.t
-val yojson_of_opt_name : opt_name -> Yojson.Safe.t
 val opt_name_of_json : string -> opt_name
 val json_of_opt_name : opt_name -> string
 
 module Opt_name : sig
   type nonrec t = opt_name
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -63,9 +63,9 @@ type id = private string
 
 val create_id : string -> id
 val id_of_yojson : Yojson.Safe.t -> id
+val yojson_of_id : id -> Yojson.Safe.t
 val id_of_jsonlike : Atd_jsonlike.AST.t -> id
 val jsonlike_of_id : id -> Atd_jsonlike.AST.t
-val yojson_of_id : id -> Yojson.Safe.t
 val id_of_json : string -> id
 val json_of_id : id -> string
 
@@ -73,9 +73,9 @@ module Id : sig
   type nonrec t = id
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -89,9 +89,9 @@ type all = {
 
 val create_all : id:id -> score:score -> tags:tag_list -> name:opt_name -> unit -> all
 val all_of_yojson : Yojson.Safe.t -> all
+val yojson_of_all : all -> Yojson.Safe.t
 val all_of_jsonlike : Atd_jsonlike.AST.t -> all
 val jsonlike_of_all : all -> Atd_jsonlike.AST.t
-val yojson_of_all : all -> Yojson.Safe.t
 val all_of_json : string -> all
 val json_of_all : all -> string
 
@@ -99,9 +99,9 @@ module All : sig
   type nonrec t = all
   val create : id:id -> score:score -> tags:tag_list -> name:opt_name -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -274,11 +274,11 @@ type tag_list = string list
 let tag_list_of_yojson (x : Yojson.Safe.t) : tag_list =
   (Atdml_runtime.Yojson.list_of_yojson Atdml_runtime.Yojson.string_of_yojson) x
 
-let tag_list_of_jsonlike (x : Atd_jsonlike.AST.t) : tag_list =
-  (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) x
-
 let yojson_of_tag_list (x : tag_list) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x
+
+let tag_list_of_jsonlike (x : Atd_jsonlike.AST.t) : tag_list =
+  (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) x
 
 let jsonlike_of_tag_list (x : tag_list) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string) x
@@ -292,9 +292,9 @@ let json_of_tag_list x =
 module Tag_list = struct
   type nonrec t = tag_list
   let of_yojson = tag_list_of_yojson
+  let to_yojson = yojson_of_tag_list
   let of_jsonlike = tag_list_of_jsonlike
   let to_jsonlike = jsonlike_of_tag_list
-  let to_yojson = yojson_of_tag_list
   let of_json = tag_list_of_json
   let to_json = json_of_tag_list
 end
@@ -307,11 +307,11 @@ let create_score (x : float) : score = x
 let score_of_yojson (x : Yojson.Safe.t) : score =
   Atdml_runtime.Yojson.float_of_yojson x
 
-let score_of_jsonlike (x : Atd_jsonlike.AST.t) : score =
-  Atdml_runtime.Jsonlike.float_of_jsonlike x
-
 let yojson_of_score (x : score) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_float x
+
+let score_of_jsonlike (x : Atd_jsonlike.AST.t) : score =
+  Atdml_runtime.Jsonlike.float_of_jsonlike x
 
 let jsonlike_of_score (x : score) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_float x
@@ -326,9 +326,9 @@ module Score = struct
   type nonrec t = score
   let create = create_score
   let of_yojson = score_of_yojson
+  let to_yojson = yojson_of_score
   let of_jsonlike = score_of_jsonlike
   let to_jsonlike = jsonlike_of_score
-  let to_yojson = yojson_of_score
   let of_json = score_of_json
   let to_json = json_of_score
 end
@@ -338,11 +338,11 @@ type opt_name = string option
 let opt_name_of_yojson (x : Yojson.Safe.t) : opt_name =
   (Atdml_runtime.Yojson.option_of_yojson Atdml_runtime.Yojson.string_of_yojson) x
 
-let opt_name_of_jsonlike (x : Atd_jsonlike.AST.t) : opt_name =
-  (Atdml_runtime.Jsonlike.option_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) x
-
 let yojson_of_opt_name (x : opt_name) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_option Atdml_runtime.Yojson.yojson_of_string) x
+
+let opt_name_of_jsonlike (x : Atd_jsonlike.AST.t) : opt_name =
+  (Atdml_runtime.Jsonlike.option_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) x
 
 let jsonlike_of_opt_name (x : opt_name) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_option Atdml_runtime.Jsonlike.jsonlike_of_string) x
@@ -356,9 +356,9 @@ let json_of_opt_name x =
 module Opt_name = struct
   type nonrec t = opt_name
   let of_yojson = opt_name_of_yojson
+  let to_yojson = yojson_of_opt_name
   let of_jsonlike = opt_name_of_jsonlike
   let to_jsonlike = jsonlike_of_opt_name
-  let to_yojson = yojson_of_opt_name
   let of_json = opt_name_of_json
   let to_json = json_of_opt_name
 end
@@ -371,11 +371,11 @@ let create_id (x : string) : id = x
 let id_of_yojson (x : Yojson.Safe.t) : id =
   Atdml_runtime.Yojson.string_of_yojson x
 
-let id_of_jsonlike (x : Atd_jsonlike.AST.t) : id =
-  Atdml_runtime.Jsonlike.string_of_jsonlike x
-
 let yojson_of_id (x : id) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
+
+let id_of_jsonlike (x : Atd_jsonlike.AST.t) : id =
+  Atdml_runtime.Jsonlike.string_of_jsonlike x
 
 let jsonlike_of_id (x : id) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_string x
@@ -390,9 +390,9 @@ module Id = struct
   type nonrec t = id
   let create = create_id
   let of_yojson = id_of_yojson
+  let to_yojson = yojson_of_id
   let of_jsonlike = id_of_jsonlike
   let to_jsonlike = jsonlike_of_id
-  let to_yojson = yojson_of_id
   let of_json = id_of_json
   let to_json = json_of_id
 end
@@ -443,6 +443,14 @@ let all_of_yojson (x : Yojson.Safe.t) : all =
     { id; score; tags; name }
   | _ -> Atdml_runtime.Yojson.bad_type "all" x
 
+let yojson_of_all (x : all) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("id", yojson_of_id x.id)];
+    [("score", yojson_of_score x.score)];
+    [("tags", yojson_of_tag_list x.tags)];
+    [("name", yojson_of_opt_name x.name)];
+  ])
+
 let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -480,14 +488,6 @@ let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
     { id; score; tags; name }
   | _ -> Atdml_runtime.Jsonlike.bad_type "all" x
 
-let yojson_of_all (x : all) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("id", yojson_of_id x.id)];
-    [("score", yojson_of_score x.score)];
-    [("tags", yojson_of_tag_list x.tags)];
-    [("name", yojson_of_opt_name x.name)];
-  ])
-
 let jsonlike_of_all (x : all) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "id", jsonlike_of_id x.id)];
@@ -506,9 +506,9 @@ module All = struct
   type nonrec t = all
   let create = create_all
   let of_yojson = all_of_yojson
+  let to_yojson = yojson_of_all
   let of_jsonlike = all_of_jsonlike
   let to_jsonlike = jsonlike_of_all
-  let to_yojson = yojson_of_all
   let of_json = all_of_json
   let to_json = json_of_all
 end

--- a/atdml/tests/named-snapshots/type_aliases
+++ b/atdml/tests/named-snapshots/type_aliases
@@ -4,6 +4,7 @@ type tag_list = string list
 
 val tag_list_of_yojson : Yojson.Safe.t -> tag_list
 val tag_list_of_jsonlike : Atd_jsonlike.AST.t -> tag_list
+val jsonlike_of_tag_list : tag_list -> Atd_jsonlike.AST.t
 val yojson_of_tag_list : tag_list -> Yojson.Safe.t
 val tag_list_of_json : string -> tag_list
 val json_of_tag_list : tag_list -> string
@@ -12,6 +13,7 @@ module Tag_list : sig
   type nonrec t = tag_list
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -22,6 +24,7 @@ type score = private float
 val create_score : float -> score
 val score_of_yojson : Yojson.Safe.t -> score
 val score_of_jsonlike : Atd_jsonlike.AST.t -> score
+val jsonlike_of_score : score -> Atd_jsonlike.AST.t
 val yojson_of_score : score -> Yojson.Safe.t
 val score_of_json : string -> score
 val json_of_score : score -> string
@@ -31,6 +34,7 @@ module Score : sig
   val create : float -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -40,6 +44,7 @@ type opt_name = string option
 
 val opt_name_of_yojson : Yojson.Safe.t -> opt_name
 val opt_name_of_jsonlike : Atd_jsonlike.AST.t -> opt_name
+val jsonlike_of_opt_name : opt_name -> Atd_jsonlike.AST.t
 val yojson_of_opt_name : opt_name -> Yojson.Safe.t
 val opt_name_of_json : string -> opt_name
 val json_of_opt_name : opt_name -> string
@@ -48,6 +53,7 @@ module Opt_name : sig
   type nonrec t = opt_name
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -58,6 +64,7 @@ type id = private string
 val create_id : string -> id
 val id_of_yojson : Yojson.Safe.t -> id
 val id_of_jsonlike : Atd_jsonlike.AST.t -> id
+val jsonlike_of_id : id -> Atd_jsonlike.AST.t
 val yojson_of_id : id -> Yojson.Safe.t
 val id_of_json : string -> id
 val json_of_id : id -> string
@@ -67,6 +74,7 @@ module Id : sig
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -82,6 +90,7 @@ type all = {
 val create_all : id:id -> score:score -> tags:tag_list -> name:opt_name -> unit -> all
 val all_of_yojson : Yojson.Safe.t -> all
 val all_of_jsonlike : Atd_jsonlike.AST.t -> all
+val jsonlike_of_all : all -> Atd_jsonlike.AST.t
 val yojson_of_all : all -> Yojson.Safe.t
 val all_of_json : string -> all
 val json_of_all : all -> string
@@ -91,6 +100,7 @@ module All : sig
   val create : id:id -> score:score -> tags:tag_list -> name:opt_name -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -239,6 +249,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -253,6 +280,9 @@ let tag_list_of_jsonlike (x : Atd_jsonlike.AST.t) : tag_list =
 let yojson_of_tag_list (x : tag_list) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x
 
+let jsonlike_of_tag_list (x : tag_list) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string) x
+
 let tag_list_of_json s =
   tag_list_of_yojson (Yojson.Safe.from_string s)
 
@@ -263,6 +293,7 @@ module Tag_list = struct
   type nonrec t = tag_list
   let of_yojson = tag_list_of_yojson
   let of_jsonlike = tag_list_of_jsonlike
+  let to_jsonlike = jsonlike_of_tag_list
   let to_yojson = yojson_of_tag_list
   let of_json = tag_list_of_json
   let to_json = json_of_tag_list
@@ -282,6 +313,9 @@ let score_of_jsonlike (x : Atd_jsonlike.AST.t) : score =
 let yojson_of_score (x : score) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_float x
 
+let jsonlike_of_score (x : score) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_float x
+
 let score_of_json s =
   score_of_yojson (Yojson.Safe.from_string s)
 
@@ -293,6 +327,7 @@ module Score = struct
   let create = create_score
   let of_yojson = score_of_yojson
   let of_jsonlike = score_of_jsonlike
+  let to_jsonlike = jsonlike_of_score
   let to_yojson = yojson_of_score
   let of_json = score_of_json
   let to_json = json_of_score
@@ -309,6 +344,9 @@ let opt_name_of_jsonlike (x : Atd_jsonlike.AST.t) : opt_name =
 let yojson_of_opt_name (x : opt_name) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_option Atdml_runtime.Yojson.yojson_of_string) x
 
+let jsonlike_of_opt_name (x : opt_name) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_option Atdml_runtime.Jsonlike.jsonlike_of_string) x
+
 let opt_name_of_json s =
   opt_name_of_yojson (Yojson.Safe.from_string s)
 
@@ -319,6 +357,7 @@ module Opt_name = struct
   type nonrec t = opt_name
   let of_yojson = opt_name_of_yojson
   let of_jsonlike = opt_name_of_jsonlike
+  let to_jsonlike = jsonlike_of_opt_name
   let to_yojson = yojson_of_opt_name
   let of_json = opt_name_of_json
   let to_json = json_of_opt_name
@@ -338,6 +377,9 @@ let id_of_jsonlike (x : Atd_jsonlike.AST.t) : id =
 let yojson_of_id (x : id) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
 
+let jsonlike_of_id (x : id) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_string x
+
 let id_of_json s =
   id_of_yojson (Yojson.Safe.from_string s)
 
@@ -349,6 +391,7 @@ module Id = struct
   let create = create_id
   let of_yojson = id_of_yojson
   let of_jsonlike = id_of_jsonlike
+  let to_jsonlike = jsonlike_of_id
   let to_yojson = yojson_of_id
   let of_json = id_of_json
   let to_json = json_of_id
@@ -445,6 +488,14 @@ let yojson_of_all (x : all) : Yojson.Safe.t =
     [("name", yojson_of_opt_name x.name)];
   ])
 
+let jsonlike_of_all (x : all) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "id", jsonlike_of_id x.id)];
+    [(Atd_jsonlike.Loc.zero, "score", jsonlike_of_score x.score)];
+    [(Atd_jsonlike.Loc.zero, "tags", jsonlike_of_tag_list x.tags)];
+    [(Atd_jsonlike.Loc.zero, "name", jsonlike_of_opt_name x.name)];
+  ])
+
 let all_of_json s =
   all_of_yojson (Yojson.Safe.from_string s)
 
@@ -456,6 +507,7 @@ module All = struct
   let create = create_all
   let of_yojson = all_of_yojson
   let of_jsonlike = all_of_jsonlike
+  let to_jsonlike = jsonlike_of_all
   let to_yojson = yojson_of_all
   let of_json = all_of_json
   let to_json = json_of_all

--- a/atdml/tests/named-snapshots/type_name_json
+++ b/atdml/tests/named-snapshots/type_name_json
@@ -4,9 +4,9 @@ type json_ = private string
 
 val create_json_ : string -> json_
 val json__of_yojson : Yojson.Safe.t -> json_
+val yojson_of_json_ : json_ -> Yojson.Safe.t
 val json__of_jsonlike : Atd_jsonlike.AST.t -> json_
 val jsonlike_of_json_ : json_ -> Atd_jsonlike.AST.t
-val yojson_of_json_ : json_ -> Yojson.Safe.t
 val json__of_json : string -> json_
 val json_of_json_ : json_ -> string
 
@@ -14,9 +14,9 @@ module Json_ : sig
   type nonrec t = json_
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -192,11 +192,11 @@ let create_json_ (x : string) : json_ = x
 let json__of_yojson (x : Yojson.Safe.t) : json_ =
   Atdml_runtime.Yojson.string_of_yojson x
 
-let json__of_jsonlike (x : Atd_jsonlike.AST.t) : json_ =
-  Atdml_runtime.Jsonlike.string_of_jsonlike x
-
 let yojson_of_json_ (x : json_) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
+
+let json__of_jsonlike (x : Atd_jsonlike.AST.t) : json_ =
+  Atdml_runtime.Jsonlike.string_of_jsonlike x
 
 let jsonlike_of_json_ (x : json_) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_string x
@@ -211,9 +211,9 @@ module Json_ = struct
   type nonrec t = json_
   let create = create_json_
   let of_yojson = json__of_yojson
+  let to_yojson = yojson_of_json_
   let of_jsonlike = json__of_jsonlike
   let to_jsonlike = jsonlike_of_json_
-  let to_yojson = yojson_of_json_
   let of_json = json__of_json
   let to_json = json_of_json_
 end

--- a/atdml/tests/named-snapshots/type_name_json
+++ b/atdml/tests/named-snapshots/type_name_json
@@ -5,6 +5,7 @@ type json_ = private string
 val create_json_ : string -> json_
 val json__of_yojson : Yojson.Safe.t -> json_
 val json__of_jsonlike : Atd_jsonlike.AST.t -> json_
+val jsonlike_of_json_ : json_ -> Atd_jsonlike.AST.t
 val yojson_of_json_ : json_ -> Yojson.Safe.t
 val json__of_json : string -> json_
 val json_of_json_ : json_ -> string
@@ -14,6 +15,7 @@ module Json_ : sig
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -162,6 +164,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -179,6 +198,9 @@ let json__of_jsonlike (x : Atd_jsonlike.AST.t) : json_ =
 let yojson_of_json_ (x : json_) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
 
+let jsonlike_of_json_ (x : json_) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_string x
+
 let json__of_json s =
   json__of_yojson (Yojson.Safe.from_string s)
 
@@ -190,6 +212,7 @@ module Json_ = struct
   let create = create_json_
   let of_yojson = json__of_yojson
   let of_jsonlike = json__of_jsonlike
+  let to_jsonlike = jsonlike_of_json_
   let to_yojson = yojson_of_json_
   let of_json = json__of_json
   let to_json = json_of_json_

--- a/atdml/tests/named-snapshots/type_name_module
+++ b/atdml/tests/named-snapshots/type_name_module
@@ -5,6 +5,7 @@ type module__ = private bool
 val create_module__ : bool -> module__
 val module___of_yojson : Yojson.Safe.t -> module__
 val module___of_jsonlike : Atd_jsonlike.AST.t -> module__
+val jsonlike_of_module__ : module__ -> Atd_jsonlike.AST.t
 val yojson_of_module__ : module__ -> Yojson.Safe.t
 val module___of_json : string -> module__
 val json_of_module__ : module__ -> string
@@ -14,6 +15,7 @@ module Module__ : sig
   val create : bool -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -23,6 +25,7 @@ type module_1 = string list
 
 val module_1_of_yojson : Yojson.Safe.t -> module_1
 val module_1_of_jsonlike : Atd_jsonlike.AST.t -> module_1
+val jsonlike_of_module_1 : module_1 -> Atd_jsonlike.AST.t
 val yojson_of_module_1 : module_1 -> Yojson.Safe.t
 val module_1_of_json : string -> module_1
 val json_of_module_1 : module_1 -> string
@@ -31,6 +34,7 @@ module Module_1 : sig
   type nonrec t = module_1
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -41,6 +45,7 @@ type module_2 = private string
 val create_module_2 : string -> module_2
 val module_2_of_yojson : Yojson.Safe.t -> module_2
 val module_2_of_jsonlike : Atd_jsonlike.AST.t -> module_2
+val jsonlike_of_module_2 : module_2 -> Atd_jsonlike.AST.t
 val yojson_of_module_2 : module_2 -> Yojson.Safe.t
 val module_2_of_json : string -> module_2
 val json_of_module_2 : module_2 -> string
@@ -50,6 +55,7 @@ module Module_2 : sig
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -60,6 +66,7 @@ type module_ = private int
 val create_module_ : int -> module_
 val module__of_yojson : Yojson.Safe.t -> module_
 val module__of_jsonlike : Atd_jsonlike.AST.t -> module_
+val jsonlike_of_module_ : module_ -> Atd_jsonlike.AST.t
 val yojson_of_module_ : module_ -> Yojson.Safe.t
 val module__of_json : string -> module_
 val json_of_module_ : module_ -> string
@@ -69,6 +76,7 @@ module Module_ : sig
   val create : int -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -217,6 +225,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -234,6 +259,9 @@ let module___of_jsonlike (x : Atd_jsonlike.AST.t) : module__ =
 let yojson_of_module__ (x : module__) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_bool x
 
+let jsonlike_of_module__ (x : module__) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_bool x
+
 let module___of_json s =
   module___of_yojson (Yojson.Safe.from_string s)
 
@@ -245,6 +273,7 @@ module Module__ = struct
   let create = create_module__
   let of_yojson = module___of_yojson
   let of_jsonlike = module___of_jsonlike
+  let to_jsonlike = jsonlike_of_module__
   let to_yojson = yojson_of_module__
   let of_json = module___of_json
   let to_json = json_of_module__
@@ -261,6 +290,9 @@ let module_1_of_jsonlike (x : Atd_jsonlike.AST.t) : module_1 =
 let yojson_of_module_1 (x : module_1) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x
 
+let jsonlike_of_module_1 (x : module_1) : Atd_jsonlike.AST.t =
+  (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string) x
+
 let module_1_of_json s =
   module_1_of_yojson (Yojson.Safe.from_string s)
 
@@ -271,6 +303,7 @@ module Module_1 = struct
   type nonrec t = module_1
   let of_yojson = module_1_of_yojson
   let of_jsonlike = module_1_of_jsonlike
+  let to_jsonlike = jsonlike_of_module_1
   let to_yojson = yojson_of_module_1
   let of_json = module_1_of_json
   let to_json = json_of_module_1
@@ -290,6 +323,9 @@ let module_2_of_jsonlike (x : Atd_jsonlike.AST.t) : module_2 =
 let yojson_of_module_2 (x : module_2) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
 
+let jsonlike_of_module_2 (x : module_2) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_string x
+
 let module_2_of_json s =
   module_2_of_yojson (Yojson.Safe.from_string s)
 
@@ -301,6 +337,7 @@ module Module_2 = struct
   let create = create_module_2
   let of_yojson = module_2_of_yojson
   let of_jsonlike = module_2_of_jsonlike
+  let to_jsonlike = jsonlike_of_module_2
   let to_yojson = yojson_of_module_2
   let of_json = module_2_of_json
   let to_json = json_of_module_2
@@ -320,6 +357,9 @@ let module__of_jsonlike (x : Atd_jsonlike.AST.t) : module_ =
 let yojson_of_module_ (x : module_) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_int x
 
+let jsonlike_of_module_ (x : module_) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_int x
+
 let module__of_json s =
   module__of_yojson (Yojson.Safe.from_string s)
 
@@ -331,6 +371,7 @@ module Module_ = struct
   let create = create_module_
   let of_yojson = module__of_yojson
   let of_jsonlike = module__of_jsonlike
+  let to_jsonlike = jsonlike_of_module_
   let to_yojson = yojson_of_module_
   let of_json = module__of_json
   let to_json = json_of_module_

--- a/atdml/tests/named-snapshots/type_name_module
+++ b/atdml/tests/named-snapshots/type_name_module
@@ -4,9 +4,9 @@ type module__ = private bool
 
 val create_module__ : bool -> module__
 val module___of_yojson : Yojson.Safe.t -> module__
+val yojson_of_module__ : module__ -> Yojson.Safe.t
 val module___of_jsonlike : Atd_jsonlike.AST.t -> module__
 val jsonlike_of_module__ : module__ -> Atd_jsonlike.AST.t
-val yojson_of_module__ : module__ -> Yojson.Safe.t
 val module___of_json : string -> module__
 val json_of_module__ : module__ -> string
 
@@ -14,9 +14,9 @@ module Module__ : sig
   type nonrec t = module__
   val create : bool -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -24,18 +24,18 @@ end
 type module_1 = string list
 
 val module_1_of_yojson : Yojson.Safe.t -> module_1
+val yojson_of_module_1 : module_1 -> Yojson.Safe.t
 val module_1_of_jsonlike : Atd_jsonlike.AST.t -> module_1
 val jsonlike_of_module_1 : module_1 -> Atd_jsonlike.AST.t
-val yojson_of_module_1 : module_1 -> Yojson.Safe.t
 val module_1_of_json : string -> module_1
 val json_of_module_1 : module_1 -> string
 
 module Module_1 : sig
   type nonrec t = module_1
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -44,9 +44,9 @@ type module_2 = private string
 
 val create_module_2 : string -> module_2
 val module_2_of_yojson : Yojson.Safe.t -> module_2
+val yojson_of_module_2 : module_2 -> Yojson.Safe.t
 val module_2_of_jsonlike : Atd_jsonlike.AST.t -> module_2
 val jsonlike_of_module_2 : module_2 -> Atd_jsonlike.AST.t
-val yojson_of_module_2 : module_2 -> Yojson.Safe.t
 val module_2_of_json : string -> module_2
 val json_of_module_2 : module_2 -> string
 
@@ -54,9 +54,9 @@ module Module_2 : sig
   type nonrec t = module_2
   val create : string -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -65,9 +65,9 @@ type module_ = private int
 
 val create_module_ : int -> module_
 val module__of_yojson : Yojson.Safe.t -> module_
+val yojson_of_module_ : module_ -> Yojson.Safe.t
 val module__of_jsonlike : Atd_jsonlike.AST.t -> module_
 val jsonlike_of_module_ : module_ -> Atd_jsonlike.AST.t
-val yojson_of_module_ : module_ -> Yojson.Safe.t
 val module__of_json : string -> module_
 val json_of_module_ : module_ -> string
 
@@ -75,9 +75,9 @@ module Module_ : sig
   type nonrec t = module_
   val create : int -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -253,11 +253,11 @@ let create_module__ (x : bool) : module__ = x
 let module___of_yojson (x : Yojson.Safe.t) : module__ =
   Atdml_runtime.Yojson.bool_of_yojson x
 
-let module___of_jsonlike (x : Atd_jsonlike.AST.t) : module__ =
-  Atdml_runtime.Jsonlike.bool_of_jsonlike x
-
 let yojson_of_module__ (x : module__) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_bool x
+
+let module___of_jsonlike (x : Atd_jsonlike.AST.t) : module__ =
+  Atdml_runtime.Jsonlike.bool_of_jsonlike x
 
 let jsonlike_of_module__ (x : module__) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_bool x
@@ -272,9 +272,9 @@ module Module__ = struct
   type nonrec t = module__
   let create = create_module__
   let of_yojson = module___of_yojson
+  let to_yojson = yojson_of_module__
   let of_jsonlike = module___of_jsonlike
   let to_jsonlike = jsonlike_of_module__
-  let to_yojson = yojson_of_module__
   let of_json = module___of_json
   let to_json = json_of_module__
 end
@@ -284,11 +284,11 @@ type module_1 = string list
 let module_1_of_yojson (x : Yojson.Safe.t) : module_1 =
   (Atdml_runtime.Yojson.list_of_yojson Atdml_runtime.Yojson.string_of_yojson) x
 
-let module_1_of_jsonlike (x : Atd_jsonlike.AST.t) : module_1 =
-  (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) x
-
 let yojson_of_module_1 (x : module_1) : Yojson.Safe.t =
   (Atdml_runtime.Yojson.yojson_of_list Atdml_runtime.Yojson.yojson_of_string) x
+
+let module_1_of_jsonlike (x : Atd_jsonlike.AST.t) : module_1 =
+  (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) x
 
 let jsonlike_of_module_1 (x : module_1) : Atd_jsonlike.AST.t =
   (Atdml_runtime.Jsonlike.jsonlike_of_list Atdml_runtime.Jsonlike.jsonlike_of_string) x
@@ -302,9 +302,9 @@ let json_of_module_1 x =
 module Module_1 = struct
   type nonrec t = module_1
   let of_yojson = module_1_of_yojson
+  let to_yojson = yojson_of_module_1
   let of_jsonlike = module_1_of_jsonlike
   let to_jsonlike = jsonlike_of_module_1
-  let to_yojson = yojson_of_module_1
   let of_json = module_1_of_json
   let to_json = json_of_module_1
 end
@@ -317,11 +317,11 @@ let create_module_2 (x : string) : module_2 = x
 let module_2_of_yojson (x : Yojson.Safe.t) : module_2 =
   Atdml_runtime.Yojson.string_of_yojson x
 
-let module_2_of_jsonlike (x : Atd_jsonlike.AST.t) : module_2 =
-  Atdml_runtime.Jsonlike.string_of_jsonlike x
-
 let yojson_of_module_2 (x : module_2) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
+
+let module_2_of_jsonlike (x : Atd_jsonlike.AST.t) : module_2 =
+  Atdml_runtime.Jsonlike.string_of_jsonlike x
 
 let jsonlike_of_module_2 (x : module_2) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_string x
@@ -336,9 +336,9 @@ module Module_2 = struct
   type nonrec t = module_2
   let create = create_module_2
   let of_yojson = module_2_of_yojson
+  let to_yojson = yojson_of_module_2
   let of_jsonlike = module_2_of_jsonlike
   let to_jsonlike = jsonlike_of_module_2
-  let to_yojson = yojson_of_module_2
   let of_json = module_2_of_json
   let to_json = json_of_module_2
 end
@@ -351,11 +351,11 @@ let create_module_ (x : int) : module_ = x
 let module__of_yojson (x : Yojson.Safe.t) : module_ =
   Atdml_runtime.Yojson.int_of_yojson x
 
-let module__of_jsonlike (x : Atd_jsonlike.AST.t) : module_ =
-  Atdml_runtime.Jsonlike.int_of_jsonlike x
-
 let yojson_of_module_ (x : module_) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_int x
+
+let module__of_jsonlike (x : Atd_jsonlike.AST.t) : module_ =
+  Atdml_runtime.Jsonlike.int_of_jsonlike x
 
 let jsonlike_of_module_ (x : module_) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_int x
@@ -370,9 +370,9 @@ module Module_ = struct
   type nonrec t = module_
   let create = create_module_
   let of_yojson = module__of_yojson
+  let to_yojson = yojson_of_module_
   let of_jsonlike = module__of_jsonlike
   let to_jsonlike = jsonlike_of_module_
-  let to_yojson = yojson_of_module_
   let of_json = module__of_json
   let to_json = json_of_module_
 end

--- a/atdml/tests/named-snapshots/type_name_t
+++ b/atdml/tests/named-snapshots/type_name_t
@@ -5,6 +5,7 @@ type t = private int
 val create_t : int -> t
 val t_of_yojson : Yojson.Safe.t -> t
 val t_of_jsonlike : Atd_jsonlike.AST.t -> t
+val jsonlike_of_t : t -> Atd_jsonlike.AST.t
 val yojson_of_t : t -> Yojson.Safe.t
 val t_of_json : string -> t
 val json_of_t : t -> string
@@ -14,6 +15,7 @@ module T : sig
   val create : int -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -162,6 +164,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -179,6 +198,9 @@ let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
 let yojson_of_t (x : t) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_int x
 
+let jsonlike_of_t (x : t) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_int x
+
 let t_of_json s =
   t_of_yojson (Yojson.Safe.from_string s)
 
@@ -190,6 +212,7 @@ module T = struct
   let create = create_t
   let of_yojson = t_of_yojson
   let of_jsonlike = t_of_jsonlike
+  let to_jsonlike = jsonlike_of_t
   let to_yojson = yojson_of_t
   let of_json = t_of_json
   let to_json = json_of_t

--- a/atdml/tests/named-snapshots/type_name_t
+++ b/atdml/tests/named-snapshots/type_name_t
@@ -4,9 +4,9 @@ type t = private int
 
 val create_t : int -> t
 val t_of_yojson : Yojson.Safe.t -> t
+val yojson_of_t : t -> Yojson.Safe.t
 val t_of_jsonlike : Atd_jsonlike.AST.t -> t
 val jsonlike_of_t : t -> Atd_jsonlike.AST.t
-val yojson_of_t : t -> Yojson.Safe.t
 val t_of_json : string -> t
 val json_of_t : t -> string
 
@@ -14,9 +14,9 @@ module T : sig
   type nonrec t = t
   val create : int -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -192,11 +192,11 @@ let create_t (x : int) : t = x
 let t_of_yojson (x : Yojson.Safe.t) : t =
   Atdml_runtime.Yojson.int_of_yojson x
 
-let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
-  Atdml_runtime.Jsonlike.int_of_jsonlike x
-
 let yojson_of_t (x : t) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_int x
+
+let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
+  Atdml_runtime.Jsonlike.int_of_jsonlike x
 
 let jsonlike_of_t (x : t) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_int x
@@ -211,9 +211,9 @@ module T = struct
   type nonrec t = t
   let create = create_t
   let of_yojson = t_of_yojson
+  let to_yojson = yojson_of_t
   let of_jsonlike = t_of_jsonlike
   let to_jsonlike = jsonlike_of_t
-  let to_yojson = yojson_of_t
   let of_json = t_of_json
   let to_json = json_of_t
 end

--- a/atdml/tests/named-snapshots/type_name_yojson
+++ b/atdml/tests/named-snapshots/type_name_yojson
@@ -4,9 +4,9 @@ type yojson_ = private int
 
 val create_yojson_ : int -> yojson_
 val yojson__of_yojson : Yojson.Safe.t -> yojson_
+val yojson_of_yojson_ : yojson_ -> Yojson.Safe.t
 val yojson__of_jsonlike : Atd_jsonlike.AST.t -> yojson_
 val jsonlike_of_yojson_ : yojson_ -> Atd_jsonlike.AST.t
-val yojson_of_yojson_ : yojson_ -> Yojson.Safe.t
 val yojson__of_json : string -> yojson_
 val json_of_yojson_ : yojson_ -> string
 
@@ -14,9 +14,9 @@ module Yojson_ : sig
   type nonrec t = yojson_
   val create : int -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -192,11 +192,11 @@ let create_yojson_ (x : int) : yojson_ = x
 let yojson__of_yojson (x : Yojson.Safe.t) : yojson_ =
   Atdml_runtime.Yojson.int_of_yojson x
 
-let yojson__of_jsonlike (x : Atd_jsonlike.AST.t) : yojson_ =
-  Atdml_runtime.Jsonlike.int_of_jsonlike x
-
 let yojson_of_yojson_ (x : yojson_) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_int x
+
+let yojson__of_jsonlike (x : Atd_jsonlike.AST.t) : yojson_ =
+  Atdml_runtime.Jsonlike.int_of_jsonlike x
 
 let jsonlike_of_yojson_ (x : yojson_) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_int x
@@ -211,9 +211,9 @@ module Yojson_ = struct
   type nonrec t = yojson_
   let create = create_yojson_
   let of_yojson = yojson__of_yojson
+  let to_yojson = yojson_of_yojson_
   let of_jsonlike = yojson__of_jsonlike
   let to_jsonlike = jsonlike_of_yojson_
-  let to_yojson = yojson_of_yojson_
   let of_json = yojson__of_json
   let to_json = json_of_yojson_
 end

--- a/atdml/tests/named-snapshots/type_name_yojson
+++ b/atdml/tests/named-snapshots/type_name_yojson
@@ -5,6 +5,7 @@ type yojson_ = private int
 val create_yojson_ : int -> yojson_
 val yojson__of_yojson : Yojson.Safe.t -> yojson_
 val yojson__of_jsonlike : Atd_jsonlike.AST.t -> yojson_
+val jsonlike_of_yojson_ : yojson_ -> Atd_jsonlike.AST.t
 val yojson_of_yojson_ : yojson_ -> Yojson.Safe.t
 val yojson__of_json : string -> yojson_
 val json_of_yojson_ : yojson_ -> string
@@ -14,6 +15,7 @@ module Yojson_ : sig
   val create : int -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -162,6 +164,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -179,6 +198,9 @@ let yojson__of_jsonlike (x : Atd_jsonlike.AST.t) : yojson_ =
 let yojson_of_yojson_ (x : yojson_) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_int x
 
+let jsonlike_of_yojson_ (x : yojson_) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_int x
+
 let yojson__of_json s =
   yojson__of_yojson (Yojson.Safe.from_string s)
 
@@ -190,6 +212,7 @@ module Yojson_ = struct
   let create = create_yojson_
   let of_yojson = yojson__of_yojson
   let of_jsonlike = yojson__of_jsonlike
+  let to_jsonlike = jsonlike_of_yojson_
   let to_yojson = yojson_of_yojson_
   let of_json = yojson__of_json
   let to_json = json_of_yojson_

--- a/atdml/tests/named-snapshots/wrap
+++ b/atdml/tests/named-snapshots/wrap
@@ -4,6 +4,7 @@ type uid = int
 
 val uid_of_yojson : Yojson.Safe.t -> uid
 val uid_of_jsonlike : Atd_jsonlike.AST.t -> uid
+val jsonlike_of_uid : uid -> Atd_jsonlike.AST.t
 val yojson_of_uid : uid -> Yojson.Safe.t
 val uid_of_json : string -> uid
 val json_of_uid : uid -> string
@@ -12,6 +13,7 @@ module Uid : sig
   type nonrec t = uid
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -21,6 +23,7 @@ type tag = string
 
 val tag_of_yojson : Yojson.Safe.t -> tag
 val tag_of_jsonlike : Atd_jsonlike.AST.t -> tag
+val jsonlike_of_tag : tag -> Atd_jsonlike.AST.t
 val yojson_of_tag : tag -> Yojson.Safe.t
 val tag_of_json : string -> tag
 val json_of_tag : tag -> string
@@ -29,6 +32,7 @@ module Tag : sig
   type nonrec t = tag
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -42,6 +46,7 @@ type record = {
 val create_record : id:uid -> label:tag -> unit -> record
 val record_of_yojson : Yojson.Safe.t -> record
 val record_of_jsonlike : Atd_jsonlike.AST.t -> record
+val jsonlike_of_record : record -> Atd_jsonlike.AST.t
 val yojson_of_record : record -> Yojson.Safe.t
 val record_of_json : string -> record
 val json_of_record : record -> string
@@ -51,6 +56,7 @@ module Record : sig
   val create : id:uid -> label:tag -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
   val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
@@ -199,6 +205,23 @@ module Atdml_runtime = struct
       | Atd_jsonlike.AST.Object (_, pairs) ->
           List.map (fun (_, k, v) -> (k, f v)) pairs
       | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
   end
 end
 
@@ -213,6 +236,9 @@ let uid_of_jsonlike (x : Atd_jsonlike.AST.t) : uid =
 let yojson_of_uid (x : uid) : Yojson.Safe.t =
   (fun x -> Atdml_runtime.Yojson.yojson_of_string ((string_of_int) x)) x
 
+let jsonlike_of_uid (x : uid) : Atd_jsonlike.AST.t =
+  (fun x -> Atdml_runtime.Jsonlike.jsonlike_of_string ((string_of_int) x)) x
+
 let uid_of_json s =
   uid_of_yojson (Yojson.Safe.from_string s)
 
@@ -223,6 +249,7 @@ module Uid = struct
   type nonrec t = uid
   let of_yojson = uid_of_yojson
   let of_jsonlike = uid_of_jsonlike
+  let to_jsonlike = jsonlike_of_uid
   let to_yojson = yojson_of_uid
   let of_json = uid_of_json
   let to_json = json_of_uid
@@ -239,6 +266,9 @@ let tag_of_jsonlike (x : Atd_jsonlike.AST.t) : tag =
 let yojson_of_tag (x : tag) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
 
+let jsonlike_of_tag (x : tag) : Atd_jsonlike.AST.t =
+  Atdml_runtime.Jsonlike.jsonlike_of_string x
+
 let tag_of_json s =
   tag_of_yojson (Yojson.Safe.from_string s)
 
@@ -249,6 +279,7 @@ module Tag = struct
   type nonrec t = tag
   let of_yojson = tag_of_yojson
   let of_jsonlike = tag_of_jsonlike
+  let to_jsonlike = jsonlike_of_tag
   let to_yojson = yojson_of_tag
   let of_json = tag_of_json
   let to_json = json_of_tag
@@ -321,6 +352,12 @@ let yojson_of_record (x : record) : Yojson.Safe.t =
     [("label", yojson_of_tag x.label)];
   ])
 
+let jsonlike_of_record (x : record) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "id", jsonlike_of_uid x.id)];
+    [(Atd_jsonlike.Loc.zero, "label", jsonlike_of_tag x.label)];
+  ])
+
 let record_of_json s =
   record_of_yojson (Yojson.Safe.from_string s)
 
@@ -332,6 +369,7 @@ module Record = struct
   let create = create_record
   let of_yojson = record_of_yojson
   let of_jsonlike = record_of_jsonlike
+  let to_jsonlike = jsonlike_of_record
   let to_yojson = yojson_of_record
   let of_json = record_of_json
   let to_json = json_of_record

--- a/atdml/tests/named-snapshots/wrap
+++ b/atdml/tests/named-snapshots/wrap
@@ -3,18 +3,18 @@
 type uid = int
 
 val uid_of_yojson : Yojson.Safe.t -> uid
+val yojson_of_uid : uid -> Yojson.Safe.t
 val uid_of_jsonlike : Atd_jsonlike.AST.t -> uid
 val jsonlike_of_uid : uid -> Atd_jsonlike.AST.t
-val yojson_of_uid : uid -> Yojson.Safe.t
 val uid_of_json : string -> uid
 val json_of_uid : uid -> string
 
 module Uid : sig
   type nonrec t = uid
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -22,18 +22,18 @@ end
 type tag = string
 
 val tag_of_yojson : Yojson.Safe.t -> tag
+val yojson_of_tag : tag -> Yojson.Safe.t
 val tag_of_jsonlike : Atd_jsonlike.AST.t -> tag
 val jsonlike_of_tag : tag -> Atd_jsonlike.AST.t
-val yojson_of_tag : tag -> Yojson.Safe.t
 val tag_of_json : string -> tag
 val json_of_tag : tag -> string
 
 module Tag : sig
   type nonrec t = tag
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -45,9 +45,9 @@ type record = {
 
 val create_record : id:uid -> label:tag -> unit -> record
 val record_of_yojson : Yojson.Safe.t -> record
+val yojson_of_record : record -> Yojson.Safe.t
 val record_of_jsonlike : Atd_jsonlike.AST.t -> record
 val jsonlike_of_record : record -> Atd_jsonlike.AST.t
-val yojson_of_record : record -> Yojson.Safe.t
 val record_of_json : string -> record
 val json_of_record : record -> string
 
@@ -55,9 +55,9 @@ module Record : sig
   type nonrec t = record
   val create : id:uid -> label:tag -> unit -> t
   val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
   val of_jsonlike : Atd_jsonlike.AST.t -> t
   val to_jsonlike : t -> Atd_jsonlike.AST.t
-  val to_yojson : t -> Yojson.Safe.t
   val of_json : string -> t
   val to_json : t -> string
 end
@@ -230,11 +230,11 @@ type uid = int
 let uid_of_yojson (x : Yojson.Safe.t) : uid =
   (fun x -> (int_of_string) (Atdml_runtime.Yojson.string_of_yojson x)) x
 
-let uid_of_jsonlike (x : Atd_jsonlike.AST.t) : uid =
-  (fun x -> (int_of_string) (Atdml_runtime.Jsonlike.string_of_jsonlike x)) x
-
 let yojson_of_uid (x : uid) : Yojson.Safe.t =
   (fun x -> Atdml_runtime.Yojson.yojson_of_string ((string_of_int) x)) x
+
+let uid_of_jsonlike (x : Atd_jsonlike.AST.t) : uid =
+  (fun x -> (int_of_string) (Atdml_runtime.Jsonlike.string_of_jsonlike x)) x
 
 let jsonlike_of_uid (x : uid) : Atd_jsonlike.AST.t =
   (fun x -> Atdml_runtime.Jsonlike.jsonlike_of_string ((string_of_int) x)) x
@@ -248,9 +248,9 @@ let json_of_uid x =
 module Uid = struct
   type nonrec t = uid
   let of_yojson = uid_of_yojson
+  let to_yojson = yojson_of_uid
   let of_jsonlike = uid_of_jsonlike
   let to_jsonlike = jsonlike_of_uid
-  let to_yojson = yojson_of_uid
   let of_json = uid_of_json
   let to_json = json_of_uid
 end
@@ -260,11 +260,11 @@ type tag = string
 let tag_of_yojson (x : Yojson.Safe.t) : tag =
   Atdml_runtime.Yojson.string_of_yojson x
 
-let tag_of_jsonlike (x : Atd_jsonlike.AST.t) : tag =
-  Atdml_runtime.Jsonlike.string_of_jsonlike x
-
 let yojson_of_tag (x : tag) : Yojson.Safe.t =
   Atdml_runtime.Yojson.yojson_of_string x
+
+let tag_of_jsonlike (x : Atd_jsonlike.AST.t) : tag =
+  Atdml_runtime.Jsonlike.string_of_jsonlike x
 
 let jsonlike_of_tag (x : tag) : Atd_jsonlike.AST.t =
   Atdml_runtime.Jsonlike.jsonlike_of_string x
@@ -278,9 +278,9 @@ let json_of_tag x =
 module Tag = struct
   type nonrec t = tag
   let of_yojson = tag_of_yojson
+  let to_yojson = yojson_of_tag
   let of_jsonlike = tag_of_jsonlike
   let to_jsonlike = jsonlike_of_tag
-  let to_yojson = yojson_of_tag
   let of_json = tag_of_json
   let to_json = json_of_tag
 end
@@ -319,6 +319,12 @@ let record_of_yojson (x : Yojson.Safe.t) : record =
     { id; label }
   | _ -> Atdml_runtime.Yojson.bad_type "record" x
 
+let yojson_of_record (x : record) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("id", yojson_of_uid x.id)];
+    [("label", yojson_of_tag x.label)];
+  ])
+
 let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
@@ -346,12 +352,6 @@ let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
     { id; label }
   | _ -> Atdml_runtime.Jsonlike.bad_type "record" x
 
-let yojson_of_record (x : record) : Yojson.Safe.t =
-  `Assoc (List.concat [
-    [("id", yojson_of_uid x.id)];
-    [("label", yojson_of_tag x.label)];
-  ])
-
 let jsonlike_of_record (x : record) : Atd_jsonlike.AST.t =
   Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
     [(Atd_jsonlike.Loc.zero, "id", jsonlike_of_uid x.id)];
@@ -368,9 +368,9 @@ module Record = struct
   type nonrec t = record
   let create = create_record
   let of_yojson = record_of_yojson
+  let to_yojson = yojson_of_record
   let of_jsonlike = record_of_jsonlike
   let to_jsonlike = jsonlike_of_record
-  let to_yojson = yojson_of_record
   let of_json = record_of_json
   let to_json = json_of_record
 end

--- a/atdml/tests/test.ml
+++ b/atdml/tests/test.ml
@@ -76,12 +76,21 @@ let test_program ?(test_jsonlike = true) ~type_name ~json_in () =
   let typed_data2 = Types.%s_of_jsonlike jsonlike_in in
   let yojson_out2 = Types.yojson_of_%s typed_data2 in
   if yojson_out <> yojson_out2 then (
-    Printf.eprintf "Jsonlike round-trip mismatch!\n";
+    Printf.eprintf "Jsonlike reader round-trip mismatch!\n";
     Printf.eprintf "Expected: %%s\n" (Yojson.Safe.pretty_to_string yojson_out);
     Printf.eprintf "Got:      %%s\n" (Yojson.Safe.pretty_to_string yojson_out2);
     exit 1
+  );
+  let jsonlike_out = Types.jsonlike_of_%s typed_data in
+  let typed_data3 = Types.%s_of_jsonlike jsonlike_out in
+  let yojson_out3 = Types.yojson_of_%s typed_data3 in
+  if yojson_out <> yojson_out3 then (
+    Printf.eprintf "Jsonlike writer round-trip mismatch!\n";
+    Printf.eprintf "Expected: %%s\n" (Yojson.Safe.pretty_to_string yojson_out);
+    Printf.eprintf "Got:      %%s\n" (Yojson.Safe.pretty_to_string yojson_out3);
+    exit 1
   )|}
-        type_name type_name
+        type_name type_name type_name type_name type_name
     else ""
   in
   sprintf {|%s
@@ -424,7 +433,7 @@ type module_ = string
   test_e2e "adapter"
     (* The adapter converts between ATD's ["Constructor", ...] sum encoding
        and an object with a "type" field, i.e. {"type": "Image", "url": "..."}.
-       For yojson: normalize/restore. For jsonlike: normalize_jsonlike. *)
+       For yojson: normalize/restore. For jsonlike: normalize_jsonlike/restore_jsonlike. *)
     ~extra_sources:[
       ("My_adapter.ml", {|
 (* Converts {"type": "Foo", ...rest} <-> ["Foo", {...rest}] *)
@@ -456,6 +465,16 @@ let normalize_jsonlike = function
       let rest = List.filter (fun (_, k, _) -> k <> "type") fields in
       Atd_jsonlike.AST.Array (loc,
         [Atd_jsonlike.AST.String (loc, tag); Atd_jsonlike.AST.Object (loc, rest)])
+  | x -> x
+
+let restore_jsonlike = function
+  | Atd_jsonlike.AST.Array (loc,
+      [Atd_jsonlike.AST.String (_, tag); Atd_jsonlike.AST.Object (_, rest)]) ->
+      Atd_jsonlike.AST.Object (loc,
+        (loc, "type", Atd_jsonlike.AST.String (loc, tag)) :: rest)
+  | Atd_jsonlike.AST.String (loc, tag) ->
+      Atd_jsonlike.AST.Object (loc,
+        [(loc, "type", Atd_jsonlike.AST.String (loc, tag))])
   | x -> x
 |})]
     ~atd_src:{|
@@ -623,6 +642,7 @@ module Module : sig
     val tag_of_yojson : Yojson.Safe.t -> tag
     val yojson_of_tag : tag -> Yojson.Safe.t
     val tag_of_jsonlike : Atd_jsonlike.AST.t -> tag
+    val jsonlike_of_tag : tag -> Atd_jsonlike.AST.t
   end
 end
 |});
@@ -640,6 +660,9 @@ module Module = struct
     let tag_of_jsonlike : Atd_jsonlike.AST.t -> tag = function
       | Atd_jsonlike.AST.String (_, s) -> s
       | x -> failwith ("Long.Module.Path.tag_of_jsonlike: " ^ Atd_jsonlike.AST.loc_msg x)
+
+    let jsonlike_of_tag (s : tag) : Atd_jsonlike.AST.t =
+      Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, s)
   end
 end
 |})]

--- a/dune-project
+++ b/dune-project
@@ -294,6 +294,6 @@ file/line/column error messages.")
  (depends
   (ocaml (>= 4.14))
   (atd-jsonlike (= :version))
-  (yamlx (>= 0.1.0))
+  (yamlx (>= 0.2.0))
   (testo (and (>= 0.3.0) :with-test))
   (odoc :with-doc)))


### PR DESCRIPTION
## Summary

- Implements #502: atdml now generates `jsonlike_of_foo` and `Foo.to_jsonlike` functions for every ATD type, enabling serialization from OCaml values to `Atd_jsonlike.AST.t`
- Implements #503: atd-yamlx gains `to_yamlx_value : Atd_jsonlike.AST.t -> YAMLx.value`, the reverse of the existing `of_yamlx_value`
- Adds `Pos.zero` and `Loc.zero` to atd-jsonlike for constructing nodes programmatically without source location information

## Generated API (per ATD type `foo`)

```ocaml
val jsonlike_of_foo : foo -> Atd_jsonlike.AST.t

module Foo : sig
  type nonrec t = foo
  val of_jsonlike : Atd_jsonlike.AST.t -> t
  val to_jsonlike : t -> Atd_jsonlike.AST.t
  ...
end
```

Generated nodes carry `Atd_jsonlike.Loc.zero` (no source location).

## Design notes

- Adapter support: module-based adapters with `M.restore` are extended to call `M.restore_jsonlike` in the jsonlike writer path, mirroring how `M.normalize_jsonlike` extends `M.normalize` for the reader
- The test for the `adapter` case now includes a `restore_jsonlike` function in `My_adapter.ml`
- The `imports e2e` test's `Long.ml` now includes `jsonlike_of_tag` alongside `tag_of_jsonlike`
- End-to-end tests verify the full writer round-trip: OCaml → jsonlike → OCaml → yojson must match the direct OCaml → yojson path

## Test plan

- [x] `dune build` passes
- [x] `cd atdml && ./test` — all 47 tests pass (44 pass, 3 xfail)
- [x] `dune runtest atd-yamlx/` — all 5 tests pass (3 original + 2 new)
- [x] `dune runtest atd-jsonlike/` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)