### PR TITLE
adtml: Don't lowercase ml and mli file names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@ in progress
 -----------
 
 * atdml: Allow user-defined `None` and `Some` constructors (#506)
+* atdml: Preserve the capitalization in the derived mli and ml files.
+         For example, `Capitalized.atd` now becomes `Capitalized.mli`
+         rather than `capitalized.mli` (#507)
 
 4.2.0 (2026-04-25)
 ------------------

--- a/atdml/src/lib/Codegen.ml
+++ b/atdml/src/lib/Codegen.ml
@@ -2129,8 +2129,11 @@ let run_file ~yojson ~jsonlike src_path =
     else
       src_name
   in
-  let ml_path = String.lowercase_ascii base_name ^ ".ml" in
-  let mli_path = String.lowercase_ascii base_name ^ ".mli" in
+  (* Keep the original capitalization of the ATD file.
+     OCaml accepts both lowercase and uppercase compilation units.
+     They're always capitalized when converted to module names. *)
+  let ml_path = base_name ^ ".ml" in
+  let mli_path = base_name ^ ".mli" in
   let module_ =
     Atd.Util.load_file
       ~annot_schema


### PR DESCRIPTION
Test plan:
```
$ touch Foo.atd
$ dune exec atdml Foo.atd  # should generate 'Foo.mli' and 'Foo.ml'
```

