### PR TITLE
Rename generated variables

### DIFF
--- a/atdml/src/lib/Codegen.ml
+++ b/atdml/src/lib/Codegen.ml
@@ -435,7 +435,7 @@ let yojson_mode = {
     B.Line "(* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD";
     B.Line "   be unique). Below the threshold, List.assoc_opt returns the first binding;";
     B.Line "   above it, the hashtable returns the last. *)";
-    B.Line "let assoc_ =";
+    B.Line "let assoc =";
     B.Block
       [ B.Line "if Atdml_runtime.list_length_gt 5 fields then";
         B.Block
@@ -469,7 +469,7 @@ let jsonlike_mode = {
     sprintf "Atd_jsonlike.AST.Object (_, [(_, \"%s\", v)])" jn);
   record_match_pat = "Atd_jsonlike.AST.Object (_, fields)";
   record_assoc_lines = [
-    B.Line "let assoc_ =";
+    B.Line "let assoc =";
     B.Block [
       B.Line "if Atdml_runtime.list_length_gt 5 fields then";
       B.Block [
@@ -488,9 +488,9 @@ let jsonlike_mode = {
     B.Line "in";
   ];
   optional_null_pat = "None | Some (Atd_jsonlike.AST.Null _)";
-  record_node_binding = [B.Line "let atdml_node_ = x in"];
+  record_node_binding = [B.Line "let _atdml_node = x in"];
   missing_req_expr = (fun tn fn ->
-    sprintf "Atdml_runtime.Jsonlike.missing_field atdml_node_ \"%s\" \"%s\"" tn fn);
+    sprintf "Atdml_runtime.Jsonlike.missing_field _atdml_node \"%s\" \"%s\"" tn fn);
   abstract_reader =
     "(fun _ -> failwith \"abstract type is not supported in jsonlike mode\")";
 }
@@ -1184,7 +1184,7 @@ let gen_reader_field env ftr mode type_name (loc, (fname, kind, an), e) : B.node
     match kind with
     | Required ->
         [
-          B.Line (sprintf "match assoc_ \"%s\" with" json_name);
+          B.Line (sprintf "match assoc \"%s\" with" json_name);
           B.Line (sprintf "| Some v -> %s v" (reader_expr env mode e));
           B.Line (sprintf "| None -> %s" (mode.missing_req_expr type_name json_name));
         ]
@@ -1195,7 +1195,7 @@ let gen_reader_field env ftr mode type_name (loc, (fname, kind, an), e) : B.node
           | _ -> e
         in
         [
-          B.Line (sprintf "match assoc_ \"%s\" with" json_name);
+          B.Line (sprintf "match assoc \"%s\" with" json_name);
           B.Line (sprintf "| %s -> Option.None" mode.optional_null_pat);
           B.Line (sprintf "| Some v -> Option.Some (%s v)" (reader_expr env mode inner_e));
         ]
@@ -1203,7 +1203,7 @@ let gen_reader_field env ftr mode type_name (loc, (fname, kind, an), e) : B.node
         (match get_ocaml_default an with
         | Some default ->
             [
-              B.Line (sprintf "match assoc_ \"%s\" with" json_name);
+              B.Line (sprintf "match assoc \"%s\" with" json_name);
               B.Line (sprintf "| None -> %s" default);
               B.Line (sprintf "| Some v -> %s v" (reader_expr env mode e));
             ]
@@ -1211,14 +1211,14 @@ let gen_reader_field env ftr mode type_name (loc, (fname, kind, an), e) : B.node
             match get_implicit_default e with
             | Some default ->
                 [
-                  B.Line (sprintf "match assoc_ \"%s\" with" json_name);
+                  B.Line (sprintf "match assoc \"%s\" with" json_name);
                   B.Line (sprintf "| None -> %s" default);
                   B.Line (sprintf "| Some v -> %s v" (reader_expr env mode e));
                 ]
             | None ->
                 (* No OCaml default — treat as required; warned by warn_defs *)
                 [
-                  B.Line (sprintf "match assoc_ \"%s\" with" json_name);
+                  B.Line (sprintf "match assoc \"%s\" with" json_name);
                   B.Line (sprintf "| Some v -> %s v" (reader_expr env mode e));
                   B.Line (sprintf "| None -> %s" (mode.missing_req_expr type_name json_name));
                 ])
@@ -1372,15 +1372,15 @@ let gen_yojson_of_field env pftr (_, (fname, kind, an), e) : B.node =
            ofname json_name (writer_expr env inner_e))
 
 (* Wrap a writer body with a restore call when an adapter is present.
-   Produces: let atdml_result_ = <body> in (restore) atdml_result_ *)
+   Produces: let atdml_result_ = <body> in (restore) atdml_result *)
 let apply_restore restore body =
   match restore with
   | None -> body
   | Some f ->
       B.Block [
-        B.Line "let atdml_result_ =";
+        B.Line "let atdml_result =";
         body;
-        B.Line (sprintf "in %s atdml_result_" f);
+        B.Line (sprintf "in %s atdml_result" f);
       ]
 
 let gen_yojson_of env ({A.name; param=params; annot=an; value=e; _} : A.type_def) : B.t =

--- a/atdml/tests/named-snapshots/adapter
+++ b/atdml/tests/named-snapshots/adapter
@@ -245,7 +245,7 @@ let text_of_yojson (x : Yojson.Safe.t) : text =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -253,12 +253,12 @@ let text_of_yojson (x : Yojson.Safe.t) : text =
       else (fun key -> List.assoc_opt key fields)
     in
     let title =
-      match assoc_ "title" with
+      match assoc "title" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "text" "title"
     in
     let body =
-      match assoc_ "body" with
+      match assoc "body" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "text" "body"
     in
@@ -274,8 +274,8 @@ let yojson_of_text (x : text) : Yojson.Safe.t =
 let text_of_jsonlike (x : Atd_jsonlike.AST.t) : text =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -285,14 +285,14 @@ let text_of_jsonlike (x : Atd_jsonlike.AST.t) : text =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let title =
-      match assoc_ "title" with
+      match assoc "title" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "text" "title"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "text" "title"
     in
     let body =
-      match assoc_ "body" with
+      match assoc "body" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "text" "body"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "text" "body"
     in
     { title; body }
   | _ -> Atdml_runtime.Jsonlike.bad_type "text" x
@@ -333,7 +333,7 @@ let image_of_yojson (x : Yojson.Safe.t) : image =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -341,7 +341,7 @@ let image_of_yojson (x : Yojson.Safe.t) : image =
       else (fun key -> List.assoc_opt key fields)
     in
     let url =
-      match assoc_ "url" with
+      match assoc "url" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "image" "url"
     in
@@ -356,8 +356,8 @@ let yojson_of_image (x : image) : Yojson.Safe.t =
 let image_of_jsonlike (x : Atd_jsonlike.AST.t) : image =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -367,9 +367,9 @@ let image_of_jsonlike (x : Atd_jsonlike.AST.t) : image =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let url =
-      match assoc_ "url" with
+      match assoc "url" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "image" "url"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "image" "url"
     in
     { url }
   | _ -> Atdml_runtime.Jsonlike.bad_type "image" x
@@ -408,11 +408,11 @@ let document_of_yojson (x : Yojson.Safe.t) : document =
   | _ -> Atdml_runtime.Yojson.bad_sum "document" x
 
 let yojson_of_document (x : document) : Yojson.Safe.t =
-  let atdml_result_ =
+  let atdml_result =
     match x with
     | Image v -> `List [`String "Image"; yojson_of_image v]
     | Text v -> `List [`String "Text"; yojson_of_text v]
-  in My_adapter.restore atdml_result_
+  in My_adapter.restore atdml_result
 
 let document_of_jsonlike (x : Atd_jsonlike.AST.t) : document =
   let x = My_adapter.normalize_jsonlike x in
@@ -422,11 +422,11 @@ let document_of_jsonlike (x : Atd_jsonlike.AST.t) : document =
   | _ -> Atdml_runtime.Jsonlike.bad_sum "document" x
 
 let jsonlike_of_document (x : document) : Atd_jsonlike.AST.t =
-  let atdml_result_ =
+  let atdml_result =
     match x with
     | Image v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Image"); jsonlike_of_image v])
     | Text v -> Atd_jsonlike.AST.Array (Atd_jsonlike.Loc.zero, [Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "Text"); jsonlike_of_text v])
-  in My_adapter.restore_jsonlike atdml_result_
+  in My_adapter.restore_jsonlike atdml_result
 
 let document_of_json s =
   document_of_yojson (Yojson.Safe.from_string s)

--- a/atdml/tests/named-snapshots/attr
+++ b/atdml/tests/named-snapshots/attr
@@ -225,7 +225,7 @@ let point_of_yojson (x : Yojson.Safe.t) : point =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -233,12 +233,12 @@ let point_of_yojson (x : Yojson.Safe.t) : point =
       else (fun key -> List.assoc_opt key fields)
     in
     let x =
-      match assoc_ "x" with
+      match assoc "x" with
       | Some v -> Atdml_runtime.Yojson.float_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "point" "x"
     in
     let y =
-      match assoc_ "y" with
+      match assoc "y" with
       | Some v -> Atdml_runtime.Yojson.float_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "point" "y"
     in
@@ -254,8 +254,8 @@ let yojson_of_point (x : point) : Yojson.Safe.t =
 let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -265,14 +265,14 @@ let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let x =
-      match assoc_ "x" with
+      match assoc "x" with
       | Some v -> Atdml_runtime.Jsonlike.float_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "point" "x"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "point" "x"
     in
     let y =
-      match assoc_ "y" with
+      match assoc "y" with
       | Some v -> Atdml_runtime.Jsonlike.float_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "point" "y"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "point" "y"
     in
     { x; y }
   | _ -> Atdml_runtime.Jsonlike.bad_type "point" x

--- a/atdml/tests/named-snapshots/builtin_types
+++ b/atdml/tests/named-snapshots/builtin_types
@@ -219,7 +219,7 @@ let all_types_of_yojson (x : Yojson.Safe.t) : all_types =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -227,57 +227,57 @@ let all_types_of_yojson (x : Yojson.Safe.t) : all_types =
       else (fun key -> List.assoc_opt key fields)
     in
     let a_unit =
-      match assoc_ "a_unit" with
+      match assoc "a_unit" with
       | Some v -> Atdml_runtime.Yojson.unit_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_unit"
     in
     let a_bool =
-      match assoc_ "a_bool" with
+      match assoc "a_bool" with
       | Some v -> Atdml_runtime.Yojson.bool_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_bool"
     in
     let a_int =
-      match assoc_ "a_int" with
+      match assoc "a_int" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_int"
     in
     let a_float =
-      match assoc_ "a_float" with
+      match assoc "a_float" with
       | Some v -> Atdml_runtime.Yojson.float_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_float"
     in
     let a_string =
-      match assoc_ "a_string" with
+      match assoc "a_string" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_string"
     in
     let a_list =
-      match assoc_ "a_list" with
+      match assoc "a_list" with
       | Some v -> (Atdml_runtime.Yojson.list_of_yojson Atdml_runtime.Yojson.int_of_yojson) v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_list"
     in
     let a_option =
-      match assoc_ "a_option" with
+      match assoc "a_option" with
       | Some v -> (Atdml_runtime.Yojson.option_of_yojson Atdml_runtime.Yojson.string_of_yojson) v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_option"
     in
     let a_nullable =
-      match assoc_ "a_nullable" with
+      match assoc "a_nullable" with
       | Some v -> (Atdml_runtime.Yojson.nullable_of_yojson Atdml_runtime.Yojson.bool_of_yojson) v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_nullable"
     in
     let a_abstract =
-      match assoc_ "a_abstract" with
+      match assoc "a_abstract" with
       | Some v -> (fun x -> x) v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_abstract"
     in
     let a_tuple =
-      match assoc_ "a_tuple" with
+      match assoc "a_tuple" with
       | Some v -> (fun x -> match x with | `List lst when List.length lst = 3 -> (Atdml_runtime.Yojson.int_of_yojson (List.nth lst 0), Atdml_runtime.Yojson.string_of_yojson (List.nth lst 1), Atdml_runtime.Yojson.bool_of_yojson (List.nth lst 2)) | _ -> Atdml_runtime.Yojson.bad_type "tuple" x) v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_tuple"
     in
     let a_nested =
-      match assoc_ "a_nested" with
+      match assoc "a_nested" with
       | Some v -> (Atdml_runtime.Yojson.option_of_yojson (fun x -> match x with | `List lst when List.length lst = 1 -> ((Atdml_runtime.Yojson.list_of_yojson Atdml_runtime.Yojson.float_of_yojson) (List.nth lst 0)) | _ -> Atdml_runtime.Yojson.bad_type "tuple" x)) v
       | None -> Atdml_runtime.Yojson.missing_field "all_types" "a_nested"
     in
@@ -302,8 +302,8 @@ let yojson_of_all_types (x : all_types) : Yojson.Safe.t =
 let all_types_of_jsonlike (x : Atd_jsonlike.AST.t) : all_types =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -313,59 +313,59 @@ let all_types_of_jsonlike (x : Atd_jsonlike.AST.t) : all_types =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let a_unit =
-      match assoc_ "a_unit" with
+      match assoc "a_unit" with
       | Some v -> Atdml_runtime.Jsonlike.unit_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_unit"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_unit"
     in
     let a_bool =
-      match assoc_ "a_bool" with
+      match assoc "a_bool" with
       | Some v -> Atdml_runtime.Jsonlike.bool_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_bool"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_bool"
     in
     let a_int =
-      match assoc_ "a_int" with
+      match assoc "a_int" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_int"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_int"
     in
     let a_float =
-      match assoc_ "a_float" with
+      match assoc "a_float" with
       | Some v -> Atdml_runtime.Jsonlike.float_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_float"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_float"
     in
     let a_string =
-      match assoc_ "a_string" with
+      match assoc "a_string" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_string"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_string"
     in
     let a_list =
-      match assoc_ "a_list" with
+      match assoc "a_list" with
       | Some v -> (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.int_of_jsonlike) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_list"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_list"
     in
     let a_option =
-      match assoc_ "a_option" with
+      match assoc "a_option" with
       | Some v -> (Atdml_runtime.Jsonlike.option_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_option"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_option"
     in
     let a_nullable =
-      match assoc_ "a_nullable" with
+      match assoc "a_nullable" with
       | Some v -> (Atdml_runtime.Jsonlike.nullable_of_jsonlike Atdml_runtime.Jsonlike.bool_of_jsonlike) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_nullable"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_nullable"
     in
     let a_abstract =
-      match assoc_ "a_abstract" with
+      match assoc "a_abstract" with
       | Some v -> (fun _ -> failwith "abstract type is not supported in jsonlike mode") v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_abstract"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_abstract"
     in
     let a_tuple =
-      match assoc_ "a_tuple" with
+      match assoc "a_tuple" with
       | Some v -> (fun x -> match x with | Atd_jsonlike.AST.Array (_, lst) when List.length lst = 3 -> (Atdml_runtime.Jsonlike.int_of_jsonlike (List.nth lst 0), Atdml_runtime.Jsonlike.string_of_jsonlike (List.nth lst 1), Atdml_runtime.Jsonlike.bool_of_jsonlike (List.nth lst 2)) | _ -> Atdml_runtime.Jsonlike.bad_type "tuple" x) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_tuple"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_tuple"
     in
     let a_nested =
-      match assoc_ "a_nested" with
+      match assoc "a_nested" with
       | Some v -> (Atdml_runtime.Jsonlike.option_of_jsonlike (fun x -> match x with | Atd_jsonlike.AST.Array (_, lst) when List.length lst = 1 -> ((Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.float_of_jsonlike) (List.nth lst 0)) | _ -> Atdml_runtime.Jsonlike.bad_type "tuple" x)) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all_types" "a_nested"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all_types" "a_nested"
     in
     { a_unit; a_bool; a_int; a_float; a_string; a_list; a_option; a_nullable; a_abstract; a_tuple; a_nested }
   | _ -> Atdml_runtime.Jsonlike.bad_type "all_types" x

--- a/atdml/tests/named-snapshots/default_variant_fields
+++ b/atdml/tests/named-snapshots/default_variant_fields
@@ -1,0 +1,410 @@
+(* Auto-generated from "default_variant_fields.atd" by atdml. *)
+
+type polymorphic_variant = [
+  | `A
+  | `B
+]
+
+val polymorphic_variant_of_yojson : Yojson.Safe.t -> polymorphic_variant
+val yojson_of_polymorphic_variant : polymorphic_variant -> Yojson.Safe.t
+val polymorphic_variant_of_jsonlike : Atd_jsonlike.AST.t -> polymorphic_variant
+val jsonlike_of_polymorphic_variant : polymorphic_variant -> Atd_jsonlike.AST.t
+val polymorphic_variant_of_json : string -> polymorphic_variant
+val json_of_polymorphic_variant : polymorphic_variant -> string
+
+module Polymorphic_variant : sig
+  type nonrec t = polymorphic_variant
+  val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
+  val of_json : string -> t
+  val to_json : t -> string
+end
+
+type classic_variant =
+  | A
+  | B
+
+val classic_variant_of_yojson : Yojson.Safe.t -> classic_variant
+val yojson_of_classic_variant : classic_variant -> Yojson.Safe.t
+val classic_variant_of_jsonlike : Atd_jsonlike.AST.t -> classic_variant
+val jsonlike_of_classic_variant : classic_variant -> Atd_jsonlike.AST.t
+val classic_variant_of_json : string -> classic_variant
+val json_of_classic_variant : classic_variant -> string
+
+module Classic_variant : sig
+  type nonrec t = classic_variant
+  val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
+  val of_json : string -> t
+  val to_json : t -> string
+end
+
+type t = {
+  classic: classic_variant;
+  poly: polymorphic_variant;
+}
+
+val create_t : ?classic:classic_variant -> ?poly:polymorphic_variant -> unit -> t
+val t_of_yojson : Yojson.Safe.t -> t
+val yojson_of_t : t -> Yojson.Safe.t
+val t_of_jsonlike : Atd_jsonlike.AST.t -> t
+val jsonlike_of_t : t -> Atd_jsonlike.AST.t
+val t_of_json : string -> t
+val json_of_t : t -> string
+
+module T : sig
+  type nonrec t = t
+  val create : ?classic:classic_variant -> ?poly:polymorphic_variant -> unit -> t
+  val of_yojson : Yojson.Safe.t -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_jsonlike : Atd_jsonlike.AST.t -> t
+  val to_jsonlike : t -> Atd_jsonlike.AST.t
+  val of_json : string -> t
+  val to_json : t -> string
+end
+
+--- ml ---
+(* Auto-generated from "default_variant_fields.atd" by atdml. *)
+[@@@ocaml.warning "-27-32-33-35-39"]
+
+(* Inlined runtime — no external dependency needed. *)
+module Atdml_runtime = struct
+  (* Returns true iff the list has strictly more than [n] elements,
+     without traversing past element n+1. *)
+  let rec list_length_gt n = function
+    | _ :: rest -> if n = 0 then true else list_length_gt (n - 1) rest
+    | [] -> false
+
+  module Yojson = struct
+    let bad_type expected_type x =
+      Printf.ksprintf failwith "expected %s, got: %s"
+        expected_type (Yojson.Safe.to_string x)
+
+    let bad_sum type_name x =
+      Printf.ksprintf failwith "invalid variant for type '%s': %s"
+        type_name (Yojson.Safe.to_string x)
+
+    let missing_field type_name field_name =
+      Printf.ksprintf failwith "missing field '%s' in object of type '%s'"
+        field_name type_name
+
+    let bool_of_yojson = function
+      | `Bool b -> b
+      | x -> bad_type "bool" x
+
+    let yojson_of_bool b = `Bool b
+
+    let int_of_yojson = function
+      | `Int n -> n
+      | x -> bad_type "int" x
+
+    let yojson_of_int n = `Int n
+
+    let float_of_yojson = function
+      | `Float f -> f
+      | `Int n -> Float.of_int n
+      | x -> bad_type "float" x
+
+    let yojson_of_float f = `Float f
+
+    let string_of_yojson = function
+      | `String s -> s
+      | x -> bad_type "string" x
+
+    let yojson_of_string s = `String s
+
+    let unit_of_yojson = function
+      | `Null -> ()
+      | x -> bad_type "null" x
+
+    let yojson_of_unit () = `Null
+
+    let list_of_yojson f = function
+      | `List xs -> List.map f xs
+      | x -> bad_type "array" x
+
+    let yojson_of_list f xs = `List (List.map f xs)
+
+    let option_of_yojson f = function
+      | `String "None" -> None
+      | `List [`String "Some"; x] -> Some (f x)
+      | x -> bad_type "option" x
+
+    let yojson_of_option f = function
+      | None -> `String "None"
+      | Some x -> `List [`String "Some"; f x]
+
+    let nullable_of_yojson f = function
+      | `Null -> None
+      | x -> Some (f x)
+
+    let yojson_of_nullable f = function
+      | None -> `Null
+      | Some x -> f x
+
+    let assoc_of_yojson f = function
+      | `Assoc pairs -> List.map (fun (k, v) -> (k, f v)) pairs
+      | x -> bad_type "object" x
+
+    let yojson_of_assoc f xs =
+      `Assoc (List.map (fun (k, v) -> (k, f v)) xs)
+  end
+
+  module Jsonlike = struct
+    let bad_type expected_type x =
+      Printf.ksprintf failwith "%sexpected %s"
+        (Atd_jsonlike.AST.loc_msg x) expected_type
+
+    let bad_sum type_name x =
+      Printf.ksprintf failwith "%sinvalid variant for type '%s'"
+        (Atd_jsonlike.AST.loc_msg x) type_name
+
+    let missing_field node type_name field_name =
+      Printf.ksprintf failwith "%smissing field '%s' in object of type '%s'"
+        (Atd_jsonlike.AST.loc_msg node) field_name type_name
+
+    let bool_of_jsonlike = function
+      | Atd_jsonlike.AST.Bool (_, b) -> b
+      | x -> bad_type "bool" x
+
+    let int_of_jsonlike = function
+      | Atd_jsonlike.AST.Number (_, n) as node ->
+          (match n.Atd_jsonlike.Number.int with
+          | Some i -> i
+          | None -> bad_type "integer" node)
+      | x -> bad_type "int" x
+
+    let float_of_jsonlike = function
+      | Atd_jsonlike.AST.Number (_, n) as node ->
+          (match n.Atd_jsonlike.Number.float with
+          | Some f -> f
+          | None -> bad_type "float" node)
+      | x -> bad_type "float" x
+
+    let string_of_jsonlike = function
+      | Atd_jsonlike.AST.String (_, s) -> s
+      | x -> bad_type "string" x
+
+    let unit_of_jsonlike = function
+      | Atd_jsonlike.AST.Null _ -> ()
+      | x -> bad_type "null" x
+
+    let list_of_jsonlike f = function
+      | Atd_jsonlike.AST.Array (_, xs) -> List.map f xs
+      | x -> bad_type "array" x
+
+    let option_of_jsonlike f = function
+      | Atd_jsonlike.AST.String (_, "None") -> None
+      | Atd_jsonlike.AST.Array (_, [Atd_jsonlike.AST.String (_, "Some"); x]) -> Some (f x)
+      | x -> bad_type "option" x
+
+    let nullable_of_jsonlike f = function
+      | Atd_jsonlike.AST.Null _ -> None
+      | x -> Some (f x)
+
+    let assoc_of_jsonlike f = function
+      | Atd_jsonlike.AST.Object (_, pairs) ->
+          List.map (fun (_, k, v) -> (k, f v)) pairs
+      | x -> bad_type "object" x
+
+    let loc = Atd_jsonlike.Loc.zero
+
+    let jsonlike_of_bool b = Atd_jsonlike.AST.Bool (loc, b)
+    let jsonlike_of_int n = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_int n)
+    let jsonlike_of_float f = Atd_jsonlike.AST.Number (loc, Atd_jsonlike.Number.of_float f)
+    let jsonlike_of_string s = Atd_jsonlike.AST.String (loc, s)
+    let jsonlike_of_unit () = Atd_jsonlike.AST.Null loc
+    let jsonlike_of_list f xs = Atd_jsonlike.AST.Array (loc, List.map f xs)
+    let jsonlike_of_option f = function
+      | None -> Atd_jsonlike.AST.String (loc, "None")
+      | Some x -> Atd_jsonlike.AST.Array (loc, [Atd_jsonlike.AST.String (loc, "Some"); f x])
+    let jsonlike_of_nullable f = function
+      | None -> Atd_jsonlike.AST.Null loc
+      | Some x -> f x
+    let jsonlike_of_assoc f xs =
+      Atd_jsonlike.AST.Object (loc, List.map (fun (k, v) -> (loc, k, f v)) xs)
+  end
+end
+
+type polymorphic_variant = [
+  | `A
+  | `B
+]
+
+let polymorphic_variant_of_yojson (x : Yojson.Safe.t) : polymorphic_variant =
+  match x with
+  | `String "A" -> `A
+  | `String "B" -> `B
+  | _ -> Atdml_runtime.Yojson.bad_sum "polymorphic_variant" x
+
+let yojson_of_polymorphic_variant (x : polymorphic_variant) : Yojson.Safe.t =
+  match x with
+  | `A -> `String "A"
+  | `B -> `String "B"
+
+let polymorphic_variant_of_jsonlike (x : Atd_jsonlike.AST.t) : polymorphic_variant =
+  match x with
+  | Atd_jsonlike.AST.String (_, "A") -> `A
+  | Atd_jsonlike.AST.String (_, "B") -> `B
+  | _ -> Atdml_runtime.Jsonlike.bad_sum "polymorphic_variant" x
+
+let jsonlike_of_polymorphic_variant (x : polymorphic_variant) : Atd_jsonlike.AST.t =
+  match x with
+  | `A -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "A")
+  | `B -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "B")
+
+let polymorphic_variant_of_json s =
+  polymorphic_variant_of_yojson (Yojson.Safe.from_string s)
+
+let json_of_polymorphic_variant x =
+  Yojson.Safe.to_string (yojson_of_polymorphic_variant x)
+
+module Polymorphic_variant = struct
+  type nonrec t = polymorphic_variant
+  let of_yojson = polymorphic_variant_of_yojson
+  let to_yojson = yojson_of_polymorphic_variant
+  let of_jsonlike = polymorphic_variant_of_jsonlike
+  let to_jsonlike = jsonlike_of_polymorphic_variant
+  let of_json = polymorphic_variant_of_json
+  let to_json = json_of_polymorphic_variant
+end
+
+type classic_variant =
+  | A
+  | B
+
+let classic_variant_of_yojson (x : Yojson.Safe.t) : classic_variant =
+  match x with
+  | `String "A" -> A
+  | `String "B" -> B
+  | _ -> Atdml_runtime.Yojson.bad_sum "classic_variant" x
+
+let yojson_of_classic_variant (x : classic_variant) : Yojson.Safe.t =
+  match x with
+  | A -> `String "A"
+  | B -> `String "B"
+
+let classic_variant_of_jsonlike (x : Atd_jsonlike.AST.t) : classic_variant =
+  match x with
+  | Atd_jsonlike.AST.String (_, "A") -> A
+  | Atd_jsonlike.AST.String (_, "B") -> B
+  | _ -> Atdml_runtime.Jsonlike.bad_sum "classic_variant" x
+
+let jsonlike_of_classic_variant (x : classic_variant) : Atd_jsonlike.AST.t =
+  match x with
+  | A -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "A")
+  | B -> Atd_jsonlike.AST.String (Atd_jsonlike.Loc.zero, "B")
+
+let classic_variant_of_json s =
+  classic_variant_of_yojson (Yojson.Safe.from_string s)
+
+let json_of_classic_variant x =
+  Yojson.Safe.to_string (yojson_of_classic_variant x)
+
+module Classic_variant = struct
+  type nonrec t = classic_variant
+  let of_yojson = classic_variant_of_yojson
+  let to_yojson = yojson_of_classic_variant
+  let of_jsonlike = classic_variant_of_jsonlike
+  let to_jsonlike = jsonlike_of_classic_variant
+  let of_json = classic_variant_of_json
+  let to_json = json_of_classic_variant
+end
+
+type t = {
+  classic: classic_variant;
+  poly: polymorphic_variant;
+}
+
+let create_t ?(classic = A) ?(poly = `A) () : t =
+  { classic; poly }
+
+let t_of_yojson (x : Yojson.Safe.t) : t =
+  match x with
+  | `Assoc fields ->
+    (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
+       be unique). Below the threshold, List.assoc_opt returns the first binding;
+       above it, the hashtable returns the last. *)
+    let assoc =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else (fun key -> List.assoc_opt key fields)
+    in
+    let classic =
+      match assoc "classic" with
+      | None -> A
+      | Some v -> classic_variant_of_yojson v
+    in
+    let poly =
+      match assoc "poly" with
+      | None -> `A
+      | Some v -> polymorphic_variant_of_yojson v
+    in
+    { classic; poly }
+  | _ -> Atdml_runtime.Yojson.bad_type "t" x
+
+let yojson_of_t (x : t) : Yojson.Safe.t =
+  `Assoc (List.concat [
+    [("classic", yojson_of_classic_variant x.classic)];
+    [("poly", yojson_of_polymorphic_variant x.poly)];
+  ])
+
+let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
+  match x with
+  | Atd_jsonlike.AST.Object (_, fields) ->
+    let _atdml_node = x in
+    let assoc =
+      if Atdml_runtime.list_length_gt 5 fields then
+        let tbl = Hashtbl.create 16 in
+        List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
+        (fun key -> Hashtbl.find_opt tbl key)
+      else
+        (fun key ->
+          List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
+    in
+    let classic =
+      match assoc "classic" with
+      | None -> A
+      | Some v -> classic_variant_of_jsonlike v
+    in
+    let poly =
+      match assoc "poly" with
+      | None -> `A
+      | Some v -> polymorphic_variant_of_jsonlike v
+    in
+    { classic; poly }
+  | _ -> Atdml_runtime.Jsonlike.bad_type "t" x
+
+let jsonlike_of_t (x : t) : Atd_jsonlike.AST.t =
+  Atd_jsonlike.AST.Object (Atd_jsonlike.Loc.zero, List.concat [
+    [(Atd_jsonlike.Loc.zero, "classic", jsonlike_of_classic_variant x.classic)];
+    [(Atd_jsonlike.Loc.zero, "poly", jsonlike_of_polymorphic_variant x.poly)];
+  ])
+
+let t_of_json s =
+  t_of_yojson (Yojson.Safe.from_string s)
+
+let json_of_t x =
+  Yojson.Safe.to_string (yojson_of_t x)
+
+module T = struct
+  type nonrec t = t
+  let create = create_t
+  let of_yojson = t_of_yojson
+  let to_yojson = yojson_of_t
+  let of_jsonlike = t_of_jsonlike
+  let to_jsonlike = jsonlike_of_t
+  let of_json = t_of_json
+  let to_json = json_of_t
+end
+
+--- Input:
+{ "classic": "B", "poly": "B" }
+--- Output:
+{ "classic": "B", "poly": "B" }

--- a/atdml/tests/named-snapshots/doc
+++ b/atdml/tests/named-snapshots/doc
@@ -311,7 +311,7 @@ let rec node_of_yojson (x : Yojson.Safe.t) : node =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -319,17 +319,17 @@ let rec node_of_yojson (x : Yojson.Safe.t) : node =
       else (fun key -> List.assoc_opt key fields)
     in
     let value =
-      match assoc_ "value" with
+      match assoc "value" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "node" "value"
     in
     let left =
-      match assoc_ "left" with
+      match assoc "left" with
       | Some v -> tree_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "node" "left"
     in
     let right =
-      match assoc_ "right" with
+      match assoc "right" with
       | Some v -> tree_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "node" "right"
     in
@@ -357,8 +357,8 @@ and yojson_of_tree (x : tree) : Yojson.Safe.t =
 let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -368,19 +368,19 @@ let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let value =
-      match assoc_ "value" with
+      match assoc "value" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "node" "value"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "node" "value"
     in
     let left =
-      match assoc_ "left" with
+      match assoc "left" with
       | Some v -> tree_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "node" "left"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "node" "left"
     in
     let right =
-      match assoc_ "right" with
+      match assoc "right" with
       | Some v -> tree_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "node" "right"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "node" "right"
     in
     { value; left; right }
   | _ -> Atdml_runtime.Jsonlike.bad_type "node" x
@@ -456,7 +456,7 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -464,17 +464,17 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
       else (fun key -> List.assoc_opt key fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "person" "name"
     in
     let age =
-      match assoc_ "age" with
+      match assoc "age" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "person" "age"
     in
     let email =
-      match assoc_ "email" with
+      match assoc "email" with
       | None | Some `Null -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Yojson.string_of_yojson v)
     in
@@ -491,8 +491,8 @@ let yojson_of_person (x : person) : Yojson.Safe.t =
 let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -502,17 +502,17 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "person" "name"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "person" "name"
     in
     let age =
-      match assoc_ "age" with
+      match assoc "age" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "person" "age"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "person" "age"
     in
     let email =
-      match assoc_ "email" with
+      match assoc "email" with
       | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Jsonlike.string_of_jsonlike v)
     in

--- a/atdml/tests/named-snapshots/field_prefix
+++ b/atdml/tests/named-snapshots/field_prefix
@@ -203,7 +203,7 @@ let t_of_yojson (x : Yojson.Safe.t) : t =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -211,17 +211,17 @@ let t_of_yojson (x : Yojson.Safe.t) : t =
       else (fun key -> List.assoc_opt key fields)
     in
     let ule =
-      match assoc_ "ule" with
+      match assoc "ule" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "t" "ule"
     in
     let if_ =
-      match assoc_ "if" with
+      match assoc "if" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "t" "if"
     in
     let if__ =
-      match assoc_ "if_" with
+      match assoc "if_" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "t" "if_"
     in
@@ -238,8 +238,8 @@ let yojson_of_t (x : t) : Yojson.Safe.t =
 let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -249,19 +249,19 @@ let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let ule =
-      match assoc_ "ule" with
+      match assoc "ule" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "t" "ule"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "t" "ule"
     in
     let if_ =
-      match assoc_ "if" with
+      match assoc "if" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "t" "if"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "t" "if"
     in
     let if__ =
-      match assoc_ "if_" with
+      match assoc "if_" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "t" "if_"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "t" "if_"
     in
     { module_ = ule; modif = if_; modif_ = if__ }
   | _ -> Atdml_runtime.Jsonlike.bad_type "t" x

--- a/atdml/tests/named-snapshots/imports
+++ b/atdml/tests/named-snapshots/imports
@@ -227,7 +227,7 @@ let tagged_of_yojson (x : Yojson.Safe.t) : tagged =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -235,12 +235,12 @@ let tagged_of_yojson (x : Yojson.Safe.t) : tagged =
       else (fun key -> List.assoc_opt key fields)
     in
     let value =
-      match assoc_ "value" with
+      match assoc "value" with
       | Some v -> Ext.tag_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "tagged" "value"
     in
     let label =
-      match assoc_ "label" with
+      match assoc "label" with
       | Some v -> Base_types.label_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "tagged" "label"
     in
@@ -256,8 +256,8 @@ let yojson_of_tagged (x : tagged) : Yojson.Safe.t =
 let tagged_of_jsonlike (x : Atd_jsonlike.AST.t) : tagged =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -267,14 +267,14 @@ let tagged_of_jsonlike (x : Atd_jsonlike.AST.t) : tagged =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let value =
-      match assoc_ "value" with
+      match assoc "value" with
       | Some v -> Ext.tag_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "tagged" "value"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "tagged" "value"
     in
     let label =
-      match assoc_ "label" with
+      match assoc "label" with
       | Some v -> Base_types.label_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "tagged" "label"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "tagged" "label"
     in
     { value; label }
   | _ -> Atdml_runtime.Jsonlike.bad_type "tagged" x
@@ -316,7 +316,7 @@ let greeting_of_yojson (x : Yojson.Safe.t) : greeting =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -324,12 +324,12 @@ let greeting_of_yojson (x : Yojson.Safe.t) : greeting =
       else (fun key -> List.assoc_opt key fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Base_types.person_name_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "greeting" "name"
     in
     let message =
-      match assoc_ "message" with
+      match assoc "message" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "greeting" "message"
     in
@@ -345,8 +345,8 @@ let yojson_of_greeting (x : greeting) : Yojson.Safe.t =
 let greeting_of_jsonlike (x : Atd_jsonlike.AST.t) : greeting =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -356,14 +356,14 @@ let greeting_of_jsonlike (x : Atd_jsonlike.AST.t) : greeting =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Base_types.person_name_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "greeting" "name"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "greeting" "name"
     in
     let message =
-      match assoc_ "message" with
+      match assoc "message" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "greeting" "message"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "greeting" "message"
     in
     { name; message }
   | _ -> Atdml_runtime.Jsonlike.bad_type "greeting" x

--- a/atdml/tests/named-snapshots/imports_e2e
+++ b/atdml/tests/named-snapshots/imports_e2e
@@ -203,7 +203,7 @@ let item_of_yojson (x : Yojson.Safe.t) : item =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -211,12 +211,12 @@ let item_of_yojson (x : Yojson.Safe.t) : item =
       else (fun key -> List.assoc_opt key fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Base_types.person_name_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "item" "name"
     in
     let tag =
-      match assoc_ "tag" with
+      match assoc "tag" with
       | Some v -> Ext.tag_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "item" "tag"
     in
@@ -232,8 +232,8 @@ let yojson_of_item (x : item) : Yojson.Safe.t =
 let item_of_jsonlike (x : Atd_jsonlike.AST.t) : item =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -243,14 +243,14 @@ let item_of_jsonlike (x : Atd_jsonlike.AST.t) : item =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Base_types.person_name_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "item" "name"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "item" "name"
     in
     let tag =
-      match assoc_ "tag" with
+      match assoc "tag" with
       | Some v -> Ext.tag_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "item" "tag"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "item" "tag"
     in
     { name; tag }
   | _ -> Atdml_runtime.Jsonlike.bad_type "item" x

--- a/atdml/tests/named-snapshots/json_repr_object
+++ b/atdml/tests/named-snapshots/json_repr_object
@@ -299,7 +299,7 @@ let record_of_yojson (x : Yojson.Safe.t) : record =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -307,12 +307,12 @@ let record_of_yojson (x : Yojson.Safe.t) : record =
       else (fun key -> List.assoc_opt key fields)
     in
     let counts =
-      match assoc_ "counts" with
+      match assoc "counts" with
       | Some v -> string_map_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "record" "counts"
     in
     let tags =
-      match assoc_ "tags" with
+      match assoc "tags" with
       | Some v -> nested_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "record" "tags"
     in
@@ -328,8 +328,8 @@ let yojson_of_record (x : record) : Yojson.Safe.t =
 let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -339,14 +339,14 @@ let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let counts =
-      match assoc_ "counts" with
+      match assoc "counts" with
       | Some v -> string_map_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "record" "counts"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "record" "counts"
     in
     let tags =
-      match assoc_ "tags" with
+      match assoc "tags" with
       | Some v -> nested_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "record" "tags"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "record" "tags"
     in
     { counts; tags }
   | _ -> Atdml_runtime.Jsonlike.bad_type "record" x

--- a/atdml/tests/named-snapshots/keyword_field_and_variant_names
+++ b/atdml/tests/named-snapshots/keyword_field_and_variant_names
@@ -268,7 +268,7 @@ let record_with_keyword_fields_of_yojson (x : Yojson.Safe.t) : record_with_keywo
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -276,22 +276,22 @@ let record_with_keyword_fields_of_yojson (x : Yojson.Safe.t) : record_with_keywo
       else (fun key -> List.assoc_opt key fields)
     in
     let method_ =
-      match assoc_ "method" with
+      match assoc "method" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "record_with_keyword_fields" "method"
     in
     let object_ =
-      match assoc_ "object" with
+      match assoc "object" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "record_with_keyword_fields" "object"
     in
     let begin_ =
-      match assoc_ "begin" with
+      match assoc "begin" with
       | None | Some `Null -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Yojson.bool_of_yojson v)
     in
     let end_ =
-      match assoc_ "end" with
+      match assoc "end" with
       | None -> []
       | Some v -> (Atdml_runtime.Yojson.list_of_yojson Atdml_runtime.Yojson.string_of_yojson) v
     in
@@ -309,8 +309,8 @@ let yojson_of_record_with_keyword_fields (x : record_with_keyword_fields) : Yojs
 let record_with_keyword_fields_of_jsonlike (x : Atd_jsonlike.AST.t) : record_with_keyword_fields =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -320,22 +320,22 @@ let record_with_keyword_fields_of_jsonlike (x : Atd_jsonlike.AST.t) : record_wit
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let method_ =
-      match assoc_ "method" with
+      match assoc "method" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "record_with_keyword_fields" "method"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "record_with_keyword_fields" "method"
     in
     let object_ =
-      match assoc_ "object" with
+      match assoc "object" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "record_with_keyword_fields" "object"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "record_with_keyword_fields" "object"
     in
     let begin_ =
-      match assoc_ "begin" with
+      match assoc "begin" with
       | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Jsonlike.bool_of_jsonlike v)
     in
     let end_ =
-      match assoc_ "end" with
+      match assoc "end" with
       | None -> []
       | Some v -> (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) v
     in

--- a/atdml/tests/named-snapshots/mutually_recursive_types
+++ b/atdml/tests/named-snapshots/mutually_recursive_types
@@ -226,7 +226,7 @@ let rec node_of_yojson (x : Yojson.Safe.t) : node =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -234,12 +234,12 @@ let rec node_of_yojson (x : Yojson.Safe.t) : node =
       else (fun key -> List.assoc_opt key fields)
     in
     let value =
-      match assoc_ "value" with
+      match assoc "value" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "node" "value"
     in
     let children =
-      match assoc_ "children" with
+      match assoc "children" with
       | Some v -> (fun x -> match x with | `List lst when List.length lst = 2 -> (tree_of_yojson (List.nth lst 0), tree_of_yojson (List.nth lst 1)) | _ -> Atdml_runtime.Yojson.bad_type "tuple" x) v
       | None -> Atdml_runtime.Yojson.missing_field "node" "children"
     in
@@ -266,8 +266,8 @@ and yojson_of_tree (x : tree) : Yojson.Safe.t =
 let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -277,14 +277,14 @@ let rec node_of_jsonlike (x : Atd_jsonlike.AST.t) : node =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let value =
-      match assoc_ "value" with
+      match assoc "value" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "node" "value"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "node" "value"
     in
     let children =
-      match assoc_ "children" with
+      match assoc "children" with
       | Some v -> (fun x -> match x with | Atd_jsonlike.AST.Array (_, lst) when List.length lst = 2 -> (tree_of_jsonlike (List.nth lst 0), tree_of_jsonlike (List.nth lst 1)) | _ -> Atdml_runtime.Jsonlike.bad_type "tuple" x) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "node" "children"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "node" "children"
     in
     { value; children }
   | _ -> Atdml_runtime.Jsonlike.bad_type "node" x

--- a/atdml/tests/named-snapshots/ocaml_private_public
+++ b/atdml/tests/named-snapshots/ocaml_private_public
@@ -349,7 +349,7 @@ let point_of_yojson (x : Yojson.Safe.t) : point =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -357,12 +357,12 @@ let point_of_yojson (x : Yojson.Safe.t) : point =
       else (fun key -> List.assoc_opt key fields)
     in
     let x =
-      match assoc_ "x" with
+      match assoc "x" with
       | Some v -> Atdml_runtime.Yojson.float_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "point" "x"
     in
     let y =
-      match assoc_ "y" with
+      match assoc "y" with
       | Some v -> Atdml_runtime.Yojson.float_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "point" "y"
     in
@@ -378,8 +378,8 @@ let yojson_of_point (x : point) : Yojson.Safe.t =
 let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -389,14 +389,14 @@ let point_of_jsonlike (x : Atd_jsonlike.AST.t) : point =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let x =
-      match assoc_ "x" with
+      match assoc "x" with
       | Some v -> Atdml_runtime.Jsonlike.float_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "point" "x"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "point" "x"
     in
     let y =
-      match assoc_ "y" with
+      match assoc "y" with
       | Some v -> Atdml_runtime.Jsonlike.float_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "point" "y"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "point" "y"
     in
     { x; y }
   | _ -> Atdml_runtime.Jsonlike.bad_type "point" x

--- a/atdml/tests/named-snapshots/protect_builtin_constructors
+++ b/atdml/tests/named-snapshots/protect_builtin_constructors
@@ -264,7 +264,7 @@ let t_of_yojson (x : Yojson.Safe.t) : t =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -272,12 +272,12 @@ let t_of_yojson (x : Yojson.Safe.t) : t =
       else (fun key -> List.assoc_opt key fields)
     in
     let option =
-      match assoc_ "option" with
+      match assoc "option" with
       | None | Some `Null -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Yojson.int_of_yojson v)
     in
     let not_options =
-      match assoc_ "not_options" with
+      match assoc "not_options" with
       | Some v -> (Atdml_runtime.Yojson.list_of_yojson not_option_of_yojson) v
       | None -> Atdml_runtime.Yojson.missing_field "t" "not_options"
     in
@@ -293,8 +293,8 @@ let yojson_of_t (x : t) : Yojson.Safe.t =
 let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -304,14 +304,14 @@ let t_of_jsonlike (x : Atd_jsonlike.AST.t) : t =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let option =
-      match assoc_ "option" with
+      match assoc "option" with
       | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Jsonlike.int_of_jsonlike v)
     in
     let not_options =
-      match assoc_ "not_options" with
+      match assoc "not_options" with
       | Some v -> (Atdml_runtime.Jsonlike.list_of_jsonlike not_option_of_jsonlike) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "t" "not_options"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "t" "not_options"
     in
     { option; not_options }
   | _ -> Atdml_runtime.Jsonlike.bad_type "t" x

--- a/atdml/tests/named-snapshots/records
+++ b/atdml/tests/named-snapshots/records
@@ -215,7 +215,7 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -223,47 +223,47 @@ let person_of_yojson (x : Yojson.Safe.t) : person =
       else (fun key -> List.assoc_opt key fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "person" "name"
     in
     let age =
-      match assoc_ "age" with
+      match assoc "age" with
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "person" "age"
     in
     let lol =
-      match assoc_ "lol" with
+      match assoc "lol" with
       | Some v -> (Atdml_runtime.Yojson.nullable_of_yojson Atdml_runtime.Yojson.int_of_yojson) v
       | None -> Atdml_runtime.Yojson.missing_field "person" "lol"
     in
     let email =
-      match assoc_ "email" with
+      match assoc "email" with
       | None | Some `Null -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Yojson.string_of_yojson v)
     in
     let score =
-      match assoc_ "score" with
+      match assoc "score" with
       | None -> 0.
       | Some v -> Atdml_runtime.Yojson.float_of_yojson v
     in
     let active =
-      match assoc_ "active" with
+      match assoc "active" with
       | None -> false
       | Some v -> Atdml_runtime.Yojson.bool_of_yojson v
     in
     let tags =
-      match assoc_ "tags" with
+      match assoc "tags" with
       | None -> []
       | Some v -> (Atdml_runtime.Yojson.list_of_yojson Atdml_runtime.Yojson.string_of_yojson) v
     in
     let level =
-      match assoc_ "level" with
+      match assoc "level" with
       | None -> 1
       | Some v -> Atdml_runtime.Yojson.int_of_yojson v
     in
     let address =
-      match assoc_ "addr" with
+      match assoc "addr" with
       | Some v -> Atdml_runtime.Yojson.string_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "person" "addr"
     in
@@ -286,8 +286,8 @@ let yojson_of_person (x : person) : Yojson.Safe.t =
 let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -297,49 +297,49 @@ let person_of_jsonlike (x : Atd_jsonlike.AST.t) : person =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "person" "name"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "person" "name"
     in
     let age =
-      match assoc_ "age" with
+      match assoc "age" with
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "person" "age"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "person" "age"
     in
     let lol =
-      match assoc_ "lol" with
+      match assoc "lol" with
       | Some v -> (Atdml_runtime.Jsonlike.nullable_of_jsonlike Atdml_runtime.Jsonlike.int_of_jsonlike) v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "person" "lol"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "person" "lol"
     in
     let email =
-      match assoc_ "email" with
+      match assoc "email" with
       | None | Some (Atd_jsonlike.AST.Null _) -> Option.None
       | Some v -> Option.Some (Atdml_runtime.Jsonlike.string_of_jsonlike v)
     in
     let score =
-      match assoc_ "score" with
+      match assoc "score" with
       | None -> 0.
       | Some v -> Atdml_runtime.Jsonlike.float_of_jsonlike v
     in
     let active =
-      match assoc_ "active" with
+      match assoc "active" with
       | None -> false
       | Some v -> Atdml_runtime.Jsonlike.bool_of_jsonlike v
     in
     let tags =
-      match assoc_ "tags" with
+      match assoc "tags" with
       | None -> []
       | Some v -> (Atdml_runtime.Jsonlike.list_of_jsonlike Atdml_runtime.Jsonlike.string_of_jsonlike) v
     in
     let level =
-      match assoc_ "level" with
+      match assoc "level" with
       | None -> 1
       | Some v -> Atdml_runtime.Jsonlike.int_of_jsonlike v
     in
     let address =
-      match assoc_ "addr" with
+      match assoc "addr" with
       | Some v -> Atdml_runtime.Jsonlike.string_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "person" "addr"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "person" "addr"
     in
     { name; age; lol; email; score; active; tags; level; address }
   | _ -> Atdml_runtime.Jsonlike.bad_type "person" x

--- a/atdml/tests/named-snapshots/type_aliases
+++ b/atdml/tests/named-snapshots/type_aliases
@@ -413,7 +413,7 @@ let all_of_yojson (x : Yojson.Safe.t) : all =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -421,22 +421,22 @@ let all_of_yojson (x : Yojson.Safe.t) : all =
       else (fun key -> List.assoc_opt key fields)
     in
     let id =
-      match assoc_ "id" with
+      match assoc "id" with
       | Some v -> id_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all" "id"
     in
     let score =
-      match assoc_ "score" with
+      match assoc "score" with
       | Some v -> score_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all" "score"
     in
     let tags =
-      match assoc_ "tags" with
+      match assoc "tags" with
       | Some v -> tag_list_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all" "tags"
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> opt_name_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "all" "name"
     in
@@ -454,8 +454,8 @@ let yojson_of_all (x : all) : Yojson.Safe.t =
 let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -465,24 +465,24 @@ let all_of_jsonlike (x : Atd_jsonlike.AST.t) : all =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let id =
-      match assoc_ "id" with
+      match assoc "id" with
       | Some v -> id_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all" "id"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all" "id"
     in
     let score =
-      match assoc_ "score" with
+      match assoc "score" with
       | Some v -> score_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all" "score"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all" "score"
     in
     let tags =
-      match assoc_ "tags" with
+      match assoc "tags" with
       | Some v -> tag_list_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all" "tags"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all" "tags"
     in
     let name =
-      match assoc_ "name" with
+      match assoc "name" with
       | Some v -> opt_name_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "all" "name"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "all" "name"
     in
     { id; score; tags; name }
   | _ -> Atdml_runtime.Jsonlike.bad_type "all" x

--- a/atdml/tests/named-snapshots/wrap
+++ b/atdml/tests/named-snapshots/wrap
@@ -299,7 +299,7 @@ let record_of_yojson (x : Yojson.Safe.t) : record =
     (* Duplicate JSON keys: behavior is unspecified (RFC 8259 §4 says keys SHOULD
        be unique). Below the threshold, List.assoc_opt returns the first binding;
        above it, the hashtable returns the last. *)
-    let assoc_ =
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (k, v) -> Hashtbl.add tbl k v) fields;
@@ -307,12 +307,12 @@ let record_of_yojson (x : Yojson.Safe.t) : record =
       else (fun key -> List.assoc_opt key fields)
     in
     let id =
-      match assoc_ "id" with
+      match assoc "id" with
       | Some v -> uid_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "record" "id"
     in
     let label =
-      match assoc_ "label" with
+      match assoc "label" with
       | Some v -> tag_of_yojson v
       | None -> Atdml_runtime.Yojson.missing_field "record" "label"
     in
@@ -328,8 +328,8 @@ let yojson_of_record (x : record) : Yojson.Safe.t =
 let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
   match x with
   | Atd_jsonlike.AST.Object (_, fields) ->
-    let atdml_node_ = x in
-    let assoc_ =
+    let _atdml_node = x in
+    let assoc =
       if Atdml_runtime.list_length_gt 5 fields then
         let tbl = Hashtbl.create 16 in
         List.iter (fun (_, k, v) -> Hashtbl.add tbl k v) fields;
@@ -339,14 +339,14 @@ let record_of_jsonlike (x : Atd_jsonlike.AST.t) : record =
           List.find_map (fun (_, k, v) : _ option -> if String.equal k key then Some v else None) fields)
     in
     let id =
-      match assoc_ "id" with
+      match assoc "id" with
       | Some v -> uid_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "record" "id"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "record" "id"
     in
     let label =
-      match assoc_ "label" with
+      match assoc "label" with
       | Some v -> tag_of_jsonlike v
-      | None -> Atdml_runtime.Jsonlike.missing_field atdml_node_ "record" "label"
+      | None -> Atdml_runtime.Jsonlike.missing_field _atdml_node "record" "label"
     in
     { id; label }
   | _ -> Atdml_runtime.Jsonlike.bad_type "record" x

--- a/atdml/tests/test.ml
+++ b/atdml/tests/test.ml
@@ -388,7 +388,24 @@ type t = {
 }
 |}
 ;
+  test_e2e "default variant fields"
+    ~atd_src:{|
+type classic_variant = [ A | B ]
+type polymorphic_variant = [ A | B ] <ocaml repr="poly">
 
+type t = {
+  ~classic <ocaml default="A">: classic_variant;
+  ~poly <ocaml default="`A">: polymorphic_variant;
+}
+|}
+    ~type_name:"t"
+    ~json_in:{|
+{
+  "classic": "B",
+  "poly": "B"
+}
+|}
+;
   test_e2e "parametric types"
     ~atd_src:{|
 type 'a result = [


### PR DESCRIPTION
- some had a useless trailing underscore
- one of them was sometimes unused resulting in a warning -> silenced with a leading underscore

The trailing underscores were introduced by Claude Code when it wrote the bulk of the implementation. I'm not sure what pattern it was following. Usually, we use trailing underscores to use identifiers that would otherwise be reserved keywords.

### PR checklist

- [x] New code has tests to catch future regressions
- [x] Documentation is up-to-date
- [x] `CHANGES.md` is up-to-date
