### PR TITLE
atdml: allow user-defined constructors named 'None' and 'Some'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+in progress
+-----------
+
+* atdml: Allow user-defined `None` and `Some` constructors (#506)
+
 4.2.0 (2026-04-25)
 ------------------
 

--- a/atd-yamlx/examples/main.ml
+++ b/atd-yamlx/examples/main.ml
@@ -22,7 +22,7 @@ let () =
   let file = "config.yaml" in
   (* Step 1: parse YAML into a generic JSON-like tree, preserving locations. *)
   let jsonlike =
-    match YAMLx.Values.one_of_yaml_file file with
+    match YAMLx.Value.of_yaml_file file with
     | Error msg -> eprintf "%s\n%!" msg; exit 1
     | Ok yaml_val ->
         match Atd_yamlx.of_yamlx_value ~file yaml_val with

--- a/atdml/src/lib/Codegen.ml
+++ b/atdml/src/lib/Codegen.ml
@@ -470,18 +470,21 @@ let jsonlike_mode = {
   record_match_pat = "Atd_jsonlike.AST.Object (_, fields)";
   record_assoc_lines = [
     B.Line "let assoc_ =";
-    B.Block
-      [ B.Line "if Atdml_runtime.list_length_gt 5 fields then";
-        B.Block
-          [ B.Line "let tbl = Hashtbl.create 16 in";
-            B.Line "List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;";
-            B.Line "(fun key -> Hashtbl.find_opt tbl key)" ];
-        B.Line "else";
-        B.Block
-          [ B.Line "(fun key ->";
-            B.Block
-              [ B.Line "match List.find_opt (fun (_, k, _) -> k = key) fields with";
-                B.Line "| None -> None | Some (_, _, v) -> Some v)" ] ] ];
+    B.Block [
+      B.Line "if Atdml_runtime.list_length_gt 5 fields then";
+      B.Block [
+        B.Line "let tbl = Hashtbl.create 16 in";
+        B.Line "List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;";
+        B.Line "(fun key -> Hashtbl.find_opt tbl key)"
+      ];
+      B.Line "else";
+      B.Block [
+        B.Line "(fun key ->";
+        B.Block [
+          B.Line "List.find_map (fun (_, k, v) : _ option -> \
+                  if String.equal k key then Some v else None) fields)" ]
+      ]
+    ];
     B.Line "in";
   ];
   optional_null_pat = "None | Some (Atd_jsonlike.AST.Null _)";
@@ -1193,8 +1196,8 @@ let gen_reader_field env ftr mode type_name (loc, (fname, kind, an), e) : B.node
         in
         [
           B.Line (sprintf "match assoc_ \"%s\" with" json_name);
-          B.Line (sprintf "| %s -> None" mode.optional_null_pat);
-          B.Line (sprintf "| Some v -> Some (%s v)" (reader_expr env mode inner_e));
+          B.Line (sprintf "| %s -> Option.None" mode.optional_null_pat);
+          B.Line (sprintf "| Some v -> Option.Some (%s v)" (reader_expr env mode inner_e));
         ]
     | With_default ->
         (match get_ocaml_default an with

--- a/atdml/tests/named-snapshots/adapter
+++ b/atdml/tests/named-snapshots/adapter
@@ -282,8 +282,7 @@ let text_of_jsonlike (x : Atd_jsonlike.AST.t) : text =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let title =
       match assoc_ "title" with
@@ -365,8 +364,7 @@ let image_of_jsonlike (x : Atd_jsonlike.AST.t) : image =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let url =
       match assoc_ "url" with

--- a/atdml/tests/named-snapshots/attr
+++ b/atdml/tests/named-snapshots/attr
@@ -262,8 +262,7 @@ let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let x =
       match assoc_ "x" with

--- a/atdml/tests/named-snapshots/builtin_types
+++ b/atdml/tests/named-snapshots/builtin_types
@@ -310,8 +310,7 @@ let all_types_of_jsonlike (x : Atd_jsonlike.AST.t) : all_types =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let a_unit =
       match assoc_ "a_unit" with

--- a/atdml/tests/named-snapshots/doc
+++ b/atdml/tests/named-snapshots/doc
@@ -365,8 +365,7 @@ let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let value =
       match assoc_ "value" with
@@ -476,8 +475,8 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
     in
     let email =
       match assoc_ "email" with
-      | None | Some `Null -> None
-      | Some v -> Some (Atdml_runtime.Yojson.string_of_yojson v)
+      | None | Some `Null -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Yojson.string_of_yojson v)
     in
     { name; age; email }
   | _ -> Atdml_runtime.Yojson.bad_type "person" x
@@ -500,8 +499,7 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
       match assoc_ "name" with
@@ -515,8 +513,8 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
     in
     let email =
       match assoc_ "email" with
-      | None | Some (Atd_jsonlike.AST.Null _) -> None
-      | Some v -> Some (Atdml_runtime.Jsonlike.string_of_jsonlike v)
+      | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Jsonlike.string_of_jsonlike v)
     in
     { name; age; email }
   | _ -> Atdml_runtime.Jsonlike.bad_type "person" x

--- a/atdml/tests/named-snapshots/field_prefix
+++ b/atdml/tests/named-snapshots/field_prefix
@@ -246,8 +246,7 @@ let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let ule =
       match assoc_ "ule" with

--- a/atdml/tests/named-snapshots/imports
+++ b/atdml/tests/named-snapshots/imports
@@ -264,8 +264,7 @@ let tagged_of_jsonlike (x : Atd_jsonlike.AST.t) : tagged =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let value =
       match assoc_ "value" with
@@ -354,8 +353,7 @@ let greeting_of_jsonlike (x : Atd_jsonlike.AST.t) : greeting =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
       match assoc_ "name" with

--- a/atdml/tests/named-snapshots/imports_e2e
+++ b/atdml/tests/named-snapshots/imports_e2e
@@ -240,8 +240,7 @@ let item_of_jsonlike (x : Atd_jsonlike.AST.t) : item =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
       match assoc_ "name" with

--- a/atdml/tests/named-snapshots/json_repr_object
+++ b/atdml/tests/named-snapshots/json_repr_object
@@ -336,8 +336,7 @@ let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let counts =
       match assoc_ "counts" with

--- a/atdml/tests/named-snapshots/keyword_field_and_variant_names
+++ b/atdml/tests/named-snapshots/keyword_field_and_variant_names
@@ -287,8 +287,8 @@ let record_with_keyword_fields_of_yojson (x : Yojson.Safe.t) : record_with_keywo
     in
     let begin_ =
       match assoc_ "begin" with
-      | None | Some `Null -> None
-      | Some v -> Some (Atdml_runtime.Yojson.bool_of_yojson v)
+      | None | Some `Null -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Yojson.bool_of_yojson v)
     in
     let end_ =
       match assoc_ "end" with
@@ -317,8 +317,7 @@ let record_with_keyword_fields_of_jsonlike (x : Atd_jsonlike.AST.t) : record_wit
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let method_ =
       match assoc_ "method" with
@@ -332,8 +331,8 @@ let record_with_keyword_fields_of_jsonlike (x : Atd_jsonlike.AST.t) : record_wit
     in
     let begin_ =
       match assoc_ "begin" with
-      | None | Some (Atd_jsonlike.AST.Null _) -> None
-      | Some v -> Some (Atdml_runtime.Jsonlike.bool_of_jsonlike v)
+      | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Jsonlike.bool_of_jsonlike v)
     in
     let end_ =
       match assoc_ "end" with

--- a/atdml/tests/named-snapshots/mutually_recursive_types
+++ b/atdml/tests/named-snapshots/mutually_recursive_types
@@ -274,8 +274,7 @@ let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let value =
       match assoc_ "value" with

--- a/atdml/tests/named-snapshots/ocaml_private_public
+++ b/atdml/tests/named-snapshots/ocaml_private_public
@@ -386,8 +386,7 @@ let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let x =
       match assoc_ "x" with

--- a/atdml/tests/named-snapshots/protect_builtin_constructors
+++ b/atdml/tests/named-snapshots/protect_builtin_constructors
@@ -1,0 +1,345 @@
+(* Auto-generated from "protect_builtin_constructors.atd" by atdml. *)
+
+type not_option =
+  | None
+  | Some
+
+val not_option_of_yojson : Yojson.Safe.t -> not_option
+val yojson_of_not_option : not_option -> Yojson.Safe.t
+val not_option_of_jsonlike : Atd_jsonlike.AST.t -> not_option
+val jsonlike_of_not_option : not_option -> Atd_jsonlike.AST.t
+val not_option_of_json : string -> not_option
+val json_of_not_option : not_option -> string
+
+module Not_option : sig
+  type nonrec t = not_option
+  val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
+  val of_json : string -> t
+  val to_json : t -> string
+end
+
+type t = {
+  option: int option;
+  not_options: not_option list;
+}
+
+val create_t : ?option:int -> not_options:not_option list -> unit -> t
+val t_of_yojson : Yojson.Safe.t -> t
+val yojson_of_t : t -> Yojson.Safe.t
+val t_of_jsonlike : Atd_jsonlike.AST.t -> t
+val jsonlike_of_t : t -> Atd_jsonlike.AST.t
+val t_of_json : string -> t
+val json_of_t : t -> string
+
+module T : sig
+  type nonrec t = t
+  val create : ?option:int -> not_options:not_option list -> unit -> t
+  val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
+  val of_json : string -> t
+  val to_json : t -> string
+end
+
+--- ml ---
+(* Auto-generated from "protect_builtin_constructors.atd" by atdml. *)
+[@@@ocaml.warning "-27-32-33-35-39"]
+
+(* Inlined runtime — no external dependency needed. *)
+module Atdml_runtime = struct
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
+  module Yojson = struct
+    let bad_type expected_type x =
+      Printf.ksprintf failwith "expected %s, got: %s"
+        expected_type (Yojson.Safe.to_string x)
+
+    let bad_sum type_name x =
+      Printf.ksprintf failwith "invalid variant for type '%s': %s"
+        type_name (Yojson.Safe.to_string x)
+
+    let missing_field type_name field_name =
+      Printf.ksprintf failwith "missing field '%s' in object of type '%s'"
+        field_name type_name
+
+    let bool_of_yojson = function
+      | `Bool b -> b
+      | x -> bad_type "bool" x
+
+    let yojson_of_bool b = `Bool b
+
+    let int_of_yojson = function
+      | `Int n -> n
+      | x -> bad_type "int" x
+
+    let yojson_of_int n = `Int n
+
+    let float_of_yojson = function
+      | `Float f -> f
+      | `Int n -> Float.of_int n
+      | x -> bad_type "float" x
+
+    let yojson_of_float f = `Float f
+
+    let string_of_yojson = function
+      | `String s -> s
+      | x -> bad_type "string" x
+
+    let yojson_of_string s = `String s
+
+    let unit_of_yojson = function
+      | `Null -> ()
+      | x -> bad_type "null" x
+
+    let yojson_of_unit () = `Null
+
+    let list_of_yojson f = function
+      | `List xs -> List.map f xs
+      | x -> bad_type "array" x
+
+    let yojson_of_list f xs = `List (List.map f xs)
+
+    let option_of_yojson f = function
+      | `String "None" -> None
+      | `List [`String "Some"; x] -> Some (f x)
+      | x -> bad_type "option" x
+
+    let yojson_of_option f = function
+      | None -> `String "None"
+      | Some x -> `List [`String "Some"; f x]
+
+    let nullable_of_yojson f = function
+      | `Null -> None
+      | x -> Some (f x)
+
+    let yojson_of_nullable f = function
+      | None -> `Null
+      | Some x -> f x
+
+    let assoc_of_yojson f = function
+      | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
+      | x -> bad_type "object" x
+
+    let yojson_of_assoc f xs =
+      `Assoc (List.map (fun (k, v) -> (k, f v)) xs)
+  end
+
+  module Jsonlike = struct
+    let bad_type expected_type x =
+      Printf.ksprintf failwith "%sexpected %s"
+        (Atd_jsonlike.AST.loc_msg x) expected_type
+
+    let bad_sum type_name x =
+      Printf.ksprintf failwith "%sinvalid variant for type '%s'"
+        (Atd_jsonlike.AST.loc_msg x) type_name
+
+    let missing_field node type_name field_name =
+      Printf.ksprintf failwith "%smissing field '%s' in object of type '%s'"
+        (Atd_jsonlike.AST.loc_msg node) field_name type_name
+
+    let bool_of_jsonlike = function
+      | Atd_jsonlike.AST.Bool (_, b) -> b
+      | x -> bad_type "bool" x
+
+    let int_of_jsonlike = function
+      | Atd_jsonlike.AST.Number (_, n) as node ->
+          (match n.Atd_jsonlike.Number.int with
+          | Some i -> i
+          | None -> bad_type "integer" node)
+      | x -> bad_type "int" x
+
+    let float_of_jsonlike = function
+      | Atd_jsonlike.AST.Number (_, n) as node ->
+          (match n.Atd_jsonlike.Number.float with
+          | Some f -> f
+          | None -> bad_type "float" node)
+      | x -> bad_type "float" x
+
+    let string_of_jsonlike = function
+      | Atd_jsonlike.AST.String (_, s) -> s
+      | x -> bad_type "string" x
+
+    let unit_of_jsonlike = function
+      | Atd_jsonlike.AST.Null _ -> ()
+      | x -> bad_type "null" x
+
+    let list_of_jsonlike f = function
+      | Atd_jsonlike.AST.Array (_, xs) -> List.map f xs
+      | x -> bad_type "array" x
+
+    let option_of_jsonlike f = function
+      | Atd_jsonlike.AST.String (_, "None") -> None
+      | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Some"); x]) -> Some (f x)
+      | x -> bad_type "option" x
+
+    let nullable_of_jsonlike f = function
+      | Atd_jsonlike.AST.Null _ -> None
+      | x -> Some (f x)
+
+    let assoc_of_jsonlike f = function
+      | Atd_jsonlike.AST.Object (_, pairs) ->
+          List.map (fun (_, k, v) -> (k, f v)) pairs
+      | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
+  end
+end
+
+type not_option =
+  | None
+  | Some
+
+let not_option_of_yojson (x : Yojson.Safe.t) : not_option =
+  match x with
+  | `String "None" -> None
+  | `String "Some" -> Some
+  | _ -> Atdml_runtime.Yojson.bad_sum "not_option" x
+
+let yojson_of_not_option (x : not_option) : Yojson.Safe.t =
+  match x with
+  | None -> `String "None"
+  | Some -> `String "Some"
+
+let not_option_of_jsonlike (x : Atd_jsonlike.AST.t) : not_option =
+  match x with
+  | Atd_jsonlike.AST.String (_, "None") -> None
+  | Atd_jsonlike.AST.String (_, "Some") -> Some
+  | _ -> Atdml_runtime.Jsonlike.bad_sum "not_option" x
+
+let jsonlike_of_not_option (x : not_option) : Atd_jsonlike.AST.t =
+  match x with
+  | None -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "None")
+  | Some -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Some")
+
+let not_option_of_json s =
+  not_option_of_yojson (Yojson.Safe.from_string s)
+
+let json_of_not_option x =
+  Yojson.Safe.to_string (yojson_of_not_option x)
+
+module Not_option = struct
+  type nonrec t = not_option
+  let of_yojson = not_option_of_yojson
+  let to_yojson = yojson_of_not_option
+  let of_jsonlike = not_option_of_jsonlike
+  let to_jsonlike = jsonlike_of_not_option
+  let of_json = not_option_of_json
+  let to_json = json_of_not_option
+end
+
+type t = {
+  option: int option;
+  not_options: not_option list;
+}
+
+let create_t ?option ~not_options () : t =
+  { option; not_options }
+
+let t_of_yojson (x : Yojson.Safe.t) : t =
+  match x with
+  | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
+    let option =
+      match assoc_ "option" with
+      | None | Some `Null -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Yojson.int_of_yojson v)
+    in
+    let not_options =
+      match assoc_ "not_options" with
+      | Some v -> (Atdml_runtime.Yojson.list_of_yojson not_option_of_yojson) v
+      | None -> Atdml_runtime.Yojson.missing_field "t" "not_options"
+    in
+    { option; not_options }
+  | _ -> Atdml_runtime.Yojson.bad_type "t" x
+
+let yojson_of_t (x : t) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    (match x.option with None -> [] | Some v -> [("option", Atdml_runtime.Yojson.yojson_of_int v)]);
+    [("not_options", (Atdml_runtime.Yojson.yojson_of_list yojson_of_not_option) x.not_options)];
+  ])
+
+let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
+  match x with
+  | Atd_jsonlike.AST.Object (_, fields) ->
+    let atdml_node_ = x in
+    let assoc_ =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else
+        (fun key ->
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
+    in
+    let option =
+      match assoc_ "option" with
+      | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Jsonlike.int_of_jsonlike v)
+    in
+    let not_options =
+      match assoc_ "not_options" with
+      | Some v -> (Atdml_runtime.Jsonlike.list_of_jsonlike not_option_of_jsonlike) v
+      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "t" "not_options"
+    in
+    { option; not_options }
+  | _ -> Atdml_runtime.Jsonlike.bad_type "t" x
+
+let jsonlike_of_t (x : t) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    (match x.option with None -> [] | Some v -> [(Atd_jsonlike.Loc.zero, "option", Atdml_runtime.Jsonlike.jsonlike_of_int v)]);
+    [(Atd_jsonlike.Loc.zero, "not_options", (Atdml_runtime.Jsonlike.jsonlike_of_list jsonlike_of_not_option) x.not_options)];
+  ])
+
+let t_of_json s =
+  t_of_yojson (Yojson.Safe.from_string s)
+
+let json_of_t x =
+  Yojson.Safe.to_string (yojson_of_t x)
+
+module T = struct
+  type nonrec t = t
+  let create = create_t
+  let of_yojson = t_of_yojson
+  let to_yojson = yojson_of_t
+  let of_jsonlike = t_of_jsonlike
+  let to_jsonlike = jsonlike_of_t
+  let of_json = t_of_json
+  let to_json = json_of_t
+end
+
+--- Input:
+{ "option": 42, "not_options": [ "None", "Some" ] }
+--- Output:
+{ "option": 42, "not_options": [ "None", "Some" ] }

--- a/atdml/tests/named-snapshots/records
+++ b/atdml/tests/named-snapshots/records
@@ -239,8 +239,8 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
     in
     let email =
       match assoc_ "email" with
-      | None | Some `Null -> None
-      | Some v -> Some (Atdml_runtime.Yojson.string_of_yojson v)
+      | None | Some `Null -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Yojson.string_of_yojson v)
     in
     let score =
       match assoc_ "score" with
@@ -294,8 +294,7 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
       match assoc_ "name" with
@@ -314,8 +313,8 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
     in
     let email =
       match assoc_ "email" with
-      | None | Some (Atd_jsonlike.AST.Null _) -> None
-      | Some v -> Some (Atdml_runtime.Jsonlike.string_of_jsonlike v)
+      | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
+      | Some v -> Option.Some (Atdml_runtime.Jsonlike.string_of_jsonlike v)
     in
     let score =
       match assoc_ "score" with

--- a/atdml/tests/named-snapshots/type_aliases
+++ b/atdml/tests/named-snapshots/type_aliases
@@ -462,8 +462,7 @@ let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let id =
       match assoc_ "id" with

--- a/atdml/tests/named-snapshots/wrap
+++ b/atdml/tests/named-snapshots/wrap
@@ -336,8 +336,7 @@ let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
         (fun key -> Hashtbl.find_opt tbl key)
       else
         (fun key ->
-          match List.find_opt (fun (_, k, _) -> k = key) fields with
-          | None -> None | Some (_, _, v) -> Some v)
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let id =
       match assoc_ "id" with

--- a/atdml/tests/test.ml
+++ b/atdml/tests/test.ml
@@ -371,6 +371,23 @@ type all_types = {
 }
 |}
 ;
+  test_e2e "protect builtin constructors"
+    ~atd_src:{|
+type not_option = [ None | Some ]
+
+type t = {
+  ?option: int option;
+  not_options: not_option list;
+}
+|}
+    ~type_name:"t"
+    ~json_in:{|
+{
+  "option": 42,
+  "not_options": ["None", "Some"]
+}
+|}
+;
 
   test_e2e "parametric types"
     ~atd_src:{|


### PR DESCRIPTION
* avoid conflict with the builtin `option` type
* simplify/optimize generated code by using `List.find_map` and specialized string comparison

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
